### PR TITLE
Redirect info and warn messages to stderr

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,8 +34,8 @@ else
   RESET=''
 fi
 
-info()  { printf "${BOLD}${GREEN}info${RESET}  %s\n" "$1"; }
-warn()  { printf "${BOLD}${YELLOW}warn${RESET}  %s\n" "$1"; }
+info()  { printf "${BOLD}${GREEN}info${RESET}  %s\n" "$1" >&2; }
+warn()  { printf "${BOLD}${YELLOW}warn${RESET}  %s\n" "$1" >&2; }
 error() { printf "${BOLD}${RED}error${RESET} %s\n" "$1" >&2; }
 
 # --- Platform detection ---

--- a/seite-sh/static/install.sh
+++ b/seite-sh/static/install.sh
@@ -36,8 +36,8 @@ else
   RESET=''
 fi
 
-info()  { printf "${BOLD}${GREEN}info${RESET}  %s\n" "$1"; }
-warn()  { printf "${BOLD}${YELLOW}warn${RESET}  %s\n" "$1"; }
+info()  { printf "${BOLD}${GREEN}info${RESET}  %s\n" "$1" >&2; }
+warn()  { printf "${BOLD}${YELLOW}warn${RESET}  %s\n" "$1" >&2; }
 error() { printf "${BOLD}${RED}error${RESET} %s\n" "$1" >&2; }
 
 # --- Platform detection ---


### PR DESCRIPTION
## Summary
Updated the `info()` and `warn()` functions to output to stderr instead of stdout, making them consistent with the `error()` function and following standard Unix conventions for diagnostic messages.

## Changes
- Modified `info()` function to redirect output to stderr using `>&2`
- Modified `warn()` function to redirect output to stderr using `>&2`
- Applied changes to both `install.sh` and `seite-sh/static/install.sh`

## Details
Previously, informational and warning messages were being written to stdout, which could interfere with script output that's meant to be piped or captured. By redirecting these diagnostic messages to stderr (consistent with the existing `error()` function), users can now:
- Capture only the actual output by redirecting stdout
- See all diagnostic messages (info, warn, error) together on stderr
- Better separate diagnostic output from functional output in scripts

https://claude.ai/code/session_01DAtwxQGv2UJvYvi5LEAY8x