### PR TITLE
Add comprehensive custom theme building guide and update doc weights

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/seite-sh/content/docs/agent.md
+++ b/seite-sh/content/docs/agent.md
@@ -1,7 +1,7 @@
 ---
 title: "AI Agent"
 description: "Use seite agent to get AI assistance with content creation, site management, and theme generation."
-weight: 8
+weight: 9
 ---
 
 ## Overview

--- a/seite-sh/content/docs/cli-reference.md
+++ b/seite-sh/content/docs/cli-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "CLI Reference"
 description: "Complete reference for all seite CLI commands, flags, and options."
-weight: 10
+weight: 11
 ---
 
 {{% callout(type="tip") %}}

--- a/seite-sh/content/docs/configuration.md
+++ b/seite-sh/content/docs/configuration.md
@@ -97,6 +97,18 @@ Enable `minify` for production builds — it strips CSS/JS comments and collapse
 
 When `fingerprint = true`, static files get hashed names (e.g., `style.a1b2c3d4.css`) and an `asset-manifest.json` is written to the output directory.
 
+### CSS processing
+
+seite does not include a Sass/SCSS/PostCSS preprocessor. This is a deliberate design choice — all theme CSS lives inline in the Tera template file, making themes completely self-contained single files with no external dependencies. This means:
+
+- No build toolchain beyond the `seite` binary itself
+- Themes are portable — install from a URL, no asset pipeline setup
+- AI-generated themes (`seite theme create`) produce one complete file
+
+Modern CSS natively supports features that previously required preprocessors: custom properties (variables), nesting, `calc()`, `color-mix()`, `clamp()`. For projects that need Sass, compile externally (`sass style.scss static/style.css`) and reference the output in your template — seite copies everything in `static/` to the output directory.
+
+See [Building Custom Themes](/docs/custom-themes#css-approach-why-inline-styles) for more detail on this approach.
+
 ## Data Files
 
 Place YAML, JSON, or TOML files in the `data/` directory to make structured data available in all templates as `{{ data.filename }}`.

--- a/seite-sh/content/docs/custom-themes.md
+++ b/seite-sh/content/docs/custom-themes.md
@@ -1,0 +1,392 @@
+---
+title: "Building Custom Themes"
+description: "Step-by-step guide to creating a custom theme from scratch — template structure, CSS, SEO requirements, and testing."
+weight: 5
+---
+
+## Overview
+
+Every seite theme is a single Tera template file that serves as `base.html`. It contains the full HTML structure, all CSS (inline), SEO meta tags, search, pagination, and accessibility features. No external stylesheets, no build tools, no preprocessors — one file, completely self-contained.
+
+This guide walks you through creating a theme from scratch. If you'd rather start from an existing theme and modify it, see [Copying a Bundled Theme](#copying-a-bundled-theme).
+
+## Quick Start: Copy and Modify
+
+The fastest path to a custom theme:
+
+```bash
+# Apply a bundled theme as your starting point
+seite theme apply default
+
+# The theme is now at templates/base.html — edit it directly
+```
+
+Open `templates/base.html` and start changing CSS values, colors, fonts, and layout. Run `seite serve` and changes reload instantly.
+
+## Starting from Scratch
+
+Create `templates/base.html` with this minimal skeleton:
+
+```html
+<!DOCTYPE html>
+<html lang="{{ lang }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ page.title | default(value=site.title) }} — {{ site.title }}{% endblock %}</title>
+
+    <!-- SEO meta tags (required — see SEO section below) -->
+    <meta name="description" content="{{ page.description | default(value=site.description) }}">
+    <link rel="canonical" href="{{ site.base_url }}{{ page.url | default(value='/') }}">
+
+    {% block head %}{% endblock %}
+
+    <style>
+        {% block extra_css %}{% endblock %}
+
+        /* Your CSS here */
+        body {
+            max-width: 720px;
+            margin: 2rem auto;
+            padding: 0 1rem;
+            font-family: system-ui, sans-serif;
+            line-height: 1.6;
+        }
+    </style>
+</head>
+<body>
+    <a href="#main" class="skip-link">{{ t.skip_to_content | default(value="Skip to main content") }}</a>
+
+    {% block header %}
+    <header>
+        <h1><a href="{{ lang_prefix }}/">{{ site.title }}</a></h1>
+    </header>
+    {% endblock %}
+
+    <main id="main">
+        {% block content %}
+        {{ page.content | safe }}
+        {% endblock %}
+    </main>
+
+    {% block footer %}
+    <footer>
+        <p>&copy; {{ site.title }}</p>
+    </footer>
+    {% endblock %}
+
+    {% block extra_js %}{% endblock %}
+</body>
+</html>
+```
+
+This is a valid (if minimal) theme. Build it and verify:
+
+```bash
+seite build
+seite serve
+```
+
+## Required Template Blocks
+
+Every theme must define these 7 blocks so that collection-specific templates (`post.html`, `doc.html`, etc.) can extend and override them:
+
+| Block | Purpose |
+|-------|---------|
+| `{% block title %}` | Page `<title>` tag |
+| `{% block head %}` | Extra content in `<head>` (meta tags, preloads) |
+| `{% block extra_css %}` | Page-specific CSS injected inside `<style>` |
+| `{% block header %}` | Site header and navigation |
+| `{% block content %}` | Main page content |
+| `{% block footer %}` | Site footer |
+| `{% block extra_js %}` | Page-specific JavaScript before `</body>` |
+
+## Adding SEO Meta Tags
+
+Search engines and social platforms need these tags. Add them to `<head>`:
+
+```html
+<!-- Core SEO -->
+<meta name="description" content="{{ page.description | default(value=site.description) }}">
+<link rel="canonical" href="{{ site.base_url }}{{ page.url | default(value='/') }}">
+{% if page.robots %}<meta name="robots" content="{{ page.robots }}">{% endif %}
+
+<!-- Open Graph -->
+<meta property="og:type" content="{% if page.collection %}article{% else %}website{% endif %}">
+<meta property="og:url" content="{{ site.base_url }}{{ page.url | default(value='/') }}">
+<meta property="og:title" content="{{ page.title | default(value=site.title) }}">
+<meta property="og:description" content="{{ page.description | default(value=site.description) }}">
+{% if page.image %}<meta property="og:image" content="{{ page.image }}">{% endif %}
+<meta property="og:site_name" content="{{ site.title }}">
+<meta property="og:locale" content="{{ lang }}">
+
+<!-- Twitter Card -->
+<meta name="twitter:card" content="{% if page.image %}summary_large_image{% else %}summary{% endif %}">
+<meta name="twitter:title" content="{{ page.title | default(value=site.title) }}">
+<meta name="twitter:description" content="{{ page.description | default(value=site.description) }}">
+{% if page.image %}<meta name="twitter:image" content="{{ page.image }}">{% endif %}
+
+<!-- Discovery links -->
+<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ lang_prefix }}/feed.xml">
+<link rel="alternate" type="text/plain" title="LLM Summary" href="{{ lang_prefix }}/llms.txt">
+{% if page.url %}<link rel="alternate" type="text/markdown" href="{{ site.base_url }}{{ page.url }}.md">{% endif %}
+
+<!-- Multi-language alternates -->
+{% if translations %}{% for t in translations %}
+<link rel="alternate" hreflang="{{ t.lang }}" href="{{ site.base_url }}{{ t.url }}">
+{% endfor %}
+<link rel="alternate" hreflang="x-default" href="{{ site.base_url }}{{ page.url | default(value='/') }}">
+{% endif %}
+```
+
+## Adding JSON-LD Structured Data
+
+Add this before `</head>` for rich search results:
+
+```html
+<script type="application/ld+json">
+{% set _url = site.base_url ~ page.url | default(value='/') %}
+{% set _title = page.title | default(value=site.title) %}
+{% set _desc = page.description | default(value=site.description) %}
+{% if page.collection == 'posts' %}
+{"@context":"https://schema.org","@type":"BlogPosting",
+ "headline":{{ _title | json_encode() }},
+ "description":{{ _desc | json_encode() }},
+ "datePublished":{{ page.date | default(value='') | json_encode() }},
+ {% if page.updated %}"dateModified":{{ page.updated | json_encode() }},{% endif %}
+ "author":{"@type":"Person","name":{{ site.author | json_encode() }}},
+ "url":{{ _url | json_encode() }}}
+{% elif page.collection %}
+{"@context":"https://schema.org","@type":"Article",
+ "headline":{{ _title | json_encode() }},
+ "description":{{ _desc | json_encode() }},
+ "url":{{ _url | json_encode() }}}
+{% else %}
+{"@context":"https://schema.org","@type":"WebSite",
+ "name":{{ site.title | json_encode() }},
+ "description":{{ site.description | json_encode() }},
+ "url":{{ site.base_url | json_encode() }}}
+{% endif %}
+</script>
+```
+
+## Adding Navigation
+
+Render `data.nav` for header links (all bundled themes do this):
+
+```html
+{% if data.nav %}
+<nav class="site-nav" aria-label="Main navigation">
+    {% for item in data.nav %}
+    {% if item.external %}
+    <a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.title }}</a>
+    {% else %}
+    <a href="{{ lang_prefix }}{{ item.url }}">{{ item.title }}</a>
+    {% endif %}
+    {% endfor %}
+</nav>
+{% endif %}
+```
+
+Note the `{{ lang_prefix }}` on internal links — this ensures URLs are correct for multilingual sites.
+
+## Adding Search
+
+Search uses a JSON index generated at build time. Add the search UI and JavaScript:
+
+```html
+<!-- In your header or sidebar -->
+<form class="search-form" role="search" aria-label="{{ t.search_label | default(value='Search site content') }}">
+    <input type="search" id="search-input"
+           placeholder="{{ t.search_placeholder | default(value='Search…') }}"
+           autocomplete="off">
+</form>
+<div id="search-results" aria-live="polite"></div>
+
+<!-- Before </body> -->
+<script>
+(function(){
+    var input = document.getElementById('search-input');
+    var results = document.getElementById('search-results');
+    if (!input) return;
+    var index = null;
+    input.addEventListener('focus', function() {
+        if (index) return;
+        fetch('{{ lang_prefix }}/search-index.json')
+            .then(function(r) { return r.json(); })
+            .then(function(data) { index = data; });
+    });
+    input.addEventListener('input', function() {
+        var q = input.value.toLowerCase().trim();
+        if (!q || !index) { results.innerHTML = ''; return; }
+        var matches = index.filter(function(item) {
+            return item.title.toLowerCase().includes(q)
+                || (item.description || '').toLowerCase().includes(q)
+                || (item.tags || []).some(function(t) { return t.toLowerCase().includes(q); });
+        }).slice(0, 8);
+        if (!matches.length) {
+            results.innerHTML = '<div class="no-results">{{ t.no_results | default(value="No results") }}</div>';
+            return;
+        }
+        results.innerHTML = matches.map(function(m) {
+            return '<a href="' + m.url + '">' + m.title +
+                   (m.description ? '<div class="result-meta">' + m.description + '</div>' : '') +
+                   '</a>';
+        }).join('');
+    });
+})();
+</script>
+```
+
+## Adding Pagination
+
+When a collection has `paginate = N` in config, the `{{ pagination }}` context is available:
+
+```html
+{% if pagination %}
+<nav class="pagination" aria-label="Pagination">
+    {% if pagination.previous_url %}
+    <a href="{{ pagination.previous_url }}">{{ t.newer | default(value="Newer") }}</a>
+    {% endif %}
+    <span>{{ t.page_n_of_total | default(value="Page") | replace(from="{n}", to=pagination.current_page) | replace(from="{total}", to=pagination.total_pages) }}</span>
+    {% if pagination.next_url %}
+    <a href="{{ pagination.next_url }}">{{ t.older | default(value="Older") }}</a>
+    {% endif %}
+</nav>
+{% endif %}
+```
+
+## Adding a Language Switcher
+
+For multilingual sites, show available translations:
+
+```html
+{% if translations | length > 0 %}
+<div class="lang-switcher">
+    <strong>{{ lang | upper }}</strong>
+    {% for tr in translations %}
+    <a href="{{ tr.url }}">{{ tr.lang | upper }}</a>
+    {% endfor %}
+</div>
+{% endif %}
+```
+
+## Accessibility Checklist
+
+Every theme should include:
+
+- **Skip-to-main link** — `<a href="#main" class="skip-link">Skip to main content</a>` as the first element in `<body>`
+- **Landmark roles** — `role="search"` on search forms, `aria-label` on navigation
+- **Live regions** — `aria-live="polite"` on search results for screen reader announcements
+- **Focus rings** — visible focus indicators on all interactive elements (don't remove `outline`)
+- **Reduced motion** — `@media (prefers-reduced-motion: reduce)` to disable animations
+
+```css
+.skip-link {
+    position: absolute;
+    left: -9999px;
+    top: 0;
+    z-index: 100;
+    padding: 0.5rem 1rem;
+    background: #fff;
+}
+.skip-link:focus {
+    left: 1rem;
+}
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+    }
+}
+```
+
+## CSS Approach: Why Inline Styles
+
+seite themes use inline CSS (inside `<style>` tags in the template) rather than external stylesheets or preprocessors like Sass. This is a deliberate design choice:
+
+- **Single-file themes** — one `.tera` file contains everything. Copy it, share it, install it from a URL. No asset dependencies to manage.
+- **Zero build tools** — no Sass compiler, no PostCSS, no Node.js. The single Rust binary handles everything.
+- **Instant portability** — themes work identically on any machine without toolchain setup.
+- **AI-friendly** — when `seite theme create` generates a theme, it produces one complete file. No multi-file coordination needed.
+
+If you need advanced CSS features, modern CSS covers most use cases that previously required preprocessors:
+
+| Sass feature | CSS equivalent |
+|-------------|----------------|
+| Variables (`$color`) | Custom properties (`--color`) |
+| Nesting (`.a { .b {} }`) | Native CSS nesting (`.a { .b {} }`) |
+| Color functions | `color-mix()`, `oklch()` |
+| Math | `calc()`, `min()`, `max()`, `clamp()` |
+
+For projects that genuinely need Sass, compile it externally (`sass style.scss static/style.css`) and reference the output in your template. seite copies everything in `static/` to the output directory.
+
+## Copying a Bundled Theme
+
+To customize a bundled theme without starting from scratch:
+
+```bash
+# Apply the theme you want to start from
+seite theme apply dark
+
+# Now edit templates/base.html directly
+```
+
+The applied theme becomes your `templates/base.html`. Modify colors, fonts, spacing, layout — anything you want. The dev server (`seite serve`) live-reloads your changes instantly.
+
+## Shortcode CSS
+
+If your content uses built-in shortcodes, include CSS for them:
+
+```css
+/* Video embeds (YouTube, Vimeo) */
+.video-embed { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin: 1.5rem 0; }
+.video-embed iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
+
+/* Callouts */
+.callout { border-left: 4px solid #0057b7; background: #f0f4ff; padding: 1rem 1.25rem; margin: 1.5rem 0; border-radius: 0 4px 4px 0; }
+.callout-title { font-weight: 600; margin-bottom: 0.5rem; font-size: 0.9rem; }
+.callout-info { border-left-color: #0057b7; background: #f0f4ff; }
+.callout-warning { border-left-color: #d97706; background: #fffbeb; }
+.callout-tip { border-left-color: #059669; background: #ecfdf5; }
+
+/* Figures */
+figure { margin: 1.5rem 0; }
+figure img { display: block; max-width: 100%; }
+figcaption { font-size: 0.85rem; color: #666; margin-top: 0.5rem; }
+```
+
+## Testing Your Theme
+
+After building your theme, verify these work:
+
+1. **Build succeeds** — `seite build` with no errors
+2. **Homepage renders** — check `/` in the dev server
+3. **Posts render** — check a post page with tags, date, reading time
+4. **Docs render** — check a doc page (sidebar navigation if using docs theme)
+5. **Search works** — type in the search box, results appear
+6. **Pagination works** — if you have enough posts, page navigation renders
+7. **Tags work** — click a tag, `/tags/{tag}/` shows filtered results
+8. **RSS link** — `/feed.xml` returns valid XML
+9. **Mobile** — resize browser below 768px, layout adapts
+10. **Accessibility** — Tab through the page, focus rings are visible
+
+## Exporting and Sharing
+
+Package your theme for others:
+
+```bash
+seite theme export my-theme --description "Dark theme with green accents"
+```
+
+This saves `templates/themes/my-theme.tera` with metadata. Host the file anywhere and others install it with:
+
+```bash
+seite theme install https://your-site.com/themes/my-theme.tera
+```
+
+## Next Steps
+
+- [Templates & Themes](/docs/templates) — all template variables, blocks, and data file integration
+- [Theme Gallery](/docs/theme-gallery) — visual previews of all 6 bundled themes
+- [Shortcodes](/docs/shortcodes) — content components your theme CSS should support

--- a/seite-sh/content/docs/deployment.md
+++ b/seite-sh/content/docs/deployment.md
@@ -1,7 +1,7 @@
 ---
 title: "Deployment"
 description: "Deploy your seite site to GitHub Pages, Cloudflare Pages, or Netlify."
-weight: 7
+weight: 8
 ---
 
 ## Overview

--- a/seite-sh/content/docs/getting-started.md
+++ b/seite-sh/content/docs/getting-started.md
@@ -195,6 +195,7 @@ This adds any new configuration that shipped with the new version (e.g., MCP ser
 - [Collections](/docs/collections) — understand how posts, docs, and pages work and how to customize them
 - [Configuration](/docs/configuration) — the full `seite.toml` reference when you need to tune settings
 - [Templates & Themes](/docs/templates) — customize the look, override blocks, and browse the 6 bundled themes
+- [Building Custom Themes](/docs/custom-themes) — create a theme from scratch or modify a bundled one
 - [Deployment](/docs/deployment) — ship your site to GitHub Pages, Cloudflare, or Netlify
 - [Workspaces](/docs/workspace) — manage multiple sites in a single repository
 - [AI Agent](/docs/agent) — let Claude write content, debug builds, and generate themes for you

--- a/seite-sh/content/docs/i18n.md
+++ b/seite-sh/content/docs/i18n.md
@@ -1,7 +1,7 @@
 ---
 title: "Multi-Language"
 description: "Add translations to your site with filename-based i18n — per-language URLs, RSS, sitemaps, and discovery files."
-weight: 6
+weight: 7
 ---
 
 ## Overview

--- a/seite-sh/content/docs/mcp-server.md
+++ b/seite-sh/content/docs/mcp-server.md
@@ -1,7 +1,7 @@
 ---
 title: "MCP Server"
 description: "Structured AI access to site content, configuration, themes, and build tools via the Model Context Protocol."
-weight: 9
+weight: 10
 ---
 
 ## Overview

--- a/seite-sh/content/docs/releases.md
+++ b/seite-sh/content/docs/releases.md
@@ -1,7 +1,7 @@
 ---
 title: "Releases"
 description: "Release history and changelog for page."
-weight: 11
+weight: 12
 ---
 
 ## v0.1.0

--- a/seite-sh/content/docs/shortcodes.md
+++ b/seite-sh/content/docs/shortcodes.md
@@ -1,7 +1,7 @@
 ---
 title: Shortcodes
 description: Reusable content components for embedding videos, callouts, figures, and custom elements in markdown
-weight: 5
+weight: 6
 ---
 
 Shortcodes are reusable content components you can use inside markdown files. They let you embed rich content like videos, callout boxes, and figures without writing raw HTML.

--- a/seite-sh/content/docs/templates.md
+++ b/seite-sh/content/docs/templates.md
@@ -311,6 +311,7 @@ Docs and posts automatically get a table of contents. Headings receive `id` anch
 
 ## Next Steps
 
+- [Building Custom Themes](/docs/custom-themes) — step-by-step guide to creating a theme from scratch
 - [Theme Gallery](/docs/theme-gallery) — browse all six bundled themes with visual previews
 - [Shortcodes](/docs/shortcodes) — add videos, callouts, and figures to your content
 - [Configuration](/docs/configuration) — data file setup and all `seite.toml` options

--- a/seite-sh/content/docs/theme-gallery.md
+++ b/seite-sh/content/docs/theme-gallery.md
@@ -1,7 +1,7 @@
 ---
 title: "Theme Gallery"
 description: "Browse all bundled themes with visual previews. Install community themes or generate your own with AI."
-weight: 9
+weight: 10
 ---
 
 ## Bundled Themes
@@ -186,5 +186,6 @@ In the dev server REPL, type `theme` to list themes or `theme <name>` to apply a
 
 ## Next Steps
 
+- [Building Custom Themes](/docs/custom-themes) — step-by-step guide to creating a theme from scratch
 - [Templates & Themes](/docs/templates) — customize theme blocks, override templates, and use data files
 - [AI Agent](/docs/agent) — use Claude for content creation, site management, and more

--- a/seite-sh/content/docs/trust-center.md
+++ b/seite-sh/content/docs/trust-center.md
@@ -2,7 +2,7 @@
 title: Trust Center
 description: Build a compliance hub with certifications, subprocessors, FAQs, and security policies
 slug: trust-center
-weight: 7
+weight: 8
 ---
 
 # Trust Center

--- a/seite-sh/content/docs/workspace.md
+++ b/seite-sh/content/docs/workspace.md
@@ -1,7 +1,7 @@
 ---
 title: "Workspaces"
 description: "Manage multiple seite sites in a single repository with shared resources, unified dev server, and coordinated deploys."
-weight: 8
+weight: 9
 ---
 
 ## Overview

--- a/seite-sh/content/pages/index.md
+++ b/seite-sh/content/pages/index.md
@@ -6,7 +6,7 @@ extra:
   hero_headline: "Ship a landing page, docs site, or blog <em>in an afternoon.</em> Not a sprint."
   hero_sub: "One repo. One CLI. Your whole web presence — built with the coding agent you already use."
 
-  ribbon_1: '<span class="ribbon-highlight">curl -fsSL</span> seite.sh/install.sh | sh'
+  ribbon_1: '<span class="ribbon-highlight">curl -fsSL</span> seite.sh/install.sh | sh &nbsp;·&nbsp; macOS, Linux, Windows'
   ribbon_2: 'ships <span class="ribbon-highlight">html</span> + <span class="ribbon-highlight">markdown</span> + <span class="ribbon-highlight">llms.txt</span>'
   ribbon_3: '<span class="ribbon-highlight">6</span> bundled themes'
   ribbon_4: '<span class="ribbon-highlight">zero</span> runtime deps'
@@ -19,7 +19,7 @@ extra:
   features_sub: "HTML, markdown, RSS, sitemaps, search indexes, and LLM discovery files — from a single Rust binary with no runtime dependencies."
 
   feature_1_title: "Sub-second builds. Always."
-  feature_1_body: "Single static binary. No Node.js, no node_modules, no version managers. Install once, runs identically on every machine on your team."
+  feature_1_body: "Single static binary for macOS, Linux, and Windows. No Node.js, no node_modules, no version managers. Install once, runs identically on every machine on your team."
 
   feature_2_title: "Your agent already knows how to use this."
   feature_2_body: "Every <code>seite init</code> generates a <code>.claude/CLAUDE.md</code> context file so Claude Code (and other agents) can orient themselves immediately. Run <code>seite agent \"...\"</code> and it reads your schema, your templates, your content — before it touches anything."
@@ -55,7 +55,7 @@ extra:
   quickstart_title_1: "Up and running in thirty seconds."
 
   step_1_title: "Install seite"
-  step_1_body: "<code>curl -fsSL seite.sh/install.sh | sh</code>. Single static binary, no runtime dependencies. Works on every machine on your team without setup."
+  step_1_body: "<code>curl -fsSL seite.sh/install.sh | sh</code> on macOS/Linux, <code>irm seite.sh/install.ps1 | iex</code> on Windows. Single static binary, no runtime dependencies. Works on every machine on your team without setup."
   step_2_title: "Scaffold your site"
   step_2_body: "<code>seite init mysite</code>. Generates config, templates, collection presets, and <code>.claude/CLAUDE.md</code> — so your coding agent is immediately oriented."
   step_3_title: "Create content with your agent"

--- a/seite-sh/content/roadmap/custom-taxonomies.md
+++ b/seite-sh/content/roadmap/custom-taxonomies.md
@@ -1,0 +1,9 @@
+---
+title: Custom Taxonomies
+description: User-defined taxonomies beyond tags — categories, series, authors, and arbitrary groupings with auto-generated listing pages
+tags:
+- planned
+weight: 8
+---
+
+User-defined taxonomies beyond the built-in `tags` system. Define arbitrary groupings like `categories`, `series`, or `authors` in `seite.toml`, each with its own auto-generated index and archive pages. Modeled after Hugo's taxonomy system but keeping seite's zero-config ergonomics — tags continue to work out of the box, custom taxonomies are opt-in via config.

--- a/seite-sh/content/roadmap/deploy-history-and-rollback.md
+++ b/seite-sh/content/roadmap/deploy-history-and-rollback.md
@@ -3,7 +3,7 @@ title: Deploy History and Rollback
 description: Track deploy history with content hashing, diff previews, and one-command rollback
 tags:
 - planned
-weight: 8
+weight: 9
 ---
 
 Track deploy history and enable rollback.

--- a/seite-sh/content/roadmap/environment-aware-builds.md
+++ b/seite-sh/content/roadmap/environment-aware-builds.md
@@ -3,7 +3,7 @@ title: Environment-Aware Builds
 description: Auto-detect CI environments and support multi-environment config sections
 tags:
 - planned
-weight: 9
+weight: 10
 ---
 
 Detect CI environment variables (`GITHUB_ACTIONS`, `NETLIFY`, `CF_PAGES`) and auto-configure behavior — skip prompts, use env secrets for base_url. Support `[deploy.production]` and `[deploy.staging]` config sections with different base_url, targets, and settings.

--- a/seite-sh/content/roadmap/s3-hosting-target.md
+++ b/seite-sh/content/roadmap/s3-hosting-target.md
@@ -3,7 +3,7 @@ title: S3 Hosting Target
 description: AWS S3 + CloudFront deploy support
 tags:
 - planned
-weight: 10
+weight: 11
 ---
 
 AWS S3 + CloudFront support via `aws s3 sync` wrapper. Post-deploy webhook support (Slack, Discord, email) for team workflows.

--- a/seite-sh/content/roadmap/subdomain-deploys.md
+++ b/seite-sh/content/roadmap/subdomain-deploys.md
@@ -3,7 +3,7 @@ title: Subdomain Deploys
 description: Per-collection subdomain support for deploying collections to separate domains
 tags:
 - planned
-weight: 11
+weight: 12
 ---
 
 Per-collection subdomain support (`subdomain = "docs"` on a collection maps to `docs.example.com`). Three phases: per-collection output directory override, per-collection base_url for URL resolution, and multi-deploy orchestration looping over subdomain configs.

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -20,6 +20,7 @@ pub fn all() -> Vec<DocPage> {
         configuration(),
         collections(),
         templates(),
+        custom_themes(),
         shortcodes(),
         i18n(),
         trust_center(),
@@ -96,12 +97,22 @@ fn templates() -> DocPage {
     }
 }
 
+fn custom_themes() -> DocPage {
+    DocPage {
+        slug: "custom-themes",
+        title: "Building Custom Themes",
+        description: "Step-by-step guide to creating a custom theme from scratch — template structure, CSS, SEO requirements, and testing.",
+        weight: 5,
+        raw_content: include_str!("../seite-sh/content/docs/custom-themes.md"),
+    }
+}
+
 fn shortcodes() -> DocPage {
     DocPage {
         slug: "shortcodes",
         title: "Shortcodes",
         description: "Reusable content components in markdown — built-in and custom shortcodes.",
-        weight: 5,
+        weight: 6,
         raw_content: include_str!("../seite-sh/content/docs/shortcodes.md"),
     }
 }
@@ -111,7 +122,7 @@ fn i18n() -> DocPage {
         slug: "i18n",
         title: "Multi-Language",
         description: "Filename-based translation system with per-language URLs, RSS, sitemap, and discovery files.",
-        weight: 6,
+        weight: 7,
         raw_content: include_str!("../seite-sh/content/docs/i18n.md"),
     }
 }
@@ -121,7 +132,7 @@ fn trust_center() -> DocPage {
         slug: "trust-center",
         title: "Trust Center",
         description: "Build a compliance hub with certifications, subprocessors, FAQs, and security policies.",
-        weight: 7,
+        weight: 8,
         raw_content: include_str!("../seite-sh/content/docs/trust-center.md"),
     }
 }
@@ -131,7 +142,7 @@ fn deployment() -> DocPage {
         slug: "deployment",
         title: "Deployment",
         description: "Deploy to GitHub Pages, Cloudflare Pages, or Netlify.",
-        weight: 7,
+        weight: 8,
         raw_content: include_str!("../seite-sh/content/docs/deployment.md"),
     }
 }
