### PR TITLE
Add multilingual 404 page support with deterministic language ordering

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,6 +1,6 @@
 pub mod defaults;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -16,7 +16,7 @@ pub struct SiteConfig {
     #[serde(default)]
     pub deploy: DeploySection,
     #[serde(default)]
-    pub languages: HashMap<String, LanguageConfig>,
+    pub languages: BTreeMap<String, LanguageConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub images: Option<ImageSection>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -152,8 +152,16 @@ fn run_serve_loop(
                         continue;
                     }
                 }
-                // Try to serve custom 404.html if it exists
-                let not_found_path = paths.output.join("404.html");
+                // Try to serve a language-specific 404.html based on URL prefix,
+                // falling back to the default 404.html
+                let lang_404_path = url_path
+                    .trim_start_matches('/')
+                    .split('/')
+                    .next()
+                    .filter(|seg| seg.len() == 2)
+                    .map(|lang| paths.output.join(lang).join("404.html"))
+                    .filter(|p| p.exists());
+                let not_found_path = lang_404_path.unwrap_or_else(|| paths.output.join("404.html"));
                 if not_found_path.exists() {
                     let content = fs::read(&not_found_path).unwrap_or_default();
                     let content = inject_livereload(&content);


### PR DESCRIPTION
## Summary
This PR enhances multilingual site support by generating language-specific 404 pages and ensuring consistent, predictable language ordering throughout the site.

## Key Changes

- **Deterministic language ordering**: Translation links are now sorted by language order (default language first, then alphabetically) to ensure the language switcher renders consistently across all pages.

- **Per-language 404 pages**: 404 pages are now generated for each configured language:
  - Default language 404 page is placed at the root (`/404.html`)
  - Other language 404 pages are placed in language-specific directories (`/{lang}/404.html`)
  - 404 page titles are localized using UI strings from the data configuration

- **Smart 404 serving**: The development server now intelligently serves language-specific 404 pages by detecting the language prefix in the requested URL path, falling back to the default 404 page when appropriate.

- **Configuration ordering**: Changed `languages` field in `SiteConfig` from `HashMap` to `BTreeMap` to maintain consistent ordering of language configurations.

## Implementation Details

- Translation vectors are sorted after being built using `lang_order` from `config.all_languages()`, with fallback to `usize::MAX` for unknown languages
- 404 page context is now language-aware, using `SiteContext::for_lang()` and language-specific UI strings
- The dev server extracts the language code from URL paths (first 2-character segment) to determine which 404 page to serve
- Error messages in 404 rendering now include the language code for better debugging

https://claude.ai/code/session_01SmpeM1S3RLf8Dp9cKXYW8Q