### PR TITLE
Add include field to Cargo.toml for package distribution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,13 @@ keywords = ["static-site-generator", "ssg", "markdown", "llm", "ai"]
 categories = ["command-line-utilities", "web-programming"]
 rust-version = "1.75"
 readme = "README.md"
+include = [
+    "src/**/*",
+    "seite-sh/content/docs/**/*.md",
+    "tests/**/*",
+    "LICENSE",
+    "README.md",
+]
 
 [[bin]]
 name = "seite"


### PR DESCRIPTION
## Summary
This change adds an explicit `include` field to the Cargo.toml manifest to control which files are packaged when distributing the crate via crates.io.

## Key Changes
- Added `include` array specifying files to be included in the published package:
  - `src/**/*` - All source code files
  - `seite-sh/content/docs/**/*.md` - Documentation markdown files
  - `tests/**/*` - Test files
  - `LICENSE` - License file
  - `README.md` - Project readme

## Details
By explicitly defining the `include` field, we ensure that only necessary files are packaged when publishing to crates.io, reducing the package size and avoiding inclusion of unnecessary files (such as CI configs, development artifacts, or other non-essential content). This is a best practice for Rust crate distribution.

https://claude.ai/code/session_01GkmmY7ahVDmJGZS1uS3kZi