@@ -141,7 +152,7 @@ fn agent() -> DocPage {
         slug: "agent",
         title: "AI Agent",
         description: "Use Claude Code as an AI assistant with full site context.",
-        weight: 8,
+        weight: 9,
         raw_content: include_str!("../seite-sh/content/docs/agent.md"),
     }
 }
@@ -151,7 +162,7 @@ fn workspace() -> DocPage {
         slug: "workspace",
         title: "Workspaces",
         description: "Manage multiple sites in a single repository.",
-        weight: 8,
+        weight: 9,
         raw_content: include_str!("../seite-sh/content/docs/workspace.md"),
     }
 }
@@ -161,7 +172,7 @@ fn mcp_server() -> DocPage {
         slug: "mcp-server",
         title: "MCP Server",
         description: "Structured AI access to site content, configuration, themes, and build tools via the Model Context Protocol.",
-        weight: 9,
+        weight: 10,
         raw_content: include_str!("../seite-sh/content/docs/mcp-server.md"),
     }
 }
@@ -171,7 +182,7 @@ fn theme_gallery() -> DocPage {
         slug: "theme-gallery",
         title: "Theme Gallery",
         description: "Visual showcase of all bundled themes.",
-        weight: 9,
+        weight: 10,
         raw_content: include_str!("../seite-sh/content/docs/theme-gallery.md"),
     }
 }
