### PR TITLE
Add background update check with 24-hour cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ src/
     upgrade.rs         Upgrade project config to current binary (version-gated steps)
     collection.rs      Collection management (add, list)
     self_update.rs     Self-update binary from GitHub Releases
+  update_check.rs        Background update check with 24h cache (~/.seite/update-cache.json)
   scaffold/            Static markdown sections for generated CLAUDE.md (include_str! at compile time)
     seo-requirements.md  SEO/GEO requirements section
     repl.md            Dev server REPL commands
@@ -403,6 +404,13 @@ Multi-site workspaces let you manage multiple `seite` sites from a single direct
 - Atomic binary replacement: rename current → backup, copy new → target, restore on failure
 
 **Build nudge** (`src/cli/build.rs`): at the start of `run()`, checks `meta::needs_upgrade()` and prints a one-liner if outdated.
+
+**Background update check** (`src/update_check.rs`):
+- Runs after every CLI command (except `self-update` and `mcp`)
+- Checks `https://seite.sh/version.txt` at most once every 24 hours
+- Caches result in `~/.seite/update-cache.json` (global, not per-project)
+- Uses a 3-second HTTP timeout; silently swallows all errors
+- Prints a one-liner via `human::info()` when a newer version is available
 
 **MCP server config**: `seite init` writes `.claude/settings.json` with a `mcpServers.seite` block. `seite upgrade` merges this into existing settings without overwriting user entries.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/seite-sh/content/docs/cli-reference.md
+++ b/seite-sh/content/docs/cli-reference.md
@@ -322,3 +322,13 @@ The command downloads the appropriate binary for your platform from GitHub Relea
 {{% callout(type="info") %}}
 After updating the binary, run `seite upgrade` in each of your projects to bring their config files up to date.
 {{% end %}}
+
+### Automatic update checks
+
+Seite checks for available updates in the background (at most once every 24 hours). When a newer version is available you'll see a one-liner after your command output:
+
+```
+ℹ A new version of seite is available: 0.1.8 → 0.2.0 (run `seite self-update`)
+```
+
+The check is non-blocking and silently skipped when offline. It does not run during `seite self-update` (which already checks) or `seite mcp` (JSON-RPC over stdio).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,5 @@ pub mod server;
 pub mod shortcodes;
 pub mod templates;
 pub mod themes;
+pub mod update_check;
 pub mod workspace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,5 +35,10 @@ fn main() -> Result<()> {
         Command::Mcp(args) => seite::cli::mcp::run(args)?,
     }
 
+    // Check for available updates (skip for self-update and mcp)
+    if !matches!(&cli.command, Command::SelfUpdate(_) | Command::Mcp(_)) {
+        seite::update_check::maybe_notify();
+    }
+
     Ok(())
 }

