### PR TITLE
Add math/LaTeX rendering and AVIF image format support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,8 @@ src/
     feed.rs            RSS generation
     sitemap.rs         XML sitemap generation
     discovery.rs       robots.txt, llms.txt, llms-full.txt
-    images.rs          Image processing (resize, WebP, srcset)
+    images.rs          Image processing (resize, WebP, AVIF, srcset)
+    math.rs            Math/LaTeX pre-processing (KaTeX rendering of $inline$ and $$display$$ blocks)
   docs.rs              Embedded documentation pages (15 docs, include_str! from seite-sh/content/docs/)
   meta.rs              Project metadata (.seite/config.json) — version tracking, upgrade detection
   mcp/
@@ -187,7 +188,7 @@ scripts/
 8. Output raw markdown alongside HTML (`slug.md` next to `slug.html`)
 9. Generate search index — `search-index.json` (default lang), `/{lang}/search-index.json` (per-language)
 10. Copy static files
-11. Process images (resize to configured widths, generate WebP variants)
+11. Process images (resize to configured widths, generate WebP and AVIF variants)
 12. Post-process HTML (rewrite `<img>` tags with srcset, `<picture>` for WebP, `loading="lazy"` — first image per page skipped for LCP)
 13. Inject analytics scripts (and optional cookie consent banner) into all HTML files
 
@@ -262,6 +263,7 @@ data_dir = "data"    # optional: directory for data files (YAML/JSON/TOML)
 public_dir = "public" # optional: root-level files copied to dist/ without prefix
 minify = true        # optional: strip CSS/JS comments + collapse whitespace
 fingerprint = true   # optional: write name.<hash8>.ext + dist/asset-manifest.json
+math = true          # optional: enable $inline$ and $$display$$ math rendering via KaTeX
 
 [deploy]
 target = "github-pages"  # or "cloudflare" or "netlify"
@@ -283,6 +285,8 @@ widths = [480, 800, 1200]  # generate resized copies at these pixel widths
 quality = 80               # JPEG/WebP quality (1-100)
 lazy_loading = true        # add loading="lazy" to <img> tags
 webp = true                # generate WebP variants alongside originals
+avif = false               # generate AVIF variants (better compression than WebP)
+avif_quality = 70          # AVIF quality (1-100, lower is fine — AVIF compresses better)
 
 # Optional: trust center (omit if not using compliance hub)
 [trust]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +101,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +158,49 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "base64"
@@ -137,6 +230,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bitstream-io"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+dependencies = [
+ "core2",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +257,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
@@ -259,7 +367,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -271,7 +379,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -342,10 +450,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "copy_dir"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "543d1dd138ef086e2ff05e3a48cf9da045da2033d16f8538fd76b86cd49b2ca3"
+dependencies = [
+ "walkdir",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -401,12 +527,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -453,7 +645,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -466,10 +658,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "equivalent"
@@ -821,6 +1039,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +1093,8 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png",
+ "ravif",
+ "rgb",
  "zune-core",
  "zune-jpeg",
 ]
