### PR TITLE
Enable manual triggering of release-tag workflow

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths: [Cargo.toml]
+  workflow_dispatch: {}
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Added support for manual workflow dispatch to the release-tag GitHub Actions workflow, allowing releases to be triggered on-demand in addition to the existing automatic trigger on Cargo.toml changes.

## Changes
- Added `workflow_dispatch: {}` trigger to the release-tag workflow, enabling manual execution via the GitHub Actions UI or API

## Details
This change allows maintainers to manually trigger the release workflow without requiring a push to `Cargo.toml`, providing more flexibility in the release process while maintaining the existing automatic trigger on version changes.

https://claude.ai/code/session_01VWLQ2gMWKiTRh4TGv56hZT