### PR TITLE
Add automated crate publishing to crates.io in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,22 @@ jobs:
   #     base64-subjects: "${{ needs.release.outputs.digests }}"
   #     upload-assets: true
 
+  publish-crate:
+    name: Publish to crates.io
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Publish to crates.io
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   deploy-site:
     name: Deploy docs site
     needs: build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,11 +409,12 @@ Multi-site workspaces let you manage multiple `seite` sites from a single direct
   1. `build` — matrix builds for macOS x86_64, macOS aarch64, Linux x86_64, Linux aarch64, Windows x86_64
   2. `release` — creates GitHub Release with `seite-{target}.tar.gz` archives + `checksums-sha256.txt`
   3. `provenance` — SLSA Level 3 attestations via `slsa-framework/slsa-github-generator`
-  4. `deploy-site` — builds and deploys `seite-sh/` to Cloudflare Pages (seite.sh)
+  4. `publish-crate` — publishes to crates.io
+  5. `deploy-site` — builds and deploys `seite-sh/` to Cloudflare Pages (seite.sh)
 - **Shell installer** (`install.sh`): `curl -fsSL .../install.sh | sh` — detects platform, downloads binary, verifies checksum
 - **PowerShell installer** (`install.ps1`): `irm .../install.ps1 | iex` — Windows installer
-- **Release flow**: bump version in `Cargo.toml` + update `seite-sh/content/docs/releases.md` → push to `main` → auto-tag → auto-release → auto-deploy docs
-- **Required GitHub secrets**: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`
+- **Release flow**: bump version in `Cargo.toml` + update `seite-sh/content/docs/releases.md` → push to `main` → auto-tag → auto-release → auto-publish crate → auto-deploy docs
+- **Required GitHub secrets**: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `CARGO_REGISTRY_TOKEN`
 
 ### Themes
 


### PR DESCRIPTION
## Summary
This PR adds automated publishing of the Rust crate to crates.io as part of the release workflow, ensuring that GitHub releases and crate registry releases stay synchronized.

## Key Changes
- **New `publish-crate` job**: Added a new workflow job that publishes the crate to crates.io after a successful release
  - Runs on Ubuntu latest with stable Rust toolchain
  - Uses `cargo publish --locked` to ensure reproducible builds
  - Requires `CARGO_REGISTRY_TOKEN` secret for authentication
  - Positioned between the `release` and `deploy-site` jobs in the workflow sequence

- **Documentation updates**: Updated `CLAUDE.md` to reflect the new publishing step
  - Added `publish-crate` as step 4 in the release workflow pipeline
  - Updated release flow description to include "auto-publish crate"
  - Added `CARGO_REGISTRY_TOKEN` to the list of required GitHub secrets

## Implementation Details
- The job depends on the `release` job completing successfully, ensuring binaries are built and released before publishing the crate
- Uses standard GitHub Actions for Rust setup (`dtolnay/rust-toolchain@stable`) and caching (`Swatinem/rust-cache@v2`)
- The `--locked` flag ensures the exact dependency versions from `Cargo.lock` are used during publication

https://claude.ai/code/session_01AkKD2RxV1nvmxSVX9tqFBq