@@ -882,6 +1108,12 @@ dependencies = [
  "byteorder-lite",
  "quick-error",
 ]
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
@@ -916,10 +1148,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -945,6 +1206,19 @@ checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "katex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bdbc7a1823f188f56ac9486993536b70a2686a58d47095dcc10507a7d242bf5"
+dependencies = [
+ "cfg-if",
+ "derive_builder",
+ "itertools 0.10.5",
+ "quick-js",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -986,10 +1260,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libquickjs-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f0b24e9bd171b75ae0295bd428fb8fe58410fb23156e5f34a4657a70c3cee96"
+dependencies = [
+ "cc",
+ "copy_dir",
+]
 
 [[package]]
 name = "libwebp-sys"
@@ -1032,12 +1326,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1077,6 +1389,27 @@ dependencies = [
  "num-traits",
  "pxfm",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "normalize-line-endings"
@@ -1121,10 +1454,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1179,6 +1553,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,7 +1600,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1253,7 +1639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1364,7 +1750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1374,6 +1760,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1411,6 +1816,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-js"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19cb4cefcb00f4ab9b332664d06005a74f582ac16aa959c6ad5912957bd83e5f"
+dependencies = [
+ "libquickjs-sys",
+ "once_cell",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,8 +1857,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1453,7 +1878,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1463,6 +1898,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rgb",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1493,6 +2006,12 @@ name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -1579,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1589,6 +2108,7 @@ dependencies = [
  "dialoguer",
  "fs_extra",
  "image",
+ "katex",
  "notify",
  "predicates",
  "pulldown-cmark",
@@ -1643,7 +2163,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1720,6 +2240,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +2278,12 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -1758,6 +2293,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1778,7 +2324,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1829,7 +2375,7 @@ dependencies = [
  "percent-encoding",
  "pest",
  "pest_derive",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
@@ -1869,7 +2415,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1880,7 +2426,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2006,7 +2552,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2165,6 +2711,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,7 +2808,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2347,7 +2904,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2358,7 +2915,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2589,7 +3146,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2605,7 +3162,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2654,6 +3211,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,7 +3244,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2702,7 +3265,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2722,7 +3285,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2762,7 +3325,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2778,9 +2778,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2791,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2801,9 +2801,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2814,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"
@@ -39,6 +39,7 @@ serde_yaml_ng = "0.10"
 # Content processing
 pulldown-cmark = "0.13"
 syntect = "5"
+katex = { version = "0.4", default-features = true, optional = true }
 
 # Templating
 tera = "1.20"
@@ -69,7 +70,7 @@ quick-xml = { version = "0.38", features = ["serialize"] }
 slug = "0.1"
 
 # Image processing
-image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp", "avif"] }
 webp = "0.3"
 
 # HTTP client (for Cloudflare API and self-update)
@@ -77,6 +78,10 @@ ureq = { version = "3", features = ["json"] }
 
 # Temp files (for self-update checksum verification)
 tempfile = "3"
+
+[features]
+default = ["math"]
+math = ["dep:katex"]
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,7 @@ allow = [
     "BSL-1.0",
     "CC0-1.0",
     "CDLA-Permissive-2.0",
+    "NCSA",
 ]
 confidence-threshold = 0.8
 

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,9 @@ ignore = [
     # bincode is unmaintained but pulled in transitively by syntect;
     # bincode 1.3.3 is considered complete by its authors
     "RUSTSEC-2025-0141",
+    # paste is unmaintained but pulled in transitively by rav1e (AVIF encoder);
+    # no upgrade path until rav1e migrates to pastey
+    "RUSTSEC-2024-0436",
 ]
 
 [licenses]

--- a/seite-sh/content/changelog/2026-02-25-v0-3-0.md
+++ b/seite-sh/content/changelog/2026-02-25-v0-3-0.md
@@ -1,0 +1,29 @@
+---
+title: v0.3.0
+description: "Math/LaTeX rendering, AVIF image format, and CI test fix."
+date: 2026-02-25
+tags:
+- new
+- fix
+---
+
+## Math/LaTeX Rendering
+
+- New `math = true` option in `[build]` config enables server-side KaTeX rendering
+- `$inline$` and `$$display$$` math delimiters are rendered to HTML during the markdown pipeline
+- KaTeX CSS automatically loaded from CDN when math is enabled
+- Code blocks and inline code spans are correctly skipped
+- All 6 bundled themes include conditional KaTeX CSS and `.katex-display` overflow handling
+- Available when built with the `math` feature flag (enabled by default)
+
+## AVIF Image Format
+
+- New `avif = true` option in `[images]` config enables AVIF variant generation
+- Configurable AVIF quality via `avif_quality` (default: 70, since AVIF compresses better than WebP)
+- AVIF source inputs (`.avif` files) now accepted in the image pipeline
+- `<picture>` elements emit `<source type="image/avif">` before WebP for optimal compression
+- Uses the `image` crate's `ravif` backend for pure-Rust AVIF encoding
+
+## Fixes
+
+- Fixed `test_self_update_check` integration test that failed without network access — now uses `--target-version` to avoid network dependency in CI

--- a/seite-sh/content/docs/configuration.md
+++ b/seite-sh/content/docs/configuration.md
@@ -42,6 +42,7 @@ description = "Un blog personal"
 widths = [480, 800, 1200]
 quality = 80
 webp = true
+avif = false
 lazy_loading = true
 
 [analytics]
@@ -91,6 +92,7 @@ paginate = 10
 | `public_dir` | string | `"public"` | Directory for root-level files copied to output without prefix (favicon.ico, .well-known/, _redirects, etc.) |
 | `minify` | bool | `false` | Strip CSS/JS comments and collapse whitespace |
 | `fingerprint` | bool | `false` | Add content hash to asset filenames for cache busting |
+| `math` | bool | `false` | Enable math/LaTeX rendering (`$inline$` and `$$display$$` blocks via KaTeX) |
 
 {{% callout(type="tip") %}}
 Enable `minify` for production builds — it strips CSS/JS comments and collapses whitespace for smaller files. Enable `fingerprint` when your CDN caches aggressively — content hashes in filenames ensure browsers always fetch the latest version.
@@ -195,10 +197,12 @@ Optional. When this section is present, `seite` automatically processes images i
 |-------|------|---------|-------------|
 | `widths` | array | `[480, 800, 1200]` | Target widths in pixels for resized copies |
 | `quality` | int | `80` | JPEG/WebP quality (1-100) |
-| `webp` | bool | `true` | Generate WebP variants |
+| `webp` | bool | `true` | Generate WebP variants alongside originals |
+| `avif` | bool | `false` | Generate AVIF variants alongside originals (better compression than WebP) |
+| `avif_quality` | int | `70` | AVIF quality (1-100). Lower than WebP is fine — AVIF compresses better |
 | `lazy_loading` | bool | `true` | Add `loading="lazy"` to `<img>` tags |
 
-When configured, images in `static/` are resized to each width, optionally converted to WebP, and `<img>` tags in HTML are rewritten with `srcset` and `<picture>` elements. To disable image processing, remove the `[images]` section entirely.
+When configured, images in `static/` are resized to each width, optionally converted to WebP and/or AVIF, and `<img>` tags in HTML are rewritten with `srcset` and `<picture>` elements. AVIF sources appear first in the `<picture>` element so browsers that support AVIF use it (best compression), falling back to WebP, then the original format. To disable image processing, remove the `[images]` section entirely.
 
 ## [analytics]
 

--- a/src/build/math.rs
+++ b/src/build/math.rs
@@ -1,0 +1,250 @@
+//! Math/LaTeX rendering: extract `$inline$` and `$$display$$` blocks from markdown
+//! and replace them with KaTeX-rendered HTML before the markdown pipeline runs.
+//!
+//! This module is only compiled when the `math` feature is enabled.
+
+/// KaTeX CSS CDN URL for inclusion in page `<head>`.
+pub const KATEX_CSS_URL: &str = "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css";
+
+/// Pre-process markdown to render math expressions via KaTeX.
+///
+/// Scans for `$$...$$` (display) and `$...$` (inline) delimiters, renders each
+/// through KaTeX, and replaces them with raw HTML that survives markdown processing.
+/// Code blocks and inline code spans are left untouched.
+#[cfg(feature = "math")]
+pub fn render_math(markdown: &str) -> String {
+    let mut result = String::with_capacity(markdown.len());
+    let chars: Vec<char> = markdown.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        // Skip fenced code blocks (``` or ~~~)
+        if i + 2 < len
+            && ((chars[i] == '`' && chars[i + 1] == '`' && chars[i + 2] == '`')
+                || (chars[i] == '~' && chars[i + 1] == '~' && chars[i + 2] == '~'))
+        {
+            let fence_char = chars[i];
+            // Count fence length
+            let fence_start = i;
+            while i < len && chars[i] == fence_char {
+                i += 1;
+            }
+            let fence_len = i - fence_start;
+            // Copy fence + skip to end of info string (rest of line)
+            for c in &chars[fence_start..i] {
+                result.push(*c);
+            }
+            while i < len && chars[i] != '\n' {
+                result.push(chars[i]);
+                i += 1;
+            }
+            if i < len {
+                result.push(chars[i]);
+                i += 1;
+            }
+            // Copy until closing fence
+            loop {
+                if i >= len {
+                    break;
+                }
+                if chars[i] == fence_char {
+                    let close_start = i;
+                    let mut close_count = 0;
+                    while i < len && chars[i] == fence_char {
+                        close_count += 1;
+                        i += 1;
+                    }
+                    for c in &chars[close_start..i] {
+                        result.push(*c);
+                    }
+                    if close_count >= fence_len {
+                        break;
+                    }
+                } else {
+                    result.push(chars[i]);
+                    i += 1;
+                }
+            }
+            continue;
+        }
+
+        // Skip inline code spans (`...`)
+        if chars[i] == '`' && (i + 1 >= len || chars[i + 1] != '`') {
+            result.push('`');
+            i += 1;
+            while i < len && chars[i] != '`' {
+                result.push(chars[i]);
+                i += 1;
+            }
+            if i < len {
+                result.push('`');
+                i += 1;
+            }
+            continue;
+        }
+
+        // Display math: $$...$$
+        if i + 1 < len && chars[i] == '$' && chars[i + 1] == '$' {
+            i += 2;
+            let expr_start = i;
+            while i + 1 < len && !(chars[i] == '$' && chars[i + 1] == '$') {
+                i += 1;
+            }
+            if i + 1 < len {
+                let expr: String = chars[expr_start..i].iter().collect();
+                i += 2; // skip closing $$
+                match render_katex(&expr, true) {
+                    Ok(html) => result.push_str(&html),
+                    Err(_) => {
+                        // On error, preserve the original
+                        result.push_str("$$");
+                        result.push_str(&expr);
+                        result.push_str("$$");
+                    }
+                }
+            } else {
+                // Unclosed $$, preserve as-is
+                result.push_str("$$");
+                let rest: String = chars[expr_start..].iter().collect();
+                result.push_str(&rest);
+                break;
+            }
+            continue;
+        }
+
+        // Inline math: $...$
+        // Must not be preceded by \ (escape) or followed by space (not math)
+        if chars[i] == '$' {
+            // Check it's not escaped
+            let escaped = i > 0 && chars[i - 1] == '\\';
+            // Check content is not empty or starting with space
+            let has_content =
+                i + 1 < len && chars[i + 1] != '$' && chars[i + 1] != ' ' && chars[i + 1] != '\n';
+
+            if !escaped && has_content {
+                i += 1;
+                let expr_start = i;
+                while i < len && chars[i] != '$' && chars[i] != '\n' {
+                    i += 1;
+                }
+                if i < len && chars[i] == '$' {
+                    let expr: String = chars[expr_start..i].iter().collect();
+                    i += 1; // skip closing $
+                    if !expr.is_empty() && !expr.ends_with(' ') {
+                        match render_katex(&expr, false) {
+                            Ok(html) => result.push_str(&html),
+                            Err(_) => {
+                                result.push('$');
+                                result.push_str(&expr);
+                                result.push('$');
+                            }
+                        }
+                    } else {
+                        // Not valid math (trailing space), preserve
+                        result.push('$');
+                        result.push_str(&expr);
+                        result.push('$');
+                    }
+                } else {
+                    // No closing $, preserve
+                    result.push('$');
+                    let rest: String = chars[expr_start..i].iter().collect();
+                    result.push_str(&rest);
+                }
+                continue;
+            }
+        }
+
+        result.push(chars[i]);
+        i += 1;
+    }
+
+    result
+}
+
+/// Render a single math expression to HTML via KaTeX.
+#[cfg(feature = "math")]
+fn render_katex(expr: &str, display_mode: bool) -> Result<String, String> {
+    let opts = katex::Opts::builder()
+        .display_mode(display_mode)
+        .output_type(katex::OutputType::HtmlAndMathml)
+        .trust(true)
+        .build()
+        .map_err(|e| format!("KaTeX options error: {e}"))?;
+
+    katex::render_with_opts(expr, &opts).map_err(|e| format!("KaTeX render error: {e}"))
+}
+
+/// Stub when math feature is not enabled — returns input unchanged.
+#[cfg(not(feature = "math"))]
+pub fn render_math(markdown: &str) -> String {
+    markdown.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_math_passthrough_no_math() {
+        let input = "Hello world, no math here.";
+        let output = render_math(input);
+        assert_eq!(output, input);
+    }
+
+    #[cfg(feature = "math")]
+    #[test]
+    fn test_render_math_inline() {
+        let input = "The formula $E=mc^2$ is famous.";
+        let output = render_math(input);
+        assert!(
+            output.contains("katex"),
+            "should contain KaTeX HTML: {output}"
+        );
+        assert!(!output.contains("$E=mc^2$"), "should not contain raw math");
+    }
+
+    #[cfg(feature = "math")]
+    #[test]
+    fn test_render_math_display() {
+        let input = "Here is a display equation:\n\n$$\\int_0^1 x^2 dx$$\n\nEnd.";
+        let output = render_math(input);
+        assert!(
+            output.contains("katex"),
+            "should contain KaTeX HTML: {output}"
+        );
+        assert!(!output.contains("$$"), "should not contain raw $$");
+    }
+
+    #[test]
+    fn test_render_math_skips_code_blocks() {
+        let input = "```\n$not math$\n```\n\nBut $x+1$ is.";
+        let output = render_math(input);
+        // The code block content should be preserved
+        assert!(output.contains("$not math$"));
+    }
+
+    #[test]
+    fn test_render_math_skips_inline_code() {
+        let input = "Use `$PATH` variable, and $x^2$ is math.";
+        let output = render_math(input);
+        assert!(output.contains("`$PATH`"));
+    }
+
+    #[test]
+    fn test_render_math_preserves_escaped_dollar() {
+        let input = r"Price is \$5 and $x$ is math.";
+        let output = render_math(input);
+        // The \$ should not be treated as math
+        assert!(output.contains(r"\$5"));
+    }
+
+    #[test]
+    fn test_render_math_no_space_after_dollar() {
+        let input = "I have $ 5 in my wallet.";
+        let output = render_math(input);
+        // $ followed by space is not math
+        assert_eq!(output, input);
+    }
+}

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -38,6 +38,10 @@ pub fn image_quality() -> u8 {
     80
 }
 
+pub fn avif_quality() -> u8 {
+    70
+}
+
 pub fn bool_true() -> bool {
     true
 }
@@ -94,6 +98,11 @@ mod tests {
     #[test]
     fn test_image_quality() {
         assert_eq!(image_quality(), 80);
+    }
+
+    #[test]
+    fn test_avif_quality() {
+        assert_eq!(avif_quality(), 70);
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -208,6 +208,9 @@ pub struct BuildSection {
     /// Add content-hash fingerprints to static filenames and write asset-manifest.json. Default: false.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub fingerprint: bool,
+    /// Enable math/LaTeX rendering ($inline$ and $$display$$ blocks). Default: false.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub math: bool,
 }
 
 impl Default for BuildSection {
@@ -221,6 +224,7 @@ impl Default for BuildSection {
             public_dir: defaults::public_dir(),
             minify: false,
             fingerprint: false,
+            math: false,
         }
     }
 }
@@ -275,6 +279,12 @@ pub struct ImageSection {
     /// Generate WebP copies alongside originals. Default: true.
     #[serde(default = "defaults::bool_true")]
     pub webp: bool,
+    /// Generate AVIF copies alongside originals. Default: false.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub avif: bool,
+    /// AVIF quality (1-100). Default: 70 (AVIF compresses better than WebP, so lower is OK).
+    #[serde(default = "defaults::avif_quality")]
+    pub avif_quality: u8,
 }
 
 impl Default for ImageSection {
@@ -284,6 +294,8 @@ impl Default for ImageSection {
             quality: defaults::image_quality(),
             lazy_loading: true,
             webp: true,
+            avif: false,
+            avif_quality: defaults::avif_quality(),
         }
     }
 }

--- a/src/scaffold/config-reference.md
+++ b/src/scaffold/config-reference.md
@@ -2,6 +2,15 @@
 
 These sections in `seite.toml` enable additional features. Omit them entirely to disable.
 
+### Build Options
+
+```toml
+[build]
+math = true  # enable $inline$ and $$display$$ math rendering via KaTeX
+```
+
+When `math = true`, the build pipeline renders LaTeX math expressions to HTML using server-side KaTeX. KaTeX CSS is automatically loaded from CDN. Code blocks and inline code spans are skipped.
+
 ### Image Processing
 
 ```toml
@@ -9,10 +18,12 @@ These sections in `seite.toml` enable additional features. Omit them entirely to
 widths = [480, 800, 1200]  # generate resized copies at these pixel widths
 quality = 80               # JPEG/WebP quality (1-100)
 webp = true                # generate WebP variants alongside originals
+avif = true                # generate AVIF variants (better compression than WebP)
+avif_quality = 70          # AVIF quality (1-100, lower is fine — AVIF compresses better)
 lazy_loading = true        # add loading="lazy" to <img> tags
 ```
 
-When enabled, the build pipeline auto-resizes images, generates WebP variants, and rewrites `<img>` tags with `srcset` and `<picture>` elements. The first image on each page is excluded from `loading="lazy"` to avoid hurting Largest Contentful Paint (LCP) performance.
+When enabled, the build pipeline auto-resizes images, generates WebP and/or AVIF variants, and rewrites `<img>` tags with `srcset` and `<picture>` elements. AVIF sources are emitted before WebP in `<picture>` elements for optimal compression. The first image on each page is excluded from `loading="lazy"` to avoid hurting Largest Contentful Paint (LCP) performance.
 
 ### Analytics
 

--- a/src/scaffold/features.md
+++ b/src/scaffold/features.md
@@ -9,7 +9,8 @@
 - **RSS feed** — Auto-generated at `/feed.xml` (per-language feeds at `/{lang}/feed.xml`)
 - **Sitemap** — Auto-generated at `/sitemap.xml` with hreflang alternates; `lastmod` uses `updated` date (with `date` fallback)
 - **Search** — `dist/search-index.json` is auto-generated every build; the default theme includes a client-side search input that queries it. No config needed.
-- **Image processing** — Add `[images]` to `seite.toml` to auto-resize images, generate WebP variants, inject `srcset`/`<picture>` elements, and add `loading="lazy"` (first image per page is skipped to optimize LCP). See Configuration section below.
+- **Math/LaTeX rendering** — Add `math = true` to `[build]` for server-side KaTeX rendering of `$inline$` and `$$display$$` math expressions. KaTeX CSS loaded automatically from CDN.
+- **Image processing** — Add `[images]` to `seite.toml` to auto-resize images, generate WebP and AVIF variants, inject `srcset`/`<picture>` elements, and add `loading="lazy"` (first image per page is skipped to optimize LCP). See Configuration section below.
 - **Analytics** — Add `[analytics]` to `seite.toml` for Google Analytics, GTM, Plausible, Fathom, or Umami. Optional cookie consent banner. See Configuration section below.
 - **Tag pages** — Auto-generated `/tags/` index and `/tags/{tag}/` archive pages, included in sitemap
 - **404 page** — Auto-generated `dist/404.html` using the `404.html` template. Customize by creating `templates/404.html`. Dev server serves it on 404 responses.

--- a/src/themes/bento.tera
+++ b/src/themes/bento.tera
@@ -131,6 +131,7 @@
         .contact-form-honeypot { display: none; }
         .contact-form-embed { min-height: 400px; border-radius: 20px; }
         .contact-form-error { color: #dc2626; background: #fef2f2; padding: 1rem; border-radius: 12px; border-left: 4px solid #dc2626; }
+        .katex-display { overflow-x: auto; overflow-y: hidden; padding: 0.5em 0; }
         .trust-hub { max-width: 1000px; margin: 0 auto; }
         .trust-hero { margin-bottom: 2.5rem; }
         .trust-hero h1 { font-size: 2.2rem; font-weight: 800; margin-bottom: 0.5rem; }
@@ -257,6 +258,9 @@
         @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } article:hover, .cert-card:hover { transform: none !important; } }
     </style>
     {% block extra_css %}{% endblock %}
+    {% if math_enabled %}
+    <link rel="stylesheet" href="{{ katex_css_url }}" crossorigin="anonymous">
+    {% endif %}
     {% block head %}{% endblock %}
 </head>
 <body>

--- a/src/themes/brutalist.tera
+++ b/src/themes/brutalist.tera
@@ -112,6 +112,7 @@
         .contact-form-honeypot { display: none; }
         .contact-form-embed { min-height: 400px; border: 3px solid #000; }
         .contact-form-error { color: #ff4d00; background: #fffef0; padding: 1rem; border: 3px solid #ff4d00; font-weight: 700; }
+        .katex-display { overflow-x: auto; overflow-y: hidden; padding: 0.5em 0; }
         .trust-hub { max-width: 780px; margin: 0 auto; }
         .trust-hero { margin-bottom: 2rem; }
         .trust-hero h1 { font-size: 2.5rem; font-weight: 900; text-transform: uppercase; margin-bottom: 0.5rem; }
@@ -235,6 +236,9 @@
         @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } }
     </style>
     {% block extra_css %}{% endblock %}
+    {% if math_enabled %}
+    <link rel="stylesheet" href="{{ katex_css_url }}" crossorigin="anonymous">
+    {% endif %}
     {% block head %}{% endblock %}
 </head>
 <body>

--- a/src/themes/dark.tera
+++ b/src/themes/dark.tera
@@ -102,6 +102,7 @@
         .contact-form-honeypot { display: none; }
         .contact-form-embed { min-height: 400px; border-radius: 4px; }
         .contact-form-error { color: #ef4444; background: rgba(239,68,68,0.1); padding: 1rem; border-radius: 4px; border-left: 4px solid #ef4444; }
+        .katex-display { overflow-x: auto; overflow-y: hidden; padding: 0.5em 0; }
         .trust-hub { max-width: 720px; margin: 0 auto; }
         .trust-hero { margin-bottom: 2rem; }
         .trust-hero h1 { font-size: 2rem; margin-bottom: 0.5rem; color: #e8e8e8; }
@@ -225,6 +226,9 @@
         @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } }
     </style>
     {% block extra_css %}{% endblock %}
+    {% if math_enabled %}
+    <link rel="stylesheet" href="{{ katex_css_url }}" crossorigin="anonymous">
+    {% endif %}
     {% block head %}{% endblock %}
 </head>
 <body>

--- a/src/themes/default.tera
+++ b/src/themes/default.tera
@@ -99,6 +99,7 @@
         .contact-form-honeypot { display: none; }
         .contact-form-embed { min-height: 400px; border-radius: 4px; }
         .contact-form-error { color: #dc2626; background: #fef2f2; padding: 1rem; border-radius: 4px; border-left: 4px solid #dc2626; }
+        .katex-display { overflow-x: auto; overflow-y: hidden; padding: 0.5em 0; }
         .trust-hub { max-width: 720px; margin: 0 auto; }
         .trust-hero { margin-bottom: 2rem; }
         .trust-hero h1 { font-size: 2rem; margin-bottom: 0.5rem; }
@@ -219,6 +220,9 @@
         @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } }
     </style>
     {% block extra_css %}{% endblock %}
+    {% if math_enabled %}
+    <link rel="stylesheet" href="{{ katex_css_url }}" crossorigin="anonymous">
+    {% endif %}
     {% block head %}{% endblock %}
 </head>
 <body>

--- a/src/themes/docs.tera
+++ b/src/themes/docs.tera
@@ -110,6 +110,7 @@
         .contact-form-honeypot { display: none; }
         .contact-form-embed { min-height: 400px; border: 1px solid #e1e4e8; border-radius: 6px; }
         .contact-form-error { color: #cb2431; background: #ffeef0; padding: 1rem; border-radius: 6px; border-left: 4px solid #cb2431; }
+        .katex-display { overflow-x: auto; overflow-y: hidden; padding: 0.5em 0; }
         .trust-hub { max-width: 800px; margin: 0 auto; }
         .trust-hero { margin-bottom: 2rem; }
         .trust-hero h1 { font-size: 2rem; margin-bottom: 0.5rem; border-bottom: 1px solid #e1e4e8; padding-bottom: 0.3rem; }
@@ -235,6 +236,9 @@
         @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } }
     </style>
     {% block extra_css %}{% endblock %}
+    {% if math_enabled %}
+    <link rel="stylesheet" href="{{ katex_css_url }}" crossorigin="anonymous">
+    {% endif %}
     {% block head %}{% endblock %}
 </head>
 <body>

--- a/src/themes/minimal.tera
+++ b/src/themes/minimal.tera
@@ -100,6 +100,7 @@
         .contact-form-honeypot { display: none; }
         .contact-form-embed { min-height: 400px; }
         .contact-form-error { color: #dc2626; padding: 1rem; border-left: 2px solid #dc2626; }
+        .katex-display { overflow-x: auto; overflow-y: hidden; padding: 0.5em 0; }
         .trust-hub { max-width: 600px; margin: 0 auto; }
         .trust-hero { margin-bottom: 2.5rem; }
         .trust-hero h1 { font-size: 1.8rem; font-weight: normal; margin-bottom: 0.5rem; }
@@ -219,6 +220,9 @@
         @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } }
     </style>
     {% block extra_css %}{% endblock %}
+    {% if math_enabled %}
+    <link rel="stylesheet" href="{{ katex_css_url }}" crossorigin="anonymous">
+    {% endif %}
     {% block head %}{% endblock %}
 </head>
 <body>

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6987,11 +6987,18 @@ fn test_workspace_build_with_site_filter() {
 
 #[test]
 fn test_self_update_check() {
-    // --check should succeed without actually updating
+    // --check with current version should report "already up to date"
+    // Uses --target-version to avoid network dependency in CI
     page_cmd()
-        .args(["self-update", "--check"])
+        .args([
+            "self-update",
+            "--check",
+            "--target-version",
+            env!("CARGO_PKG_VERSION"),
+        ])
         .assert()
-        .success();
+        .success()
+        .stdout(predicate::str::contains("up to date"));
 }
 
 // --- additional deploy tests ---

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1894,6 +1894,146 @@ fn test_build_no_image_processing_without_config() {
     assert!(!site_dir.join("dist/static/images/photo.webp").exists());
 }
 
+#[test]
+fn test_build_image_avif_generation() {
+    let tmp = TempDir::new().unwrap();
+    init_site(&tmp, "site", "AVIF Test", "posts");
+    let site_dir = tmp.path().join("site");
+
+    write_test_image(&site_dir, "photo.png");
+
+    // Add AVIF config
+    let toml_path = site_dir.join("seite.toml");
+    let mut config = fs::read_to_string(&toml_path).unwrap();
+    if let Some(pos) = config.find("\n[images]") {
+        config.truncate(pos);
+    }
+    config.push_str(
+        "\n[images]\nwidths = [48]\nquality = 80\nlazy_loading = true\nwebp = true\navif = true\navif_quality = 70\n",
+    );
+    fs::write(&toml_path, config).unwrap();
+
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+
+    // Resized AVIF should exist
+    assert!(
+        site_dir.join("dist/static/images/photo-48w.avif").exists(),
+        "resized AVIF at 48w should exist"
+    );
+    // Full-size AVIF should exist
+    assert!(
+        site_dir.join("dist/static/images/photo.avif").exists(),
+        "full-size AVIF should exist"
+    );
+    // WebP should also exist (both enabled)
+    assert!(site_dir.join("dist/static/images/photo-48w.webp").exists());
+}
+
+#[test]
+fn test_build_image_avif_picture_element() {
+    let tmp = TempDir::new().unwrap();
+    init_site(&tmp, "site", "AVIF Picture Test", "posts,pages");
+    let site_dir = tmp.path().join("site");
+
+    let page_content = "---\ntitle: Gallery\n---\n\n![A photo](/static/images/photo.png)\n";
+    fs::write(site_dir.join("content/pages/gallery.md"), page_content).unwrap();
+
+    write_test_image(&site_dir, "photo.png");
+
+    let toml_path = site_dir.join("seite.toml");
+    let mut config = fs::read_to_string(&toml_path).unwrap();
+    if let Some(pos) = config.find("\n[images]") {
+        config.truncate(pos);
+    }
+    config.push_str(
+        "\n[images]\nwidths = [48]\nquality = 80\nlazy_loading = true\nwebp = true\navif = true\navif_quality = 70\n",
+    );
+    fs::write(&toml_path, config).unwrap();
+
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+
+    let html = fs::read_to_string(site_dir.join("dist/gallery.html")).unwrap();
+    assert!(html.contains("image/avif"), "should have AVIF source type");
+    assert!(html.contains("image/webp"), "should have WebP source type");
+    // AVIF should appear before WebP in the HTML
+    let avif_pos = html.find("image/avif").unwrap();
+    let webp_pos = html.find("image/webp").unwrap();
+    assert!(
+        avif_pos < webp_pos,
+        "AVIF source should appear before WebP for browser priority"
+    );
+}
+
+// ── Math/LaTeX rendering ──
+
+#[test]
+fn test_build_math_disabled_no_rendering() {
+    let tmp = TempDir::new().unwrap();
+    init_site(&tmp, "site", "Math Off", "posts,pages");
+    let site_dir = tmp.path().join("site");
+
+    let page_content = "---\ntitle: Math Page\n---\n\nThe formula $E=mc^2$ inline.\n";
+    fs::write(site_dir.join("content/pages/math.md"), page_content).unwrap();
+
+    // math defaults to false — no need to set it
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+
+    let html = fs::read_to_string(site_dir.join("dist/math.html")).unwrap();
+    // With math disabled, no KaTeX CSS link injected and no rendered math spans
+    assert!(
+        !html.contains("katex.min.css"),
+        "should not inject katex CSS link"
+    );
+    assert!(
+        !html.contains("<span class=\"katex\""),
+        "should not contain rendered katex spans"
+    );
+}
+
+#[test]
+fn test_build_math_enabled_renders_katex() {
+    let tmp = TempDir::new().unwrap();
+    init_site(&tmp, "site", "Math On", "posts,pages");
+    let site_dir = tmp.path().join("site");
+
+    let page_content = "---\ntitle: Math Page\n---\n\nThe formula $E=mc^2$ inline.\n";
+    fs::write(site_dir.join("content/pages/math.md"), page_content).unwrap();
+
+    // Enable math in the existing [build] section
+    let toml_path = site_dir.join("seite.toml");
+    let mut config = fs::read_to_string(&toml_path).unwrap();
+    config = config.replace("[build]", "[build]\nmath = true");
+    fs::write(&toml_path, config).unwrap();
+
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+
+    let html = fs::read_to_string(site_dir.join("dist/math.html")).unwrap();
+    assert!(
+        html.contains("katex"),
+        "should contain katex rendered output: {html}"
+    );
+    assert!(
+        html.contains("katex.min.css"),
+        "should inject katex CSS link"
+    );
+}
+
 // ── Reading time + word count ──
 
 #[test]


### PR DESCRIPTION
## Summary

This release adds two major features to seite: server-side math/LaTeX rendering via KaTeX and AVIF image format support for better compression. Version bumped to 0.3.0.

## Key Changes

### Math/LaTeX Rendering
- New `math` option in `[build]` config section enables `$inline$` and `$$display$$` math expression rendering
- Implemented `src/build/math.rs` module that pre-processes markdown to extract and render math blocks through KaTeX before the markdown pipeline
- Math expressions are converted to HTML/MathML via the `katex` crate (optional feature, enabled by default)
- Properly skips code blocks (fenced with ``` or ~~~) and inline code spans to avoid false positives
- Handles edge cases: escaped dollars (`\$`), space-prefixed dollars, unclosed delimiters
- KaTeX CSS automatically loaded from CDN when enabled
- All 6 bundled themes updated with `.katex-display` overflow handling for responsive display math

### AVIF Image Format Support
- New `avif` and `avif_quality` options in `[images]` config section
- Extended `ProcessedImage` struct with `avif_entries` field for AVIF variant tracking
- Image processing pipeline now generates AVIF variants alongside WebP when enabled
- AVIF quality defaults to 70 (lower than WebP's 80 since AVIF compresses better)
- `<picture>` elements now emit AVIF sources before WebP for optimal format negotiation
- Uses `image` crate's `ravif` backend for pure-Rust AVIF encoding
- Added "avif" to supported image extensions

### Configuration & Documentation
- Updated `src/config/mod.rs` with new `BuildSection.math` and `ImageSection.avif`/`avif_quality` fields
- Added defaults in `src/config/defaults.rs` for AVIF quality (70)
- Updated config reference and documentation with new options
- Added changelog entry for v0.3.0

### Build Integration
- Math pre-processing integrated into `build_site()` pipeline before markdown conversion
- Build flags (including math support) now passed to template context via `insert_build_flags()`
- Updated integration test `test_self_update_check` to use `--target-version` flag, eliminating network dependency in CI

## Implementation Details

- Math rendering is a pre-pass that converts `$...$` and `$$...$$` to raw HTML before markdown processing, ensuring the HTML survives markdown conversion
- AVIF encoding uses speed=6 quality setting for reasonable build performance
- Picture element source order: AVIF → WebP → original (browsers pick first supported format)
- All existing tests updated to include empty `avif_entries` vectors for compatibility

https://claude.ai/code/session_01PbGWgbMPYXdtexgpM9YtX6