@@ -181,7 +192,7 @@ fn cli_reference() -> DocPage {
         slug: "cli-reference",
         title: "CLI Reference",
         description: "Complete reference for all seite CLI commands, flags, and options.",
-        weight: 10,
+        weight: 11,
         raw_content: include_str!("../seite-sh/content/docs/cli-reference.md"),
     }
 }
@@ -191,7 +202,7 @@ fn releases() -> DocPage {
         slug: "releases",
         title: "Releases",
         description: "Version history and release notes.",
-        weight: 11,
+        weight: 12,
         raw_content: include_str!("../seite-sh/content/docs/releases.md"),
     }
 }
@@ -204,8 +215,8 @@ mod tests {
     fn test_all_returns_all_docs() {
         let docs = all();
         assert!(
-            docs.len() >= 13,
-            "Expected at least 13 docs, got {}",
+            docs.len() >= 14,
+            "Expected at least 14 docs, got {}",
             docs.len()
         );
     }


### PR DESCRIPTION
## Summary

This PR adds a new comprehensive documentation guide for building custom themes from scratch, along with supporting updates to the documentation structure and configuration examples.

## Key Changes

- **New documentation**: Added `custom-themes.md` — a 392-line guide covering:
  - Theme structure and the single-file Tera template approach
  - Quick start via copying bundled themes
  - Minimal skeleton template with all required blocks
  - SEO meta tags, JSON-LD structured data, and accessibility requirements
  - Navigation, search, pagination, and language switcher implementation
  - Detailed explanation of why seite uses inline CSS instead of preprocessors
  - Testing checklist and theme export/sharing instructions

- **Documentation structure**: Updated `src/docs.rs` to:
  - Register the new `custom-themes` doc page with weight 5 (between Templates and Shortcodes)
  - Reweight all subsequent documentation pages (Shortcodes → 6, i18n → 7, etc.)
  - Updated corresponding frontmatter in all affected doc files

- **Configuration documentation**: Enhanced `configuration.md` with a new "CSS processing" section explaining:
  - Why seite doesn't include Sass/SCSS/PostCSS preprocessors
  - Modern CSS alternatives (custom properties, nesting, `calc()`, `color-mix()`)
  - How to use external Sass compilation if needed

- **Roadmap**: Added `custom-taxonomies.md` as a planned feature for user-defined taxonomies beyond tags

- **Version bump**: Updated `Cargo.toml` from 0.1.6 to 0.1.7

- **Minor content updates**: Updated homepage ribbon text and adjusted theme gallery weight

## Implementation Details

The new guide is comprehensive and practical, covering both the "quick start" path (copying a bundled theme) and the "from scratch" path with a minimal working template. It includes real code examples for all major features (search, pagination, SEO, accessibility) and explains seite's design philosophy around single-file themes and inline CSS. The guide is integrated into the documentation navigation and cross-referenced from related pages.

https://claude.ai/code/session_014DfmxpNpvFGK2raHKoitkE