### PR TITLE
fix: generate _redirects and version.txt in docs-only deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -60,11 +60,23 @@ jobs:
         working-directory: seite-sh
         run: seite build
 
-      - name: Copy install scripts to dist root
+      - name: Generate routing and download files
         working-directory: seite-sh
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          TAG=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name)
+
+          # Install scripts at site root
           cp static/install.sh dist/install.sh
           cp static/install.ps1 dist/install.ps1
+
+          # version.txt — latest version pointer
+          echo "$TAG" > dist/version.txt
+
+          # _redirects — route /download/ paths to GitHub Releases
+          printf '/download/latest/* https://github.com/seite-sh/seite/releases/download/%s/:splat 302\n' "$TAG" > dist/_redirects
+          printf '/download/* https://github.com/seite-sh/seite/releases/download/:splat 302\n' >> dist/_redirects
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
The deploy-docs workflow was missing the _redirects file that maps /download/* to GitHub Releases, and the version.txt pointer. These were only generated by the full release workflow, so any docs-only deploy would clobber them — causing 404s on the install script's download URLs.

Now both workflows produce identical routing files, with deploy-docs fetching the latest release tag via the GitHub API.

https://claude.ai/code/session_01DAtwxQGv2UJvYvi5LEAY8x