### PR TITLE
Refactor CI/CD workflows and optimize build configuration

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,6 +27,13 @@ jobs:
         working-directory: seite-sh
         run: seite build
 
+      - name: Generate routing files
+        working-directory: seite-sh
+        run: |
+          # Rewrite /install.sh to /static/install.sh (200 = serve content at path)
+          printf '/install.sh /static/install.sh 200\n' > dist/_redirects
+          printf '/install.ps1 /static/install.ps1 200\n' >> dist/_redirects
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,12 +27,11 @@ jobs:
         working-directory: seite-sh
         run: seite build
 
-      - name: Generate routing files
+      - name: Copy install scripts to dist root
         working-directory: seite-sh
         run: |
-          # Rewrite /install.sh to /static/install.sh (200 = serve content at path)
-          printf '/install.sh /static/install.sh 200\n' > dist/_redirects
-          printf '/install.ps1 /static/install.ps1 200\n' >> dist/_redirects
+          cp static/install.sh dist/install.sh
+          cp static/install.ps1 dist/install.ps1
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,15 +18,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build seite from source
         run: cargo install --path .

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -13,9 +13,6 @@ permissions:
 jobs:
   tag:
     runs-on: ubuntu-latest
-    outputs:
-      created: ${{ steps.create.outputs.created }}
-      tag: ${{ steps.version.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,19 +36,10 @@ jobs:
           fi
 
       - name: Create and push tag
-        id: create
         if: steps.check.outputs.exists == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
-          echo "created=true" >> "$GITHUB_OUTPUT"
-
-  release:
-    needs: tag
-    if: needs.tag.outputs.created == 'true'
-    uses: ./.github/workflows/release.yml
-    with:
-      tag: ${{ needs.tag.outputs.tag }}
-    secrets: inherit
+          # Tag push triggers release.yml via its push:tags:["v*"] trigger

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,6 @@ on:
   push:
     tags: ["v*"]
   workflow_dispatch:
-  workflow_call:
-    inputs:
-      tag:
-        description: "Release tag (e.g., v0.1.0)"
-        required: true
-        type: string
 
 permissions:
   contents: write
@@ -140,12 +134,7 @@ jobs:
 
       - name: Resolve tag
         id: tag
-        run: |
-          if [ -n "${{ inputs.tag }}" ]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/download-artifact@v4
         with:
@@ -190,12 +179,7 @@ jobs:
 
       - name: Resolve tag
         id: tag
-        run: |
-          if [ -n "${{ inputs.tag }}" ]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,7 @@ jobs:
         working-directory: seite-sh
         run: seite build
 
-      - name: Generate download routing files
+      - name: Generate routing files
         working-directory: seite-sh
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
@@ -220,10 +220,12 @@ jobs:
           # version.txt — latest version pointer
           echo "$TAG" > dist/version.txt
 
-          # _redirects — route /download/ paths to GitHub Releases
-          # First rule: /download/latest/* resolves to the current release
-          # Second rule: /download/<version>/* passes through to any release
-          printf '/download/latest/* https://github.com/seite-sh/seite/releases/download/%s/:splat 302\n' "$TAG" > dist/_redirects
+          # _redirects — Cloudflare Pages routing rules
+          # Install scripts: rewrite /install.sh to /static/install.sh (200 = serve content at path)
+          printf '/install.sh /static/install.sh 200\n' > dist/_redirects
+          printf '/install.ps1 /static/install.ps1 200\n' >> dist/_redirects
+          # Download routing: /download/ paths to GitHub Releases
+          printf '/download/latest/* https://github.com/seite-sh/seite/releases/download/%s/:splat 302\n' "$TAG" >> dist/_redirects
           printf '/download/* https://github.com/seite-sh/seite/releases/download/:splat 302\n' >> dist/_redirects
 
       - name: Deploy to Cloudflare Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,20 +212,20 @@ jobs:
         working-directory: seite-sh
         run: seite build
 
-      - name: Generate routing files
+      - name: Generate routing and download files
         working-directory: seite-sh
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
 
+          # Install scripts at site root
+          cp static/install.sh dist/install.sh
+          cp static/install.ps1 dist/install.ps1
+
           # version.txt — latest version pointer
           echo "$TAG" > dist/version.txt
 
-          # _redirects — Cloudflare Pages routing rules
-          # Install scripts: rewrite /install.sh to /static/install.sh (200 = serve content at path)
-          printf '/install.sh /static/install.sh 200\n' > dist/_redirects
-          printf '/install.ps1 /static/install.ps1 200\n' >> dist/_redirects
-          # Download routing: /download/ paths to GitHub Releases
-          printf '/download/latest/* https://github.com/seite-sh/seite/releases/download/%s/:splat 302\n' "$TAG" >> dist/_redirects
+          # _redirects — route /download/ paths to GitHub Releases
+          printf '/download/latest/* https://github.com/seite-sh/seite/releases/download/%s/:splat 302\n' "$TAG" > dist/_redirects
           printf '/download/* https://github.com/seite-sh/seite/releases/download/:splat 302\n' >> dist/_redirects
 
       - name: Deploy to Cloudflare Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,12 +43,6 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             use_cross: true
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-            use_cross: false
-          - target: aarch64-pc-windows-msvc
-            os: windows-latest
-            use_cross: false
     steps:
       - uses: actions/checkout@v4
 
@@ -56,28 +50,16 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Cache cargo registry
-        uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache build artifacts
-        if: ${{ !matrix.use_cross }}
-        uses: actions/cache@v4
-        with:
-          path: target/
-          key: ${{ runner.os }}-cargo-build-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.target }}
 
       - name: Cache cross binary
         if: matrix.use_cross
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/cross
-          key: ${{ runner.os }}-cross-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cross-0.2
 
       - name: Install cross
         if: matrix.use_cross
