### PR TITLE
Fix deploy workflows to use shell installer instead of cargo install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -1551,22 +1551,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{{{ runner.os }}}}-cargo-${{{{ hashFiles('**/Cargo.lock') }}}}
-
       - name: Install seite
-        run: cargo install --path .
+        run: curl -fsSL https://seite.sh/install.sh | sh
 
       - name: Build site
         run: seite build
@@ -1612,22 +1598,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{{{ runner.os }}}}-cargo-${{{{ hashFiles('**/Cargo.lock') }}}}
-
       - name: Install seite
-        run: cargo install --path .
+        run: curl -fsSL https://seite.sh/install.sh | sh
 
       - name: Build site
         run: seite build
@@ -1647,7 +1619,7 @@ pub fn generate_netlify_config(config: &SiteConfig) -> String {
     let output_dir = &config.build.output_dir;
     format!(
         r#"[build]
-  command = "cargo install --path . && seite build"
+  command = "curl -fsSL https://seite.sh/install.sh | sh && seite build"
   publish = "{output_dir}"
 
 [[redirects]]
@@ -1675,22 +1647,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{{{ runner.os }}}}-cargo-${{{{ hashFiles('**/Cargo.lock') }}}}
-
       - name: Install seite
-        run: cargo install --path .
+        run: curl -fsSL https://seite.sh/install.sh | sh
 
       - name: Build site
         run: seite build


### PR DESCRIPTION
## Summary
Updates deployment workflow generation and adds an upgrade step to fix existing workflows that rely on building seite from source. New workflows now use the pre-built binary installer instead of `cargo install --path .`, which is more efficient and doesn't require Rust toolchain setup.

## Key Changes
- **Updated workflow generation** (`src/deploy/mod.rs`):
  - Removed Rust toolchain installation step from GitHub Actions workflows
  - Removed cargo caching configuration
  - Replaced `cargo install --path .` with `curl -fsSL https://seite.sh/install.sh | sh` for GitHub Pages, Cloudflare, and Netlify workflows
  - Updated Netlify build command to use shell installer

- **Added upgrade step** (`src/cli/upgrade.rs`):
  - New `check_deploy_workflows()` function detects and fixes old workflows containing `cargo install --path .`
  - Automatically regenerates `.github/workflows/deploy.yml` and `netlify.toml` with corrected installer commands
  - Registered as upgrade step for version 0.1.6+

- **Added integration test** (`tests/integration.rs`):
  - Verifies fresh site initialization doesn't use cargo install
  - Tests upgrade process correctly replaces old workflows with shell installer approach
  - Confirms workflow still builds the site after upgrade

- **Version bump**: Updated to 0.1.6

## Implementation Details
The upgrade mechanism intelligently regenerates deployment configurations by:
1. Loading the site config to determine the deploy target
2. Checking for the presence of `cargo install --path .` in existing workflows
3. Regenerating the appropriate workflow file using existing deploy generation functions
4. Providing clear descriptions of what was fixed during the upgrade process

https://claude.ai/code/session_01TpCDFwaSXsj5ziSdNotsL4