--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -1,0 +1,236 @@
+//! Background update check — shows a one-liner when a newer seite version is available.
+//!
+//! Stores a cache file at `~/.seite/update-cache.json` so we only hit the
+//! network at most once every 24 hours. All errors are silently swallowed —
+//! a failed check should never break the CLI.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::output::human;
+use crate::platform;
+
+/// How often to check for updates (24 hours).
+const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// HTTP timeout for the version check (3 seconds).
+const HTTP_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Cached update check result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UpdateCache {
+    /// ISO 8601 timestamp of when we last checked.
+    last_check: String,
+    /// The latest version string from the remote (e.g. "0.2.0").
+    latest_version: String,
+}
+
+/// Directory name under the user's home for global seite state.
+const CACHE_DIR: &str = ".seite";
+
+/// Cache filename.
+const CACHE_FILE: &str = "update-cache.json";
+
+/// Run the background update check. Call this from `main()` after command dispatch.
+///
+/// - Skips if we checked less than 24 hours ago (reads cache).
+/// - If the cache is stale, fetches the latest version from seite.sh/version.txt.
+/// - If a newer version is available, prints a one-liner info message.
+/// - All errors are silently ignored.
+pub fn maybe_notify() {
+    // Best-effort: never panic or propagate errors
+    let _ = check_and_notify();
+}
+
+fn check_and_notify() -> Option<()> {
+    let cache_path = cache_path()?;
+    let current_version = env!("CARGO_PKG_VERSION");
+
+    // Try to read existing cache
+    let cache = load_cache(&cache_path);
+
+    let latest_version = if should_check(&cache) {
+        // Fetch from network
+        let version = fetch_latest_version()?;
+        // Write cache regardless of result
+        let _ = write_cache(
+            &cache_path,
+            &UpdateCache {
+                last_check: Utc::now().to_rfc3339(),
+                latest_version: version.clone(),
+            },
+        );
+        version
+    } else {
+        // Use cached version
+        cache?.latest_version
+    };
+
+    // Compare versions
+    if version_is_newer(&latest_version, current_version) {
+        human::info(&format!(
+            "A new version of seite is available: {current_version} → {latest_version} \
+             (run `seite self-update`)"
+        ));
+    }
+
+    Some(())
+}
+
+/// Return the path to `~/.seite/update-cache.json`.
+fn cache_path() -> Option<PathBuf> {
+    platform::home_dir().map(|home| home.join(CACHE_DIR).join(CACHE_FILE))
+}
+
+/// Load the cache file, returning `None` if it doesn't exist or is invalid.
+fn load_cache(path: &PathBuf) -> Option<UpdateCache> {
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Write the cache file, creating the directory if needed.
+fn write_cache(path: &PathBuf, cache: &UpdateCache) -> Option<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).ok()?;
+    }
+    let json = serde_json::to_string_pretty(cache).ok()?;
+    fs::write(path, json).ok()
+}
+
+/// Determine if we should fetch a new version from the network.
+fn should_check(cache: &Option<UpdateCache>) -> bool {
+    match cache {
+        None => true,
+        Some(c) => {
+            let Ok(last) = c.last_check.parse::<DateTime<Utc>>() else {
+                return true;
+            };
+            let elapsed = Utc::now().signed_duration_since(last);
+            elapsed.num_seconds() < 0
+                || elapsed.to_std().unwrap_or(CHECK_INTERVAL) >= CHECK_INTERVAL
+        }
+    }
+}
+
+/// Fetch the latest version string from seite.sh/version.txt with a short timeout.
+fn fetch_latest_version() -> Option<String> {
+    let agent = ureq::Agent::new_with_config(
+        ureq::config::Config::builder()
+            .timeout_global(Some(HTTP_TIMEOUT))
+            .build(),
+    );
+
+    let mut response = agent
+        .get("https://seite.sh/version.txt")
+        .header("User-Agent", "seite-update-check")
+        .call()
+        .ok()?;
+
+    let body = response.body_mut().read_to_string().ok()?;
+    let version = body.trim().trim_start_matches('v').to_string();
+    if version.is_empty() {
+        return None;
+    }
+    Some(version)
+}
+
+/// Return true if `latest` is a higher semver than `current`.
+fn version_is_newer(latest: &str, current: &str) -> bool {
+    let parse = |s: &str| -> (u64, u64, u64) {
+        let parts: Vec<&str> = s.split('.').collect();
+        if parts.len() >= 3 {
+            (
+                parts[0].parse().unwrap_or(0),
+                parts[1].parse().unwrap_or(0),
+                parts[2].parse().unwrap_or(0),
+            )
+        } else {
+            (0, 0, 0)
+        }
+    };
+    parse(latest) > parse(current)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_is_newer() {
+        assert!(version_is_newer("0.2.0", "0.1.7"));
+        assert!(version_is_newer("1.0.0", "0.9.9"));
+        assert!(version_is_newer("0.1.8", "0.1.7"));
+        assert!(!version_is_newer("0.1.7", "0.1.7"));
+        assert!(!version_is_newer("0.1.6", "0.1.7"));
+        assert!(!version_is_newer("0.0.1", "0.1.7"));
+    }
+
+    #[test]
+    fn test_should_check_no_cache() {
+        assert!(should_check(&None));
+    }
+
+    #[test]
+    fn test_should_check_stale_cache() {
+        let old = Utc::now() - chrono::Duration::hours(25);
+        let cache = UpdateCache {
+            last_check: old.to_rfc3339(),
+            latest_version: "0.1.7".to_string(),
+        };
+        assert!(should_check(&Some(cache)));
+    }
+
+    #[test]
+    fn test_should_check_fresh_cache() {
+        let recent = Utc::now() - chrono::Duration::hours(1);
+        let cache = UpdateCache {
+            last_check: recent.to_rfc3339(),
+            latest_version: "0.1.7".to_string(),
+        };
+        assert!(!should_check(&Some(cache)));
+    }
+
+    #[test]
+    fn test_should_check_invalid_timestamp() {
+        let cache = UpdateCache {
+            last_check: "not-a-date".to_string(),
+            latest_version: "0.1.7".to_string(),
+        };
+        assert!(should_check(&Some(cache)));
+    }
+
+    #[test]
+    fn test_cache_roundtrip() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("update-cache.json");
+
+        let cache = UpdateCache {
+            last_check: Utc::now().to_rfc3339(),
+            latest_version: "0.2.0".to_string(),
+        };
+
+        write_cache(&path, &cache).unwrap();
+        let loaded = load_cache(&path).unwrap();
+        assert_eq!(loaded.latest_version, "0.2.0");
+        assert_eq!(loaded.last_check, cache.last_check);
+    }
+
+    #[test]
+    fn test_load_cache_missing_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("nonexistent.json");
+        assert!(load_cache(&path).is_none());
+    }
+
+    #[test]
+    fn test_load_cache_invalid_json() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("bad.json");
+        fs::write(&path, "not json").unwrap();
+        assert!(load_cache(&path).is_none());
+    }
+}


### PR DESCRIPTION
## Summary
Adds a non-blocking background update check that notifies users when a newer version of seite is available. The check runs after every CLI command (except `self-update` and `mcp`), respects a 24-hour cache to minimize network requests, and silently handles all errors to never disrupt the CLI.

## Key Changes
- **New module** `src/update_check.rs`: Implements background version checking with caching
  - Fetches latest version from `https://seite.sh/version.txt` with a 3-second timeout
  - Caches result in `~/.seite/update-cache.json` to avoid repeated network calls
  - Compares versions using semantic versioning logic
  - All errors are silently swallowed (network failures, invalid JSON, missing home dir, etc.)
  
- **Integration in `src/main.rs`**: Calls `update_check::maybe_notify()` after command dispatch, skipping for `self-update` and `mcp` commands

- **Version bump**: Updated `Cargo.toml` from 0.1.7 to 0.1.8

- **Documentation**: Added section to `cli-reference.md` explaining the automatic update check behavior

## Implementation Details
- Cache file stored at `~/.seite/update-cache.json` (global, not per-project)
- Check interval: 24 hours; uses ISO 8601 timestamps for cache validation
- HTTP timeout: 3 seconds to prevent hanging on slow/offline networks
- Version comparison: Simple semver parsing (major.minor.patch) with tuple comparison
- User notification: One-liner via `human::info()` suggesting `seite self-update`
- Comprehensive test coverage: version comparison, cache staleness, roundtrip serialization, error cases

https://claude.ai/code/session_01L8TpLjnF1BhwmxFgGG9kvy