@@ -86,8 +68,7 @@ jobs:
             cargo install cross --locked
           fi
 
-      - name: Build (Unix)
-        if: runner.os != 'Windows'
+      - name: Build
         run: |
           if [ "${{ matrix.use_cross }}" = "true" ]; then
             cross build --release --locked --target ${{ matrix.target }}
@@ -95,34 +76,64 @@ jobs:
             cargo build --release --locked --target ${{ matrix.target }}
           fi
 
-      - name: Build (Windows)
-        if: runner.os == 'Windows'
-        run: cargo build --release --locked --target ${{ matrix.target }}
-
-      - name: Package (Unix)
-        if: runner.os != 'Windows'
+      - name: Package
         run: |
           cd target/${{ matrix.target }}/release
           tar czf ../../../seite-${{ matrix.target }}.tar.gz seite
           cd ../../..
 
-      - name: Package (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          Compress-Archive -Path "target/${{ matrix.target }}/release/seite.exe" -DestinationPath "seite-${{ matrix.target }}.zip"
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: seite-${{ matrix.target }}
-          path: |
-            seite-${{ matrix.target }}.tar.gz
-            seite-${{ matrix.target }}.zip
+          path: seite-${{ matrix.target }}.tar.gz
+
+  build-windows:
+    name: Build Windows (x86_64 + aarch64)
+    needs: ci
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: windows
+
+      - name: Build x86_64
+        run: cargo build --release --locked --target x86_64-pc-windows-msvc
+
+      - name: Build aarch64
+        run: cargo build --release --locked --target aarch64-pc-windows-msvc
+
+      - name: Package x86_64
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "target/x86_64-pc-windows-msvc/release/seite.exe" -DestinationPath "seite-x86_64-pc-windows-msvc.zip"
+
+      - name: Package aarch64
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "target/aarch64-pc-windows-msvc/release/seite.exe" -DestinationPath "seite-aarch64-pc-windows-msvc.zip"
+
+      - name: Upload x86_64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: seite-x86_64-pc-windows-msvc
+          path: seite-x86_64-pc-windows-msvc.zip
+
+      - name: Upload aarch64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: seite-aarch64-pc-windows-msvc
+          path: seite-aarch64-pc-windows-msvc.zip
 
   release:
     name: Create release
-    needs: build
+    needs: [build, build-windows]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -172,7 +183,7 @@ jobs:
 
   deploy-site:
     name: Deploy docs site
-    needs: [build, release]
+    needs: [build, build-windows, release]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags: ["v*"]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g., v0.1.0) — required for manual dispatch"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -134,7 +139,12 @@ jobs:
 
       - name: Resolve tag
         id: tag
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/download-artifact@v4
         with:
@@ -179,7 +189,12 @@ jobs:
 
       - name: Resolve tag
         id: tag
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,14 +18,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - name: Build
         run: cargo build --verbose
       - name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,6 @@ assert_cmd = "2"
 predicates = "3"
 
 [profile.release]
-lto = true
+lto = "thin"
 codegen-units = 1
 strip = true


### PR DESCRIPTION
## Summary
This PR refactors the GitHub Actions workflows to improve build efficiency and simplify the release process. It consolidates caching strategies, separates Windows builds into a dedicated job, and optimizes the release build profile.

## Key Changes

### Workflow Improvements
- **Unified caching**: Replaced manual cargo registry/build artifact caching with `Swatinem/rust-cache@v2` across all workflows (release, deploy-docs, and rust.yml)
- **Separated Windows builds**: Extracted Windows (x86_64 and aarch64) builds into a dedicated `build-windows` job, simplifying the main build matrix
- **Removed workflow_call trigger**: Eliminated the `workflow_call` input from release.yml since tag pushes now directly trigger the workflow via the `push:tags` trigger
- **Simplified release-tag.yml**: Removed the intermediate `release` job that called release.yml; tag creation now directly triggers release.yml through git push
- **Updated job dependencies**: Modified `release` and `deploy-site` jobs to depend on both `build` and `build-windows` jobs

### Build Configuration
- **Optimized LTO**: Changed release profile from `lto = true` to `lto = "thin"` for faster build times while maintaining optimization benefits

### Implementation Details
- Windows builds now use explicit `Compress-Archive` commands for each target (x86_64 and aarch64) with separate artifact uploads
- Unix builds continue to use tar.gz compression
- Cross-compilation caching key simplified to use `matrix.target` instead of OS-specific keys
- Cross binary cache key changed from hash-based to version-based (`0.2`) for better cache stability

https://claude.ai/code/session_01LfFoQ8Uh5Y9KG4AJrSuuin