### PR TITLE
Add 4 new themes + 2026 design refresh for all 10 bundled themes

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -841,7 +841,7 @@ fn generate_claude_md(
     md.push_str("seite collection list                    # List site collections\n");
     md.push_str("seite collection add <preset>            # Add a preset collection (posts, docs, pages, changelog, roadmap, trust)\n");
     md.push_str("seite theme list                         # List available themes\n");
-    md.push_str("seite theme apply <name>                 # Apply a bundled theme (default, minimal, dark, docs, brutalist, bento)\n");
+    md.push_str("seite theme apply <name>                 # Apply a bundled theme (default, minimal, dark, docs, brutalist, bento, landing, terminal, magazine, academic)\n");
     md.push_str("seite theme create \"coral brutalist\"     # Generate a custom theme with AI (requires Claude Code)\n");
     md.push_str("seite theme install <url>                # Install theme from URL\n");
     md.push_str("seite theme export <name>                # Export current theme for sharing\n");

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -1227,7 +1227,7 @@ mod tests {
         assert_eq!(result["contents"][0]["uri"], "seite://themes");
         assert_eq!(result["contents"][0]["mimeType"], "application/json");
 
-        // Should include all 6 bundled themes
+        // Should include all 10 bundled themes
         let bundled_names: Vec<&str> = themes
             .iter()
             .filter(|t| t["source"] == "bundled")
@@ -1239,7 +1239,11 @@ mod tests {
         assert!(bundled_names.contains(&"docs"));
         assert!(bundled_names.contains(&"brutalist"));
         assert!(bundled_names.contains(&"bento"));
-        assert_eq!(bundled_names.len(), 6);
+        assert!(bundled_names.contains(&"landing"));
+        assert!(bundled_names.contains(&"terminal"));
+        assert!(bundled_names.contains(&"magazine"));
+        assert!(bundled_names.contains(&"academic"));
+        assert_eq!(bundled_names.len(), 10);
     }
 
     #[test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -86,7 +86,7 @@ pub fn list() -> Result<serde_json::Value, JsonRpcError> {
                     "properties": {
                         "name": {
                             "type": "string",
-                            "description": "Theme name: default, minimal, dark, docs, brutalist, bento, or an installed theme"
+                            "description": "Theme name: default, minimal, dark, docs, brutalist, bento, landing, terminal, magazine, academic, or an installed theme"
                         }
                     },
                     "required": ["name"]
@@ -482,7 +482,7 @@ fn call_apply_theme(
 
     Ok(serde_json::json!({
         "applied": false,
-        "error": format!("Theme not found: {name}. Available bundled themes: default, minimal, dark, docs, brutalist, bento"),
+        "error": format!("Theme not found: {name}. Available bundled themes: default, minimal, dark, docs, brutalist, bento, landing, terminal, magazine, academic"),
     }))
 }
 

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -17,7 +17,18 @@ pub struct InstalledTheme {
 }
 
 pub fn all() -> Vec<Theme> {
-    vec![default(), minimal(), dark(), docs(), brutalist(), bento()]
+    vec![
+        default(),
+        minimal(),
+        dark(),
+        docs(),
+        brutalist(),
+        bento(),
+        landing(),
+        terminal(),
+        magazine(),
+        academic(),
+    ]
 }
 
 pub fn by_name(name: &str) -> Option<Theme> {
@@ -141,6 +152,38 @@ pub fn bento() -> Theme {
     }
 }
 
+pub fn landing() -> Theme {
+    Theme {
+        name: "landing",
+        description: "Marketing and landing page theme with hero sections and CTAs",
+        base_html: include_str!("themes/landing.tera"),
+    }
+}
+
+pub fn terminal() -> Theme {
+    Theme {
+        name: "terminal",
+        description: "Monospace hacker theme with green-on-black terminal aesthetic",
+        base_html: include_str!("themes/terminal.tera"),
+    }
+}
+
+pub fn magazine() -> Theme {
+    Theme {
+        name: "magazine",
+        description: "Multi-column editorial layout with featured articles",
+        base_html: include_str!("themes/magazine.tera"),
+    }
+}
+
+pub fn academic() -> Theme {
+    Theme {
+        name: "academic",
+        description: "Scholarly serif theme for research and long-form writing",
+        base_html: include_str!("themes/academic.tera"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -166,7 +209,7 @@ mod tests {
         let mut names: Vec<_> = themes.iter().map(|t| t.name).collect();
         names.sort();
         names.dedup();
-        assert_eq!(names.len(), 6);
+        assert_eq!(names.len(), 10);
     }
 
     #[test]
@@ -218,6 +261,10 @@ mod tests {
         assert!(names.contains(&"docs"));
         assert!(names.contains(&"brutalist"));
         assert!(names.contains(&"bento"));
+        assert!(names.contains(&"landing"));
+        assert!(names.contains(&"terminal"));
+        assert!(names.contains(&"magazine"));
+        assert!(names.contains(&"academic"));
     }
 
     #[test]

--- a/src/themes/academic.tera
+++ b/src/themes/academic.tera
@@ -1,0 +1,324 @@
+<!DOCTYPE html>
+<html lang="{{ lang }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="/favicon.ico">
+    <title>{% block title %}{{ site.title }}{% endblock %}</title>
+    <meta name="description" content="{{ page.description | default(value=site.description) }}">
+    <link rel="canonical" href="{{ site.base_url }}{{ page.url | default(value='/') }}">
+    <meta property="og:type" content="{% if page.collection %}article{% else %}website{% endif %}">
+    <meta property="og:url" content="{{ site.base_url }}{{ page.url | default(value='/') }}">
+    <meta property="og:title" content="{{ page.title | default(value=site.title) }}">
+    <meta property="og:description" content="{{ page.description | default(value=site.description) }}">
+    {% if page.image %}<meta property="og:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    <meta property="og:site_name" content="{{ site.title }}">
+    <meta property="og:locale" content="{{ lang }}">
+    <meta name="twitter:card" content="{% if page.image %}summary_large_image{% else %}summary{% endif %}">
+    <meta name="twitter:title" content="{{ page.title | default(value=site.title) }}">
+    <meta name="twitter:description" content="{{ page.description | default(value=site.description) }}">
+    {% if page.image %}<meta name="twitter:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    {% if page.robots %}<meta name="robots" content="{{ page.robots }}">{% endif %}
+    <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ lang_prefix }}/feed.xml">
+    <link rel="alternate" type="text/plain" title="LLM Summary" href="{{ lang_prefix }}/llms.txt">
+    {% if page.url %}<link rel="alternate" type="text/markdown" title="Markdown" href="{{ site.base_url }}{{ page.url }}.md">{% endif %}
+    {% if translations %}{% for t in translations %}<link rel="alternate" hreflang="{{ t.lang }}" href="{{ site.base_url }}{{ t.url }}">
+    {% endfor %}<link rel="alternate" hreflang="x-default" href="{{ site.base_url }}{{ page.url | default(value='/') }}">
+    {% endif %}
+    <script type="application/ld+json">
+    {% set _ld_url = page.url | default(value='/') %}{% set _ld_href = site.base_url ~ _ld_url %}{% set _ld_title = page.title | default(value=site.title) %}{% set _ld_desc = page.description | default(value=site.description) %}
+    {% if page.collection == 'posts' %}{"@context":"https://schema.org","@type":"BlogPosting","headline":{{ _ld_title | json_encode() }},"description":{{ _ld_desc | json_encode() }},"datePublished":{{ page.date | default(value='') | json_encode() }}{% if page.updated %},"dateModified":{{ page.updated | json_encode() }}{% endif %},"author":{"@type":"Person","name":{{ site.author | json_encode() }}},"publisher":{"@type":"Organization","name":{{ site.title | json_encode() }}},"url":{{ _ld_href | json_encode() }}}
+    {% elif page.collection %}{"@context":"https://schema.org","@type":"Article","headline":{{ _ld_title | json_encode() }},"description":{{ _ld_desc | json_encode() }}{% if page.updated %},"dateModified":{{ page.updated | json_encode() }}{% endif %},"author":{"@type":"Person","name":{{ site.author | json_encode() }}},"publisher":{"@type":"Organization","name":{{ site.title | json_encode() }}},"url":{{ _ld_href | json_encode() }}}
+    {% else %}{"@context":"https://schema.org","@type":"WebSite","name":{{ site.title | json_encode() }},"description":{{ site.description | json_encode() }},"url":{{ site.base_url | json_encode() }}}
+    {% endif %}
+    </script>
+    <style>
+        *, *::before, *::after { box-sizing: border-box; }
+        body { max-width: 720px; margin: 2rem auto; padding: 0 1.5rem; font-family: 'Palatino Linotype', Palatino, Georgia, 'Times New Roman', serif; font-size: 1.05rem; line-height: 1.8; color: #2c2c2c; background: #fcfcfa; }
+        a { color: #8b4513; }
+        a:hover { color: #6b3410; }
+
+        /* Header — understated institutional style */
+        header { margin-bottom: 2.5rem; padding-bottom: 1rem; border-bottom: 1px solid #d5d0c8; }
+        header h1 { margin: 0 0 0.15rem; font-size: 1.5rem; font-weight: 400; letter-spacing: 0.02em; }
+        header h1 a { color: #2c2c2c; text-decoration: none; }
+        header p { margin: 0; color: #8a8275; font-size: 0.9rem; font-style: italic; }
+        nav.site-nav { margin-top: 0.75rem; }
+        nav.site-nav a { color: #8b4513; margin-right: 1.25rem; text-decoration: none; font-size: 0.9rem; font-variant: small-caps; letter-spacing: 0.04em; }
+        nav.site-nav a:hover { text-decoration: underline; }
+        .lang-switcher { display: inline-flex; gap: 0.4rem; font-size: 0.8rem; float: right; margin-top: 0.5rem; }
+        .lang-switcher a { color: #8a8275; padding: 0.1rem 0.35rem; text-decoration: none; border: 1px solid #d5d0c8; }
+        .lang-switcher a:hover { border-color: #8b4513; color: #8b4513; }
+        .lang-switcher strong { padding: 0.1rem 0.35rem; background: #8b4513; color: #fcfcfa; }
+        .search-form { margin-top: 0.75rem; }
+        .search-form input { width: 100%; padding: 0.4rem 0.6rem; border: 1px solid #d5d0c8; background: #fcfcfa; font-family: inherit; font-size: 0.9rem; color: #2c2c2c; }
+        .search-form input:focus { outline: none; border-color: #8b4513; }
+        #search-results { border: 1px solid #d5d0c8; background: #fcfcfa; }
+        #search-results a { display: block; padding: 0.5rem 0.6rem; text-decoration: none; border-bottom: 1px solid #ebe8e2; font-size: 0.9rem; color: #8b4513; }
+        #search-results a:last-child { border-bottom: none; }
+        #search-results a:hover { background: #f5f3ef; }
+        #search-results strong { color: #2c2c2c; }
+        #search-results .result-meta { font-size: 0.75rem; color: #8a8275; margin-top: 0.1rem; }
+        #search-results .no-results { padding: 0.5rem 0.6rem; color: #8a8275; font-size: 0.9rem; }
+
+        /* Article listing */
+        article { margin-bottom: 2rem; }
+        article h3 { margin: 0 0 0.2rem; font-size: 1.1rem; font-weight: 400; }
+        article h3 a { color: #2c2c2c; text-decoration: none; }
+        article h3 a:hover { color: #8b4513; }
+        article p { color: #555; font-size: 0.95rem; margin: 0.3rem 0 0; }
+
+        /* Single article — scholarly layout */
+        main > article h1 { font-size: 1.8rem; font-weight: 400; margin: 0 0 0.5rem; line-height: 1.3; }
+        main > article h2 { font-size: 1.25rem; font-weight: 400; margin-top: 2.5rem; padding-bottom: 0.25rem; border-bottom: 1px solid #d5d0c8; font-variant: small-caps; letter-spacing: 0.02em; }
+        main > article h3 { font-size: 1.05rem; font-weight: 700; margin-top: 1.5rem; }
+        time { font-size: 0.8rem; color: #8a8275; font-style: italic; }
+        .reading-time { color: #8a8275; font-size: 0.85rem; }
+        .tags a, .tags span { color: #8b4513; font-size: 0.8rem; margin-right: 0.5rem; text-decoration: none; font-variant: small-caps; }
+        .tags a:hover { text-decoration: underline; }
+
+        /* Abstract / description block for articles */
+        .page-meta { margin-bottom: 2rem; padding: 1rem 1.25rem; background: #f5f3ef; border-left: 3px solid #8b4513; font-style: italic; color: #555; }
+
+        /* Typography */
+        pre { background: #2c2c2c; color: #e8e0d4; padding: 1rem; overflow-x: auto; font-size: 0.85rem; font-family: ui-monospace, 'SFMono-Regular', Menlo, monospace; }
+        pre code { background: none; color: inherit; padding: 0; font-family: inherit; }
+        code { font-size: 0.85em; background: #f0ece6; padding: 0.15em 0.35em; font-family: ui-monospace, 'SFMono-Regular', Menlo, monospace; }
+        blockquote { border-left: 3px solid #d5d0c8; margin: 1.5rem 0 1.5rem 2rem; padding-left: 1rem; color: #555; font-style: italic; }
+        img { max-width: 100%; height: auto; }
+        figure { margin: 2rem 0; text-align: center; }
+        figure img { display: inline-block; }
+        figcaption { font-size: 0.85rem; color: #8a8275; margin-top: 0.5rem; font-style: italic; }
+        hr { border: none; text-align: center; margin: 2.5rem 0; }
+        hr::before { content: '* * *'; color: #d5d0c8; letter-spacing: 0.5em; font-size: 0.8rem; }
+
+        /* Footnotes — academic style with proper formatting */
+        .footnote-definition { font-size: 0.85rem; color: #555; border-top: 1px solid #d5d0c8; margin-top: 2.5rem; padding-top: 1rem; }
+        .footnote-definition p { display: inline; }
+        .footnote-definition + .footnote-definition { border-top: none; margin-top: 0; padding-top: 0.25rem; }
+        sup.footnote-reference a { text-decoration: none; color: #8b4513; font-weight: 600; font-size: 0.8em; }
+
+        /* Embeds */
+        .video-embed { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin: 1.5rem 0; }
+        .video-embed iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
+        .gist-embed { margin: 1.5rem 0; }
+
+        /* Callouts — muted academic tones */
+        .callout { padding: 1rem 1.25rem; margin: 1.5rem 0; border-left: 3px solid #8b4513; background: #f5f3ef; }
+        .callout-title { font-weight: 700; margin-bottom: 0.4rem; font-size: 0.85rem; font-variant: small-caps; }
+        .callout-info { border-left-color: #3a6b8c; background: #f0f5f8; }
+        .callout-warning { border-left-color: #b8860b; background: #faf6ed; }
+        .callout-danger { border-left-color: #8b2500; background: #faf0ed; }
+        .callout-tip { border-left-color: #2e6b3a; background: #f0f5f1; }
+        .callout-note { border-left-color: #8a8275; background: #f5f3ef; }
+        .callout p:last-child { margin-bottom: 0; }
+
+        /* Contact form */
+        .contact-form { max-width: 480px; }
+        .contact-form-field { margin-bottom: 1rem; }
+        .contact-form-field label { display: block; font-weight: 400; margin-bottom: 0.25rem; font-size: 0.9rem; font-variant: small-caps; }
+        .contact-form-field input, .contact-form-field textarea { width: 100%; padding: 0.5rem 0.6rem; border: 1px solid #d5d0c8; background: #fcfcfa; font: inherit; box-sizing: border-box; }
+        .contact-form-field input:focus, .contact-form-field textarea:focus { outline: none; border-color: #8b4513; }
+        .contact-form-submit { background: #8b4513; color: #fcfcfa; border: none; padding: 0.5rem 1.5rem; font: inherit; cursor: pointer; font-variant: small-caps; letter-spacing: 0.04em; }
+        .contact-form-submit:hover { background: #6b3410; }
+        .contact-form-honeypot { display: none; }
+        .contact-form-embed { min-height: 400px; }
+        .contact-form-error { color: #8b2500; background: #faf0ed; padding: 1rem; border-left: 3px solid #8b2500; }
+
+        /* Trust center */
+        .trust-hub { max-width: 720px; margin: 0 auto; }
+        .trust-hero { margin-bottom: 2rem; }
+        .trust-hero h1 { font-size: 1.8rem; font-weight: 400; margin-bottom: 0.5rem; }
+        .trust-section { margin-bottom: 2.5rem; }
+        .trust-section h2 { font-size: 1.25rem; font-weight: 400; margin-bottom: 1rem; border-bottom: 1px solid #d5d0c8; padding-bottom: 0.25rem; font-variant: small-caps; }
+        .trust-breadcrumb { font-size: 0.85rem; color: #8a8275; margin-bottom: 1.5rem; }
+        .trust-breadcrumb a { color: #8b4513; text-decoration: none; }
+        .trust-breadcrumb a:hover { text-decoration: underline; }
+        .trust-description { color: #555; margin-bottom: 1.5rem; line-height: 1.8; }
+        .cert-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.5rem; }
+        .cert-card { border: 1px solid #d5d0c8; padding: 1.25rem; background: #fcfcfa; transition: border-color 0.15s; }
+        .cert-card:hover { border-color: #8b4513; }
+        .cert-card__header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+        .cert-card__title { font-weight: 700; font-size: 1rem; color: #2c2c2c; }
+        .cert-card__desc { font-size: 0.9rem; color: #555; margin-bottom: 0.75rem; }
+        .cert-card__link { font-size: 0.85rem; color: #8b4513; text-decoration: none; }
+        .cert-card__link:hover { text-decoration: underline; }
+        .cert-status { display: inline-block; font-size: 0.7rem; font-weight: 600; padding: 0.15rem 0.5rem; text-transform: uppercase; letter-spacing: 0.04em; }
+        .cert-status--active { background: #e8f0e4; color: #2e5a1e; }
+        .cert-status--in_progress { background: #faf6ed; color: #8b6914; }
+        .cert-status--planned { background: #f0ece6; color: #8a8275; }
+        .cert-detail { margin-bottom: 2rem; padding: 1.25rem; border: 1px solid #d5d0c8; background: #f5f3ef; }
+        .cert-meta { font-size: 0.9rem; color: #555; margin-bottom: 0.35rem; }
+        .cert-meta strong { color: #2c2c2c; }
+        .trust-item { padding: 0.75rem 0; border-bottom: 1px solid #ebe8e2; }
+        .trust-item:last-child { border-bottom: none; }
+        .subprocessor-table-wrap { overflow-x: auto; margin: 1.5rem 0; }
+        .subprocessor-table { border-collapse: collapse; width: 100%; }
+        .subprocessor-table th, .subprocessor-table td { border: 1px solid #d5d0c8; padding: 0.5rem 0.75rem; text-align: left; font-size: 0.9rem; }
+        .subprocessor-table th { background: #f5f3ef; font-weight: 600; font-variant: small-caps; }
+        .faq-section { margin-top: 2rem; }
+        .faq-item { border-bottom: 1px solid #ebe8e2; }
+        .faq-item summary { padding: 0.75rem 0; cursor: pointer; font-weight: 400; color: #2c2c2c; font-variant: small-caps; }
+        .faq-item summary:hover { color: #8b4513; }
+        .faq-answer { padding: 0 0 1rem; color: #555; line-height: 1.8; }
+        .trust-page { margin-bottom: 2rem; }
+
+        /* Changelog */
+        .changelog-entry-header { margin-bottom: 1.5rem; }
+        .changelog-meta { display: flex; align-items: center; gap: 1rem; margin-top: 0.5rem; color: #8a8275; font-size: 0.85rem; }
+        .changelog-summary { color: #555; font-size: 1rem; margin-bottom: 1.5rem; font-style: italic; }
+        .changelog-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+        .changelog-tag { display: inline-block; padding: 0.1rem 0.5rem; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+        .changelog-tag--new { background: #e8f0e4; color: #2e5a1e; }
+        .changelog-tag--fix { background: #e4ecf5; color: #1e3a6b; }
+        .changelog-tag--breaking { background: #f5e4e4; color: #8b2500; }
+        .changelog-tag--improvement { background: #f0e8f5; color: #5a2e6b; }
+        .changelog-tag--deprecated { background: #f0ece6; color: #6b6560; }
+        .changelog-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 1rem; margin-bottom: 2rem; }
+        .changelog-header h1 { margin-bottom: 0; }
+        .changelog-rss { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.8rem; color: #8a8275; text-decoration: none; padding: 0.25rem 0.6rem; border: 1px solid #d5d0c8; }
+        .changelog-rss:hover { color: #8b4513; border-color: #8b4513; }
+        .changelog-back { margin-bottom: 1.5rem; }
+        .changelog-back a { color: #8a8275; text-decoration: none; font-size: 0.9rem; }
+        .changelog-back a:hover { color: #8b4513; }
+        .changelog-timeline { position: relative; padding-left: 2rem; }
+        .changelog-timeline::before { content: ''; position: absolute; left: 0; top: 0.5rem; bottom: 0; width: 1px; background: #d5d0c8; }
+        .changelog-item { position: relative; padding-bottom: 1.5rem; border-bottom: 1px solid #ebe8e2; margin-bottom: 0; }
+        .changelog-item::before { content: ''; position: absolute; left: -2rem; top: 0.5rem; width: 8px; height: 8px; border-radius: 50%; background: #8b4513; transform: translateX(-3.5px); }
+        .changelog-item:last-child { border-bottom: none; }
+        .changelog-item-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 0.5rem; }
+        .changelog-item-header h2 { margin: 0; font-size: 1.15rem; font-weight: 400; }
+        .changelog-item-header time { color: #8a8275; font-size: 0.8rem; white-space: nowrap; }
+        .changelog-item .changelog-tags { margin-top: 0.5rem; }
+        .changelog-item p, .changelog-item .excerpt { margin-top: 0.5rem; color: #555; }
+        .changelog-feed .changelog-item::before { display: none; }
+        .changelog-feed { display: flex; flex-direction: column; gap: 0; }
+
+        /* Roadmap */
+        .roadmap-back { margin-bottom: 1.5rem; }
+        .roadmap-back a { color: #8a8275; text-decoration: none; font-size: 0.9rem; }
+        .roadmap-back a:hover { color: #8b4513; }
+        .roadmap-entry-header { margin-bottom: 1.5rem; }
+        .roadmap-summary { color: #555; font-size: 1rem; margin-bottom: 1.5rem; }
+        .roadmap-status-badges { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
+        .roadmap-status { display: inline-block; padding: 0.15rem 0.6rem; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+        .roadmap-status--planned { background: #e4ecf5; color: #1e3a6b; }
+        .roadmap-status--in-progress { background: #faf6ed; color: #8b6914; }
+        .roadmap-status--done { background: #e8f0e4; color: #2e5a1e; }
+        .roadmap-status--cancelled { background: #f0ece6; color: #6b6560; text-decoration: line-through; }
+        .roadmap-grouped { display: flex; flex-direction: column; gap: 2rem; }
+        .roadmap-section-header { display: flex; align-items: center; gap: 0.75rem; font-size: 1.05rem; margin-bottom: 1rem; font-variant: small-caps; }
+        .roadmap-items { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; }
+        .roadmap-card { padding: 1rem 1.25rem; border: 1px solid #d5d0c8; background: #fcfcfa; transition: border-color 0.15s; }
+        .roadmap-card:hover { border-color: #8b4513; }
+        .roadmap-card h3 { margin: 0 0 0.25rem; font-size: 1rem; font-weight: 400; }
+        .roadmap-card p, .roadmap-card .excerpt { margin: 0; color: #555; font-size: 0.9rem; }
+        .roadmap-kanban { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; }
+        .roadmap-column-header { font-size: 1rem; margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem; font-variant: small-caps; }
+        .roadmap-count { font-size: 0.8rem; color: #8a8275; font-weight: 400; }
+        .roadmap-timeline { position: relative; padding-left: 2rem; }
+        .roadmap-timeline::before { content: ''; position: absolute; left: 0.5rem; top: 0; bottom: 0; width: 1px; background: #d5d0c8; }
+        .roadmap-milestone { position: relative; margin-bottom: 2rem; }
+        .roadmap-milestone-dot { position: absolute; left: -1.75rem; top: 0.3rem; width: 10px; height: 10px; border-radius: 50%; border: 2px solid #8b4513; background: #fcfcfa; }
+        .roadmap-milestone-dot .roadmap-status { display: none; }
+        .roadmap-milestone-content h3 { margin: 0 0 0.25rem; font-weight: 400; }
+        .roadmap-milestone-content p { margin: 0.25rem 0 0; color: #555; font-size: 0.9rem; }
+        @media (max-width: 768px) { .roadmap-kanban { grid-template-columns: 1fr; } }
+
+        /* Tables */
+        table { border-collapse: collapse; width: 100%; margin: 1.5rem 0; }
+        th, td { border: 1px solid #d5d0c8; padding: 0.5rem 0.75rem; text-align: left; font-size: 0.9rem; }
+        th { background: #f5f3ef; font-weight: 600; font-variant: small-caps; }
+        ul.contains-task-list, ol.contains-task-list { list-style: none; padding-left: 0; }
+        li.task-list-item { display: flex; align-items: baseline; gap: 0.5rem; }
+        li.task-list-item input[type="checkbox"] { margin: 0; pointer-events: none; }
+
+        /* TOC — paper outline style */
+        .toc { margin: 1.5rem 0; padding: 1rem 1.25rem; border: 1px solid #d5d0c8; background: #f5f3ef; }
+        .toc > ul { margin: 0; padding-left: 1.25rem; }
+        .toc ul ul { padding-left: 1rem; }
+        .toc li { margin: 0.2rem 0; }
+        .toc a { text-decoration: none; color: #8b4513; }
+        .toc a:hover { text-decoration: underline; }
+
+        /* Pagination */
+        .pagination { display: flex; justify-content: space-between; align-items: center; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #d5d0c8; }
+        .pagination a { text-decoration: none; }
+        .pagination a:hover { text-decoration: underline; }
+        .pagination span { color: #8a8275; font-size: 0.9rem; }
+
+        /* Footer */
+        footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d5d0c8; color: #8a8275; font-size: 0.85rem; }
+        footer nav { margin-bottom: 0.5rem; }
+        footer nav a { color: #555; text-decoration: none; }
+        footer nav a:hover { color: #8b4513; }
+
+        /* Accessibility */
+        .skip-link { position: absolute; top: -100%; left: 0; padding: 0.5rem 1rem; background: #8b4513; color: #fcfcfa; z-index: 100; text-decoration: none; }
+        .skip-link:focus { top: 0; }
+        :focus-visible { outline: 2px solid #8b4513; outline-offset: 2px; }
+        @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } }
+    </style>
+    {% block extra_css %}{% endblock %}
+    {% block head %}{% endblock %}
+</head>
+<body>
+    <a href="#main" class="skip-link">{{ t.skip_to_content }}</a>
+    <header>
+    {% block header %}
+        <h1><a href="{{ lang_prefix }}/">{{ site.title }}</a></h1>
+        {% if site.description %}<p>{{ site.description }}</p>{% endif %}
+        {% if data.nav %}
+        <nav class="site-nav" aria-label="Main navigation">
+            {% for item in data.nav %}{% if item.external %}<a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.title }}</a>{% else %}<a href="{{ lang_prefix }}{{ item.url }}">{{ item.title }}</a>{% endif %}{% endfor %}
+        </nav>
+        {% endif %}
+        {% if translations | length > 1 %}
+        <nav class="lang-switcher">
+            {% for t in translations %}{% if t.lang == lang %}<strong>{{ t.lang | upper }}</strong>{% else %}<a href="{{ t.url }}">{{ t.lang | upper }}</a>{% endif %}{% endfor %}
+        </nav>
+        {% endif %}
+        <form class="search-form" role="search" aria-label="{{ t.search_label }}" onsubmit="return false">
+            <input type="search" id="search-input" placeholder="{{ t.search_placeholder }}" autocomplete="off" aria-label="{{ t.search_label }}">
+        </form>
+        <div id="search-results" aria-live="polite"></div>
+    {% endblock %}
+    </header>
+    <main id="main">
+        {% block content %}{% endblock %}
+    </main>
+    <footer>
+        {% if data.footer %}{% if data.footer.links %}
+        <nav aria-label="Footer navigation">
+            {% for link in data.footer.links %}{% if link.external %}<a href="{{ link.url }}" target="_blank" rel="noopener">{{ link.title }}</a>{% else %}<a href="{{ lang_prefix }}{{ link.url }}">{{ link.title }}</a>{% endif %}{% if not loop.last %} &middot; {% endif %}{% endfor %}
+        </nav>
+        {% endif %}{% endif %}
+        <p>&copy; {% if data.footer %}{% if data.footer.copyright %}{{ data.footer.copyright }}{% else %}{{ site.author }}{% endif %}{% else %}{{ site.author }}{% endif %}</p>
+    </footer>
+    <script>
+    (function(){
+        var index = null;
+        var input = document.getElementById('search-input');
+        var results = document.getElementById('search-results');
+        var basePath = {{ site.base_path | json_encode() }};
+        var indexUrl = basePath + {% if lang != default_language %}('/' + {{ lang | json_encode() }} + '/search-index.json'){% else %}'/search-index.json'{% endif %};
+        function load(cb) { if (index) { cb(); return; } fetch(indexUrl).then(function(r){return r.json();}).then(function(d){index=d;cb();}).catch(function(){index=[];}); }
+        function search(q) {
+            q = q.toLowerCase().trim();
+            if (!q) { results.innerHTML = ''; return; }
+            var hits = index.filter(function(e){
+                return (e.title||'').toLowerCase().includes(q) || (e.description||'').toLowerCase().includes(q) || (e.tags||[]).some(function(t){return t.toLowerCase().includes(q);});
+            }).slice(0, 8);
+            if (!hits.length) { results.innerHTML = '<div class="no-results">{{ t.no_results }}</div>'; return; }
+            results.innerHTML = hits.map(function(e){
+                var meta = [e.collection, e.date].filter(Boolean).join(' · ');
+                return '<a href="' + basePath + e.url + '"><strong>' + e.title + '</strong>' + (meta ? '<div class="result-meta">' + meta + '</div>' : '') + '</a>';
+            }).join('');
+        }
+        input.addEventListener('input', function(){ load(function(){ search(input.value); }); });
+    })();
+    </script>
+    {% block footer %}{% endblock %}
+    {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/src/themes/academic.tera
+++ b/src/themes/academic.tera
@@ -11,13 +11,16 @@
     <meta property="og:url" content="{{ site.base_url }}{{ page.url | default(value='/') }}">
     <meta property="og:title" content="{{ page.title | default(value=site.title) }}">
     <meta property="og:description" content="{{ page.description | default(value=site.description) }}">
-    {% if page.image %}<meta property="og:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    {% if page.image %}{% set _abs_image = page.image %}{% if not page.image is starting_with("http") %}{% set _abs_image = site.base_url ~ page.image %}{% endif %}<meta property="og:image" content="{{ _abs_image }}">
+    <meta property="og:image:width" content="1200"><meta property="og:image:height" content="630">{% endif %}
     <meta property="og:site_name" content="{{ site.title }}">
     <meta property="og:locale" content="{{ lang }}">
+    {% if page.collection and page.date %}<meta property="article:published_time" content="{{ page.date }}">{% endif %}
+    {% if page.collection and page.updated %}<meta property="article:modified_time" content="{{ page.updated }}">{% endif %}
     <meta name="twitter:card" content="{% if page.image %}summary_large_image{% else %}summary{% endif %}">
     <meta name="twitter:title" content="{{ page.title | default(value=site.title) }}">
     <meta name="twitter:description" content="{{ page.description | default(value=site.description) }}">
-    {% if page.image %}<meta name="twitter:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    {% if page.image %}<meta name="twitter:image" content="{{ _abs_image }}">{% endif %}
     {% if page.robots %}<meta name="robots" content="{{ page.robots }}">{% endif %}
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ lang_prefix }}/feed.xml">
     <link rel="alternate" type="text/plain" title="LLM Summary" href="{{ lang_prefix }}/llms.txt">
@@ -32,6 +35,9 @@
     {% else %}{"@context":"https://schema.org","@type":"WebSite","name":{{ site.title | json_encode() }},"description":{{ site.description | json_encode() }},"url":{{ site.base_url | json_encode() }}}
     {% endif %}
     </script>
+    {% if page.collection %}{% set _bc_col_url = site.base_url ~ lang_prefix ~ "/" ~ page.collection %}<script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
+    </script>{% endif %}
     <style>
         *, *::before, *::after { box-sizing: border-box; }
         body { max-width: 720px; margin: 2rem auto; padding: 0 1.5rem; font-family: 'Palatino Linotype', Palatino, Georgia, 'Times New Roman', serif; font-size: 1.05rem; line-height: 1.8; color: #2c2c2c; background: #fcfcfa; }

--- a/src/themes/academic.tera
+++ b/src/themes/academic.tera
@@ -39,231 +39,776 @@
     {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
     </script>{% endif %}
     <style>
-        *, *::before, *::after { box-sizing: border-box; }
-        body { max-width: 720px; margin: 2rem auto; padding: 0 1.5rem; font-family: 'Palatino Linotype', Palatino, Georgia, 'Times New Roman', serif; font-size: 1.05rem; line-height: 1.8; color: #2c2c2c; background: #fcfcfa; }
-        a { color: #8b4513; }
-        a:hover { color: #6b3410; }
+        /* === RESET & BASE === */
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 15px; -webkit-text-size-adjust: 100%; }
+        body {
+            width: 87.5%;
+            max-width: 1400px;
+            margin-left: auto;
+            margin-right: auto;
+            padding: 2.5rem 0 4rem;
+            font-family: 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
+            font-size: 1.1rem;
+            line-height: 1.6;
+            color: #111;
+            background: #fffff8;
+            counter-reset: sidenote-counter;
+        }
+        /* Links — scholarly dark red */
+        a { color: #a00000; text-decoration: none; }
+        a:hover { text-decoration: underline; }
 
-        /* Header — understated institutional style */
-        header { margin-bottom: 2.5rem; padding-bottom: 1rem; border-bottom: 1px solid #d5d0c8; }
-        header h1 { margin: 0 0 0.15rem; font-size: 1.5rem; font-weight: 400; letter-spacing: 0.02em; }
-        header h1 a { color: #2c2c2c; text-decoration: none; }
-        header p { margin: 0; color: #8a8275; font-size: 0.9rem; font-style: italic; }
+        /* === HEADER — understated scholarly masthead === */
+        header {
+            margin-bottom: 2.5rem;
+            padding-bottom: 1.5rem;
+            border-bottom: 1px solid #e0ddd5;
+            max-width: 60%;
+        }
+        header h1 {
+            margin: 0 0 0.15rem;
+            font-size: 1.6rem;
+            font-weight: 400;
+            letter-spacing: 0.01em;
+            line-height: 1.3;
+        }
+        header h1 a { color: #111; text-decoration: none; }
+        header h1 a:hover { color: #a00000; text-decoration: none; }
+        header > p {
+            margin: 0;
+            color: #666;
+            font-size: 0.95rem;
+            font-style: italic;
+            line-height: 1.5;
+        }
         nav.site-nav { margin-top: 0.75rem; }
-        nav.site-nav a { color: #8b4513; margin-right: 1.25rem; text-decoration: none; font-size: 0.9rem; font-variant: small-caps; letter-spacing: 0.04em; }
+        nav.site-nav a {
+            color: #a00000;
+            margin-right: 1.5rem;
+            text-decoration: none;
+            font-size: 0.85rem;
+            font-variant: small-caps;
+            letter-spacing: 0.05em;
+        }
         nav.site-nav a:hover { text-decoration: underline; }
-        .lang-switcher { display: inline-flex; gap: 0.4rem; font-size: 0.8rem; float: right; margin-top: 0.5rem; }
-        .lang-switcher a { color: #8a8275; padding: 0.1rem 0.35rem; text-decoration: none; border: 1px solid #d5d0c8; }
-        .lang-switcher a:hover { border-color: #8b4513; color: #8b4513; }
-        .lang-switcher strong { padding: 0.1rem 0.35rem; background: #8b4513; color: #fcfcfa; }
-        .search-form { margin-top: 0.75rem; }
-        .search-form input { width: 100%; padding: 0.4rem 0.6rem; border: 1px solid #d5d0c8; background: #fcfcfa; font-family: inherit; font-size: 0.9rem; color: #2c2c2c; }
-        .search-form input:focus { outline: none; border-color: #8b4513; }
-        #search-results { border: 1px solid #d5d0c8; background: #fcfcfa; }
-        #search-results a { display: block; padding: 0.5rem 0.6rem; text-decoration: none; border-bottom: 1px solid #ebe8e2; font-size: 0.9rem; color: #8b4513; }
+
+        /* Language switcher */
+        .lang-switcher {
+            display: inline-flex;
+            gap: 0.35rem;
+            font-size: 0.75rem;
+            float: right;
+            margin-top: 0.3rem;
+        }
+        .lang-switcher a {
+            color: #999;
+            padding: 0.1rem 0.4rem;
+            text-decoration: none;
+            border: 1px solid #e0ddd5;
+        }
+        .lang-switcher a:hover { border-color: #a00000; color: #a00000; }
+        .lang-switcher strong {
+            padding: 0.1rem 0.4rem;
+            background: #a00000;
+            color: #fffff8;
+            font-weight: 600;
+        }
+
+        /* Search */
+        .search-form { margin-top: 0.75rem; max-width: 100%; }
+        .search-form input {
+            width: 100%;
+            padding: 0.35rem 0;
+            border: none;
+            border-bottom: 1px solid #e0ddd5;
+            background: transparent;
+            font-family: inherit;
+            font-size: 0.85rem;
+            color: #111;
+        }
+        .search-form input:focus { outline: none; border-bottom-color: #a00000; }
+        .search-form input::placeholder { color: #999; font-style: italic; }
+        #search-results {
+            background: #fffff8;
+            border: 1px solid #e0ddd5;
+            border-top: none;
+            max-width: 100%;
+        }
+        #search-results:empty { border: none; }
+        #search-results a {
+            display: block;
+            padding: 0.5rem 0.6rem;
+            text-decoration: none;
+            border-bottom: 1px solid #f0ede5;
+            font-size: 0.85rem;
+            color: #a00000;
+        }
         #search-results a:last-child { border-bottom: none; }
-        #search-results a:hover { background: #f5f3ef; }
-        #search-results strong { color: #2c2c2c; }
-        #search-results .result-meta { font-size: 0.75rem; color: #8a8275; margin-top: 0.1rem; }
-        #search-results .no-results { padding: 0.5rem 0.6rem; color: #8a8275; font-size: 0.9rem; }
+        #search-results a:hover { background: #f7f4ee; text-decoration: none; }
+        #search-results strong { color: #111; font-weight: 600; }
+        #search-results .result-meta { font-size: 0.7rem; color: #999; margin-top: 0.15rem; }
+        #search-results .no-results { padding: 0.5rem 0.6rem; color: #999; font-size: 0.85rem; font-style: italic; }
 
-        /* Article listing */
-        article { margin-bottom: 2rem; }
-        article h3 { margin: 0 0 0.2rem; font-size: 1.1rem; font-weight: 400; }
-        article h3 a { color: #2c2c2c; text-decoration: none; }
-        article h3 a:hover { color: #8b4513; }
-        article p { color: #555; font-size: 0.95rem; margin: 0.3rem 0 0; }
+        /* === MAIN CONTENT — Tufte wide layout === */
+        main {
+            width: 60%;
+            position: relative;
+        }
 
-        /* Single article — scholarly layout */
-        main > article h1 { font-size: 1.8rem; font-weight: 400; margin: 0 0 0.5rem; line-height: 1.3; }
-        main > article h2 { font-size: 1.25rem; font-weight: 400; margin-top: 2.5rem; padding-bottom: 0.25rem; border-bottom: 1px solid #d5d0c8; font-variant: small-caps; letter-spacing: 0.02em; }
-        main > article h3 { font-size: 1.05rem; font-weight: 700; margin-top: 1.5rem; }
-        time { font-size: 0.8rem; color: #8a8275; font-style: italic; }
-        .reading-time { color: #8a8275; font-size: 0.85rem; }
-        .tags a, .tags span { color: #8b4513; font-size: 0.8rem; margin-right: 0.5rem; text-decoration: none; font-variant: small-caps; }
+        /* === ARTICLE LISTING (index pages) === */
+        .article-list article { margin-bottom: 1.75rem; }
+        .article-list article h3 {
+            margin: 0 0 0.1rem;
+            font-size: 1.05rem;
+            font-weight: 400;
+        }
+        .article-list article h3 a { color: #111; text-decoration: none; }
+        .article-list article h3 a:hover { color: #a00000; }
+        .article-list article p { color: #666; font-size: 0.9rem; margin: 0.2rem 0 0; line-height: 1.5; }
+        .article-list article time { font-size: 0.75rem; color: #999; font-style: italic; }
+
+        /* === SINGLE ARTICLE — scholarly typesetting === */
+
+        /* h1 — article title, light weight, elegant */
+        main > article h1,
+        main > .article-header h1 {
+            font-size: 2rem;
+            font-weight: 400;
+            margin: 0 0 0.5rem;
+            line-height: 1.25;
+        }
+
+        /* h2 — section header, SMALL CAPS not bold (paper style) */
+        main h2 {
+            font-variant: small-caps;
+            letter-spacing: 0.01em;
+            font-size: 1.1rem;
+            font-weight: 400;
+            margin-top: 2.5rem;
+            margin-bottom: 0.6rem;
+        }
+
+        /* h3 — subsection, bold */
+        main h3 {
+            font-size: 1rem;
+            font-weight: 700;
+            margin-top: 1.8rem;
+            margin-bottom: 0.4rem;
+        }
+
+        main h4 {
+            font-size: 0.95rem;
+            font-weight: 700;
+            font-style: italic;
+            margin-top: 1.5rem;
+            margin-bottom: 0.3rem;
+        }
+
+        main p { margin-bottom: 1rem; }
+
+        /* Date, reading time, tags */
+        time { font-size: 0.8rem; color: #999; font-style: italic; }
+        .reading-time { color: #999; font-size: 0.8rem; font-style: italic; }
+        .tags a, .tags span {
+            color: #a00000;
+            font-size: 0.75rem;
+            margin-right: 0.5rem;
+            text-decoration: none;
+            font-variant: small-caps;
+            letter-spacing: 0.03em;
+        }
         .tags a:hover { text-decoration: underline; }
 
-        /* Abstract / description block for articles */
-        .page-meta { margin-bottom: 2rem; padding: 1rem 1.25rem; background: #f5f3ef; border-left: 3px solid #8b4513; font-style: italic; color: #555; }
+        /* Epigraph / abstract / page-meta — italic, content-width, no border */
+        .page-meta {
+            font-style: italic;
+            margin: 1.5rem 0 2rem;
+            padding: 0;
+            border: none;
+            font-size: 0.95rem;
+            color: #555;
+            line-height: 1.65;
+            max-width: 100%;
+        }
 
-        /* Typography */
-        pre { background: #2c2c2c; color: #e8e0d4; padding: 1rem; overflow-x: auto; font-size: 0.85rem; font-family: ui-monospace, 'SFMono-Regular', Menlo, monospace; }
-        pre code { background: none; color: inherit; padding: 0; font-family: inherit; }
-        code { font-size: 0.85em; background: #f0ece6; padding: 0.15em 0.35em; font-family: ui-monospace, 'SFMono-Regular', Menlo, monospace; }
-        blockquote { border-left: 3px solid #d5d0c8; margin: 1.5rem 0 1.5rem 2rem; padding-left: 1rem; color: #555; font-style: italic; }
+        /* === TYPOGRAPHY — TUFTE STYLE === */
+
+        /* Blockquotes — italic, indented, NO border */
+        blockquote {
+            margin: 1.5rem 0 1.5rem 2rem;
+            padding: 0;
+            border: none;
+            font-style: italic;
+            color: #333;
+        }
+        blockquote p { margin-bottom: 0.5rem; }
+        blockquote footer { font-style: normal; font-size: 0.85rem; color: #999; margin-top: 0.25rem; border: none; padding: 0; }
+
+        /* Ornamental section divider */
+        hr {
+            border: none;
+            margin: 2.5rem auto;
+            width: 40%;
+        }
+        hr::before {
+            content: '\00a7';
+            display: block;
+            text-align: center;
+            font-size: 1.2rem;
+            color: #999;
+        }
+
+        /* Code — warm tints, smaller than body */
+        pre {
+            background: #f7f4ee;
+            color: #111;
+            padding: 1rem 1.25rem;
+            overflow-x: auto;
+            font-size: 0.8rem;
+            line-height: 1.55;
+            font-family: ui-monospace, 'SFMono-Regular', 'SF Mono', Menlo, Consolas, monospace;
+            border: 1px solid #e0ddd5;
+            margin: 1.5rem 0;
+            position: relative;
+        }
+        pre code {
+            background: none;
+            color: inherit;
+            padding: 0;
+            font-family: inherit;
+            font-size: inherit;
+            border: none;
+        }
+        code {
+            font-size: 0.8em;
+            background: #f7f4ee;
+            padding: 0.1em 0.3em;
+            font-family: ui-monospace, 'SFMono-Regular', 'SF Mono', Menlo, Consolas, monospace;
+            border: 1px solid #ece9e1;
+        }
+
+        /* Copy button for code blocks */
+        .code-copy-btn {
+            position: absolute;
+            top: 0.4rem;
+            right: 0.4rem;
+            background: #e0ddd5;
+            border: none;
+            padding: 0.2rem 0.5rem;
+            font-size: 0.65rem;
+            cursor: pointer;
+            color: #666;
+            font-family: inherit;
+            opacity: 0;
+            transition: opacity 0.15s;
+        }
+        pre:hover .code-copy-btn { opacity: 1; }
+        .code-copy-btn:hover { background: #d0cdc5; color: #111; }
+
+        /* Images */
         img { max-width: 100%; height: auto; }
-        figure { margin: 2rem 0; text-align: center; }
-        figure img { display: inline-block; }
-        figcaption { font-size: 0.85rem; color: #8a8275; margin-top: 0.5rem; font-style: italic; }
-        hr { border: none; text-align: center; margin: 2.5rem 0; }
-        hr::before { content: '* * *'; color: #d5d0c8; letter-spacing: 0.5em; font-size: 0.8rem; }
 
-        /* Footnotes — academic style with proper formatting */
-        .footnote-definition { font-size: 0.85rem; color: #555; border-top: 1px solid #d5d0c8; margin-top: 2.5rem; padding-top: 1rem; }
+        /* Figures — can span wider than content column */
+        figure {
+            margin: 2rem 0;
+            max-width: 100%;
+        }
+        figure img { display: block; }
+        figcaption {
+            font-size: 0.8rem;
+            color: #666;
+            margin-top: 0.5rem;
+            font-style: italic;
+            line-height: 1.5;
+        }
+
+        /* Tables — scholarly, clean lines */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1.5rem 0;
+            font-size: 0.9rem;
+        }
+        th, td {
+            border-bottom: 1px solid #e0ddd5;
+            padding: 0.4rem 0.75rem;
+            text-align: left;
+        }
+        th {
+            border-bottom: 2px solid #111;
+            font-weight: 600;
+            font-variant: small-caps;
+            letter-spacing: 0.02em;
+        }
+        thead th { border-bottom: 2px solid #111; }
+        tbody tr:last-child td { border-bottom: 1px solid #e0ddd5; }
+
+        /* Task lists */
+        ul.contains-task-list, ol.contains-task-list { list-style: none; padding-left: 0; }
+        li.task-list-item { display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.25rem; }
+        li.task-list-item input[type="checkbox"] { margin: 0; pointer-events: none; accent-color: #a00000; }
+
+        /* Lists */
+        ul, ol { padding-left: 1.5rem; margin-bottom: 1rem; }
+        li { margin-bottom: 0.25rem; }
+
+        /* === FOOTNOTES — SIDENOTE STYLE (Tufte) === */
+        .footnote-definition {
+            float: right;
+            clear: right;
+            margin-right: -45%;
+            width: 40%;
+            margin-top: 0.2rem;
+            margin-bottom: 1rem;
+            font-size: 0.8rem;
+            line-height: 1.5;
+            color: #666;
+            position: relative;
+        }
         .footnote-definition p { display: inline; }
-        .footnote-definition + .footnote-definition { border-top: none; margin-top: 0; padding-top: 0.25rem; }
-        sup.footnote-reference a { text-decoration: none; color: #8b4513; font-weight: 600; font-size: 0.8em; }
+        .footnote-definition + .footnote-definition { margin-top: 0; }
 
-        /* Embeds */
-        .video-embed { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin: 1.5rem 0; }
+        /* Sidenote reference numbers — small superscript in red */
+        sup.footnote-reference a {
+            font-size: 0.65em;
+            vertical-align: super;
+            text-decoration: none;
+            color: #a00000;
+            font-weight: 600;
+            line-height: 0;
+        }
+        sup.footnote-reference a:hover { color: #700000; text-decoration: none; }
+
+        /* === TOC — paper outline === */
+        .toc {
+            margin: 1.5rem 0 2rem;
+            padding: 0;
+            border: none;
+            background: transparent;
+            font-size: 0.85rem;
+        }
+        .toc > ul { margin: 0; padding-left: 1.25rem; list-style: none; }
+        .toc ul ul { padding-left: 1rem; }
+        .toc li { margin: 0.15rem 0; }
+        .toc li::before { content: none; }
+        .toc a { text-decoration: none; color: #a00000; }
+        .toc a:hover { text-decoration: underline; }
+
+        /* === PAGINATION === */
+        .pagination {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-top: 2.5rem;
+            padding-top: 1rem;
+            border-top: 1px solid #e0ddd5;
+            font-size: 0.9rem;
+        }
+        .pagination a { text-decoration: none; color: #a00000; }
+        .pagination a:hover { text-decoration: underline; }
+        .pagination span { color: #999; font-size: 0.85rem; }
+
+        /* === EMBEDS === */
+        .video-embed {
+            position: relative;
+            padding-bottom: 56.25%;
+            height: 0;
+            overflow: hidden;
+            margin: 1.5rem 0;
+        }
         .video-embed iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
         .gist-embed { margin: 1.5rem 0; }
 
-        /* Callouts — muted academic tones */
-        .callout { padding: 1rem 1.25rem; margin: 1.5rem 0; border-left: 3px solid #8b4513; background: #f5f3ef; }
-        .callout-title { font-weight: 700; margin-bottom: 0.4rem; font-size: 0.85rem; font-variant: small-caps; }
-        .callout-info { border-left-color: #3a6b8c; background: #f0f5f8; }
-        .callout-warning { border-left-color: #b8860b; background: #faf6ed; }
-        .callout-danger { border-left-color: #8b2500; background: #faf0ed; }
-        .callout-tip { border-left-color: #2e6b3a; background: #f0f5f1; }
-        .callout-note { border-left-color: #8a8275; background: #f5f3ef; }
+        /* === CALLOUTS — muted academic tones === */
+        .callout {
+            padding: 0.8rem 1rem;
+            margin: 1.5rem 0;
+            border-left: 3px solid #e0ddd5;
+            background: transparent;
+            font-size: 0.95rem;
+        }
+        .callout-title {
+            font-weight: 600;
+            margin-bottom: 0.3rem;
+            font-size: 0.8rem;
+            font-variant: small-caps;
+            letter-spacing: 0.03em;
+        }
+        .callout-info { border-left-color: #4a6fa5; }
+        .callout-info .callout-title { color: #4a6fa5; }
+        .callout-warning { border-left-color: #b8860b; }
+        .callout-warning .callout-title { color: #b8860b; }
+        .callout-danger { border-left-color: #a00000; }
+        .callout-danger .callout-title { color: #a00000; }
+        .callout-tip { border-left-color: #3a6b4a; }
+        .callout-tip .callout-title { color: #3a6b4a; }
+        .callout-note { border-left-color: #999; }
+        .callout-note .callout-title { color: #666; }
         .callout p:last-child { margin-bottom: 0; }
 
-        /* Contact form */
+        /* === CONTACT FORM === */
         .contact-form { max-width: 480px; }
-        .contact-form-field { margin-bottom: 1rem; }
-        .contact-form-field label { display: block; font-weight: 400; margin-bottom: 0.25rem; font-size: 0.9rem; font-variant: small-caps; }
-        .contact-form-field input, .contact-form-field textarea { width: 100%; padding: 0.5rem 0.6rem; border: 1px solid #d5d0c8; background: #fcfcfa; font: inherit; box-sizing: border-box; }
-        .contact-form-field input:focus, .contact-form-field textarea:focus { outline: none; border-color: #8b4513; }
-        .contact-form-submit { background: #8b4513; color: #fcfcfa; border: none; padding: 0.5rem 1.5rem; font: inherit; cursor: pointer; font-variant: small-caps; letter-spacing: 0.04em; }
-        .contact-form-submit:hover { background: #6b3410; }
+        .contact-form-field { margin-bottom: 1.25rem; }
+        .contact-form-field label {
+            display: block;
+            font-weight: 400;
+            margin-bottom: 0.25rem;
+            font-size: 0.85rem;
+            font-variant: small-caps;
+            letter-spacing: 0.03em;
+            color: #666;
+        }
+        .contact-form-field input,
+        .contact-form-field textarea {
+            width: 100%;
+            padding: 0.5rem 0;
+            border: none;
+            border-bottom: 1px solid #e0ddd5;
+            background: transparent;
+            font: inherit;
+            font-size: 0.95rem;
+            color: #111;
+        }
+        .contact-form-field input:focus,
+        .contact-form-field textarea:focus {
+            outline: none;
+            border-bottom-color: #a00000;
+        }
+        .contact-form-submit {
+            background: transparent;
+            color: #a00000;
+            border: 1px solid #a00000;
+            padding: 0.45rem 1.5rem;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+            font-variant: small-caps;
+            letter-spacing: 0.05em;
+            transition: background 0.15s, color 0.15s;
+        }
+        .contact-form-submit:hover { background: #a00000; color: #fffff8; }
         .contact-form-honeypot { display: none; }
         .contact-form-embed { min-height: 400px; }
-        .contact-form-error { color: #8b2500; background: #faf0ed; padding: 1rem; border-left: 3px solid #8b2500; }
+        .contact-form-error {
+            color: #a00000;
+            background: #fdf4f4;
+            padding: 0.8rem 1rem;
+            border-left: 3px solid #a00000;
+            font-size: 0.9rem;
+        }
 
-        /* Trust center */
-        .trust-hub { max-width: 720px; margin: 0 auto; }
+        /* === TRUST CENTER === */
+        .trust-hub { max-width: 100%; }
         .trust-hero { margin-bottom: 2rem; }
-        .trust-hero h1 { font-size: 1.8rem; font-weight: 400; margin-bottom: 0.5rem; }
+        .trust-hero h1 { font-size: 2rem; font-weight: 400; margin-bottom: 0.5rem; }
         .trust-section { margin-bottom: 2.5rem; }
-        .trust-section h2 { font-size: 1.25rem; font-weight: 400; margin-bottom: 1rem; border-bottom: 1px solid #d5d0c8; padding-bottom: 0.25rem; font-variant: small-caps; }
-        .trust-breadcrumb { font-size: 0.85rem; color: #8a8275; margin-bottom: 1.5rem; }
-        .trust-breadcrumb a { color: #8b4513; text-decoration: none; }
+        .trust-section h2 {
+            font-size: 1.1rem;
+            font-weight: 400;
+            font-variant: small-caps;
+            letter-spacing: 0.01em;
+            margin-bottom: 1rem;
+            padding-bottom: 0.25rem;
+            border-bottom: 1px solid #e0ddd5;
+        }
+        .trust-breadcrumb { font-size: 0.8rem; color: #999; margin-bottom: 1.5rem; }
+        .trust-breadcrumb a { color: #a00000; text-decoration: none; }
         .trust-breadcrumb a:hover { text-decoration: underline; }
-        .trust-description { color: #555; margin-bottom: 1.5rem; line-height: 1.8; }
-        .cert-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.5rem; }
-        .cert-card { border: 1px solid #d5d0c8; padding: 1.25rem; background: #fcfcfa; transition: border-color 0.15s; }
-        .cert-card:hover { border-color: #8b4513; }
+        .trust-description { color: #666; margin-bottom: 1.5rem; line-height: 1.6; }
+        .cert-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.25rem; }
+        .cert-card {
+            border: 1px solid #e0ddd5;
+            padding: 1.25rem;
+            background: #fffff8;
+            transition: border-color 0.15s;
+        }
+        .cert-card:hover { border-color: #a00000; }
         .cert-card__header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
-        .cert-card__title { font-weight: 700; font-size: 1rem; color: #2c2c2c; }
-        .cert-card__desc { font-size: 0.9rem; color: #555; margin-bottom: 0.75rem; }
-        .cert-card__link { font-size: 0.85rem; color: #8b4513; text-decoration: none; }
+        .cert-card__title { font-weight: 600; font-size: 0.95rem; color: #111; }
+        .cert-card__desc { font-size: 0.85rem; color: #666; margin-bottom: 0.75rem; line-height: 1.5; }
+        .cert-card__link { font-size: 0.8rem; color: #a00000; text-decoration: none; }
         .cert-card__link:hover { text-decoration: underline; }
-        .cert-status { display: inline-block; font-size: 0.7rem; font-weight: 600; padding: 0.15rem 0.5rem; text-transform: uppercase; letter-spacing: 0.04em; }
+        .cert-status {
+            display: inline-block;
+            font-size: 0.65rem;
+            font-weight: 600;
+            padding: 0.1rem 0.45rem;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            font-family: ui-monospace, 'SFMono-Regular', monospace;
+        }
         .cert-status--active { background: #e8f0e4; color: #2e5a1e; }
-        .cert-status--in_progress { background: #faf6ed; color: #8b6914; }
-        .cert-status--planned { background: #f0ece6; color: #8a8275; }
-        .cert-detail { margin-bottom: 2rem; padding: 1.25rem; border: 1px solid #d5d0c8; background: #f5f3ef; }
-        .cert-meta { font-size: 0.9rem; color: #555; margin-bottom: 0.35rem; }
-        .cert-meta strong { color: #2c2c2c; }
-        .trust-item { padding: 0.75rem 0; border-bottom: 1px solid #ebe8e2; }
+        .cert-status--in_progress { background: #faf5e6; color: #8b6914; }
+        .cert-status--planned { background: #f0ede5; color: #999; }
+        .cert-detail { margin-bottom: 2rem; padding: 1.25rem; border: 1px solid #e0ddd5; background: #f7f4ee; }
+        .cert-meta { font-size: 0.85rem; color: #666; margin-bottom: 0.35rem; }
+        .cert-meta strong { color: #111; }
+        .trust-item { padding: 0.75rem 0; border-bottom: 1px solid #f0ede5; }
         .trust-item:last-child { border-bottom: none; }
         .subprocessor-table-wrap { overflow-x: auto; margin: 1.5rem 0; }
         .subprocessor-table { border-collapse: collapse; width: 100%; }
-        .subprocessor-table th, .subprocessor-table td { border: 1px solid #d5d0c8; padding: 0.5rem 0.75rem; text-align: left; font-size: 0.9rem; }
-        .subprocessor-table th { background: #f5f3ef; font-weight: 600; font-variant: small-caps; }
+        .subprocessor-table th,
+        .subprocessor-table td {
+            border-bottom: 1px solid #e0ddd5;
+            padding: 0.4rem 0.75rem;
+            text-align: left;
+            font-size: 0.85rem;
+        }
+        .subprocessor-table th {
+            border-bottom: 2px solid #111;
+            font-weight: 600;
+            font-variant: small-caps;
+        }
         .faq-section { margin-top: 2rem; }
-        .faq-item { border-bottom: 1px solid #ebe8e2; }
-        .faq-item summary { padding: 0.75rem 0; cursor: pointer; font-weight: 400; color: #2c2c2c; font-variant: small-caps; }
-        .faq-item summary:hover { color: #8b4513; }
-        .faq-answer { padding: 0 0 1rem; color: #555; line-height: 1.8; }
+        .faq-item { border-bottom: 1px solid #f0ede5; }
+        .faq-item summary {
+            padding: 0.75rem 0;
+            cursor: pointer;
+            font-weight: 400;
+            color: #111;
+            font-size: 0.95rem;
+        }
+        .faq-item summary:hover { color: #a00000; }
+        .faq-item summary::marker { color: #999; }
+        .faq-answer { padding: 0 0 1rem; color: #666; line-height: 1.6; font-size: 0.9rem; }
         .trust-page { margin-bottom: 2rem; }
 
-        /* Changelog */
+        /* === CHANGELOG === */
         .changelog-entry-header { margin-bottom: 1.5rem; }
-        .changelog-meta { display: flex; align-items: center; gap: 1rem; margin-top: 0.5rem; color: #8a8275; font-size: 0.85rem; }
-        .changelog-summary { color: #555; font-size: 1rem; margin-bottom: 1.5rem; font-style: italic; }
-        .changelog-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
-        .changelog-tag { display: inline-block; padding: 0.1rem 0.5rem; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+        .changelog-meta {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            margin-top: 0.5rem;
+            color: #999;
+            font-size: 0.8rem;
+        }
+        .changelog-summary { color: #666; font-size: 0.95rem; margin-bottom: 1.5rem; font-style: italic; }
+        .changelog-tags { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+        .changelog-tag {
+            display: inline-block;
+            padding: 0.1rem 0.45rem;
+            font-size: 0.65rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            font-family: ui-monospace, 'SFMono-Regular', monospace;
+        }
         .changelog-tag--new { background: #e8f0e4; color: #2e5a1e; }
         .changelog-tag--fix { background: #e4ecf5; color: #1e3a6b; }
-        .changelog-tag--breaking { background: #f5e4e4; color: #8b2500; }
+        .changelog-tag--breaking { background: #f5e4e4; color: #a00000; }
         .changelog-tag--improvement { background: #f0e8f5; color: #5a2e6b; }
-        .changelog-tag--deprecated { background: #f0ece6; color: #6b6560; }
-        .changelog-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 1rem; margin-bottom: 2rem; }
+        .changelog-tag--deprecated { background: #f0ede5; color: #666; }
+        .changelog-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            flex-wrap: wrap;
+            gap: 1rem;
+            margin-bottom: 2rem;
+        }
         .changelog-header h1 { margin-bottom: 0; }
-        .changelog-rss { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.8rem; color: #8a8275; text-decoration: none; padding: 0.25rem 0.6rem; border: 1px solid #d5d0c8; }
-        .changelog-rss:hover { color: #8b4513; border-color: #8b4513; }
+        .changelog-rss {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            font-size: 0.75rem;
+            color: #999;
+            text-decoration: none;
+            padding: 0.2rem 0.5rem;
+            border: 1px solid #e0ddd5;
+        }
+        .changelog-rss:hover { color: #a00000; border-color: #a00000; }
         .changelog-back { margin-bottom: 1.5rem; }
-        .changelog-back a { color: #8a8275; text-decoration: none; font-size: 0.9rem; }
-        .changelog-back a:hover { color: #8b4513; }
+        .changelog-back a { color: #999; text-decoration: none; font-size: 0.85rem; }
+        .changelog-back a:hover { color: #a00000; }
         .changelog-timeline { position: relative; padding-left: 2rem; }
-        .changelog-timeline::before { content: ''; position: absolute; left: 0; top: 0.5rem; bottom: 0; width: 1px; background: #d5d0c8; }
-        .changelog-item { position: relative; padding-bottom: 1.5rem; border-bottom: 1px solid #ebe8e2; margin-bottom: 0; }
-        .changelog-item::before { content: ''; position: absolute; left: -2rem; top: 0.5rem; width: 8px; height: 8px; border-radius: 50%; background: #8b4513; transform: translateX(-3.5px); }
+        .changelog-timeline::before {
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 0.5rem;
+            bottom: 0;
+            width: 1px;
+            background: #e0ddd5;
+        }
+        .changelog-item {
+            position: relative;
+            padding-bottom: 1.5rem;
+            border-bottom: 1px solid #f0ede5;
+            margin-bottom: 0;
+        }
+        .changelog-item::before {
+            content: '';
+            position: absolute;
+            left: -2rem;
+            top: 0.5rem;
+            width: 7px;
+            height: 7px;
+            border-radius: 50%;
+            background: #a00000;
+            transform: translateX(-3px);
+        }
         .changelog-item:last-child { border-bottom: none; }
-        .changelog-item-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 0.5rem; }
-        .changelog-item-header h2 { margin: 0; font-size: 1.15rem; font-weight: 400; }
-        .changelog-item-header time { color: #8a8275; font-size: 0.8rem; white-space: nowrap; }
+        .changelog-item-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+        .changelog-item-header h2 { margin: 0; font-size: 1.05rem; font-weight: 400; font-variant: normal; }
+        .changelog-item-header time { color: #999; font-size: 0.75rem; white-space: nowrap; }
         .changelog-item .changelog-tags { margin-top: 0.5rem; }
-        .changelog-item p, .changelog-item .excerpt { margin-top: 0.5rem; color: #555; }
+        .changelog-item p, .changelog-item .excerpt { margin-top: 0.5rem; color: #666; font-size: 0.9rem; }
         .changelog-feed .changelog-item::before { display: none; }
         .changelog-feed { display: flex; flex-direction: column; gap: 0; }
 
-        /* Roadmap */
+        /* === ROADMAP === */
         .roadmap-back { margin-bottom: 1.5rem; }
-        .roadmap-back a { color: #8a8275; text-decoration: none; font-size: 0.9rem; }
-        .roadmap-back a:hover { color: #8b4513; }
+        .roadmap-back a { color: #999; text-decoration: none; font-size: 0.85rem; }
+        .roadmap-back a:hover { color: #a00000; }
         .roadmap-entry-header { margin-bottom: 1.5rem; }
-        .roadmap-summary { color: #555; font-size: 1rem; margin-bottom: 1.5rem; }
-        .roadmap-status-badges { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
-        .roadmap-status { display: inline-block; padding: 0.15rem 0.6rem; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+        .roadmap-summary { color: #666; font-size: 0.95rem; margin-bottom: 1.5rem; }
+        .roadmap-status-badges { display: flex; flex-wrap: wrap; gap: 0.35rem; margin-top: 0.5rem; }
+        .roadmap-status {
+            display: inline-block;
+            padding: 0.1rem 0.5rem;
+            font-size: 0.65rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            font-family: ui-monospace, 'SFMono-Regular', monospace;
+        }
         .roadmap-status--planned { background: #e4ecf5; color: #1e3a6b; }
-        .roadmap-status--in-progress { background: #faf6ed; color: #8b6914; }
+        .roadmap-status--in-progress { background: #faf5e6; color: #8b6914; }
         .roadmap-status--done { background: #e8f0e4; color: #2e5a1e; }
-        .roadmap-status--cancelled { background: #f0ece6; color: #6b6560; text-decoration: line-through; }
+        .roadmap-status--cancelled { background: #f0ede5; color: #666; text-decoration: line-through; }
         .roadmap-grouped { display: flex; flex-direction: column; gap: 2rem; }
-        .roadmap-section-header { display: flex; align-items: center; gap: 0.75rem; font-size: 1.05rem; margin-bottom: 1rem; font-variant: small-caps; }
-        .roadmap-items { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; }
-        .roadmap-card { padding: 1rem 1.25rem; border: 1px solid #d5d0c8; background: #fcfcfa; transition: border-color 0.15s; }
-        .roadmap-card:hover { border-color: #8b4513; }
-        .roadmap-card h3 { margin: 0 0 0.25rem; font-size: 1rem; font-weight: 400; }
-        .roadmap-card p, .roadmap-card .excerpt { margin: 0; color: #555; font-size: 0.9rem; }
-        .roadmap-kanban { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; }
-        .roadmap-column-header { font-size: 1rem; margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem; font-variant: small-caps; }
-        .roadmap-count { font-size: 0.8rem; color: #8a8275; font-weight: 400; }
+        .roadmap-section-header {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            font-size: 1rem;
+            margin-bottom: 1rem;
+            font-variant: small-caps;
+            letter-spacing: 0.01em;
+        }
+        .roadmap-items { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1rem; }
+        .roadmap-card {
+            padding: 1rem 1.25rem;
+            border: 1px solid #e0ddd5;
+            background: #fffff8;
+            transition: border-color 0.15s;
+        }
+        .roadmap-card:hover { border-color: #a00000; }
+        .roadmap-card h3 { margin: 0 0 0.25rem; font-size: 0.95rem; font-weight: 400; }
+        .roadmap-card p, .roadmap-card .excerpt { margin: 0; color: #666; font-size: 0.85rem; }
+        .roadmap-kanban { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.25rem; }
+        .roadmap-column-header {
+            font-size: 0.95rem;
+            margin-bottom: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-variant: small-caps;
+        }
+        .roadmap-count { font-size: 0.75rem; color: #999; font-weight: 400; }
         .roadmap-timeline { position: relative; padding-left: 2rem; }
-        .roadmap-timeline::before { content: ''; position: absolute; left: 0.5rem; top: 0; bottom: 0; width: 1px; background: #d5d0c8; }
+        .roadmap-timeline::before {
+            content: '';
+            position: absolute;
+            left: 0.5rem;
+            top: 0;
+            bottom: 0;
+            width: 1px;
+            background: #e0ddd5;
+        }
         .roadmap-milestone { position: relative; margin-bottom: 2rem; }
-        .roadmap-milestone-dot { position: absolute; left: -1.75rem; top: 0.3rem; width: 10px; height: 10px; border-radius: 50%; border: 2px solid #8b4513; background: #fcfcfa; }
+        .roadmap-milestone-dot {
+            position: absolute;
+            left: -1.75rem;
+            top: 0.3rem;
+            width: 9px;
+            height: 9px;
+            border-radius: 50%;
+            border: 2px solid #a00000;
+            background: #fffff8;
+        }
         .roadmap-milestone-dot .roadmap-status { display: none; }
         .roadmap-milestone-content h3 { margin: 0 0 0.25rem; font-weight: 400; }
-        .roadmap-milestone-content p { margin: 0.25rem 0 0; color: #555; font-size: 0.9rem; }
+        .roadmap-milestone-content p { margin: 0.25rem 0 0; color: #666; font-size: 0.85rem; }
         @media (max-width: 768px) { .roadmap-kanban { grid-template-columns: 1fr; } }
 
-        /* Tables */
-        table { border-collapse: collapse; width: 100%; margin: 1.5rem 0; }
-        th, td { border: 1px solid #d5d0c8; padding: 0.5rem 0.75rem; text-align: left; font-size: 0.9rem; }
-        th { background: #f5f3ef; font-weight: 600; font-variant: small-caps; }
-        ul.contains-task-list, ol.contains-task-list { list-style: none; padding-left: 0; }
-        li.task-list-item { display: flex; align-items: baseline; gap: 0.5rem; }
-        li.task-list-item input[type="checkbox"] { margin: 0; pointer-events: none; }
+        /* === FOOTER === */
+        footer {
+            margin-top: 4rem;
+            padding-top: 1rem;
+            border-top: 1px solid #e0ddd5;
+            color: #999;
+            font-size: 0.8rem;
+            max-width: 60%;
+        }
+        footer nav { margin-bottom: 0.4rem; }
+        footer nav a { color: #666; text-decoration: none; font-variant: small-caps; letter-spacing: 0.03em; }
+        footer nav a:hover { color: #a00000; }
 
-        /* TOC — paper outline style */
-        .toc { margin: 1.5rem 0; padding: 1rem 1.25rem; border: 1px solid #d5d0c8; background: #f5f3ef; }
-        .toc > ul { margin: 0; padding-left: 1.25rem; }
-        .toc ul ul { padding-left: 1rem; }
-        .toc li { margin: 0.2rem 0; }
-        .toc a { text-decoration: none; color: #8b4513; }
-        .toc a:hover { text-decoration: underline; }
-
-        /* Pagination */
-        .pagination { display: flex; justify-content: space-between; align-items: center; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #d5d0c8; }
-        .pagination a { text-decoration: none; }
-        .pagination a:hover { text-decoration: underline; }
-        .pagination span { color: #8a8275; font-size: 0.9rem; }
-
-        /* Footer */
-        footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d5d0c8; color: #8a8275; font-size: 0.85rem; }
-        footer nav { margin-bottom: 0.5rem; }
-        footer nav a { color: #555; text-decoration: none; }
-        footer nav a:hover { color: #8b4513; }
-
-        /* Accessibility */
-        .skip-link { position: absolute; top: -100%; left: 0; padding: 0.5rem 1rem; background: #8b4513; color: #fcfcfa; z-index: 100; text-decoration: none; }
+        /* === ACCESSIBILITY === */
+        .skip-link {
+            position: absolute;
+            top: -100%;
+            left: 0;
+            padding: 0.5rem 1rem;
+            background: #a00000;
+            color: #fffff8;
+            z-index: 100;
+            text-decoration: none;
+            font-size: 0.85rem;
+        }
         .skip-link:focus { top: 0; }
-        :focus-visible { outline: 2px solid #8b4513; outline-offset: 2px; }
-        @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } }
+        :focus-visible { outline: 2px solid #a00000; outline-offset: 2px; }
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                animation-duration: 0.01ms !important;
+                transition-duration: 0.01ms !important;
+                scroll-behavior: auto !important;
+            }
+        }
+
+        /* === RESPONSIVE — collapse to single column === */
+        @media (max-width: 1000px) {
+            body { width: 92%; padding: 1.5rem 0 3rem; }
+            header { max-width: 100%; }
+            main { width: 100%; }
+            footer { max-width: 100%; }
+
+            /* Footnotes go inline when no margin space */
+            .footnote-definition {
+                float: none;
+                margin-right: 0;
+                width: 100%;
+                font-size: 0.8rem;
+                border-top: 1px solid #e0ddd5;
+                margin-top: 2rem;
+                padding-top: 0.75rem;
+            }
+            .footnote-definition + .footnote-definition {
+                border-top: none;
+                margin-top: 0;
+                padding-top: 0.3rem;
+            }
+        }
+
+        @media (max-width: 600px) {
+            body { font-size: 1rem; }
+            main > article h1,
+            main > .article-header h1 { font-size: 1.5rem; }
+            header h1 { font-size: 1.3rem; }
+            pre { font-size: 0.75rem; padding: 0.75rem; }
+            .cert-grid { grid-template-columns: 1fr; }
+            .roadmap-items { grid-template-columns: 1fr; }
+        }
     </style>
     {% block extra_css %}{% endblock %}
     {% block head %}{% endblock %}

--- a/src/themes/academic.tera
+++ b/src/themes/academic.tera
@@ -38,6 +38,9 @@
     {% if page.collection %}{% set _bc_col_url = site.base_url ~ lang_prefix ~ "/" ~ page.collection %}<script type="application/ld+json">
     {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
     </script>{% endif %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">
     <style>
         /* === RESET & BASE === */
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -48,7 +51,7 @@
             margin-left: auto;
             margin-right: auto;
             padding: 2.5rem 0 4rem;
-            font-family: 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
+            font-family: 'EB Garamond', Palatino, Georgia, serif;
             font-size: 1.1rem;
             line-height: 1.6;
             color: #111;
@@ -156,17 +159,111 @@
             position: relative;
         }
 
+        /* === HOMEPAGE CONTENT — scholarly intro === */
+        .homepage-content {
+            margin-bottom: 2.5rem;
+            padding-bottom: 2rem;
+            border-bottom: 1px solid #e0ddd5;
+        }
+        .homepage-content > h1:first-child {
+            font-size: 2rem;
+            font-weight: 400;
+            line-height: 1.25;
+            margin-bottom: 0.75rem;
+        }
+        .homepage-content > p {
+            margin-bottom: 1rem;
+            line-height: 1.7;
+        }
+        .homepage-content > p strong { color: #111; font-weight: 600; }
+        .homepage-content > p a { color: #a00000; }
+        .homepage-content > h2 {
+            font-variant: small-caps;
+            letter-spacing: 0.01em;
+            font-size: 1.1rem;
+            font-weight: 400;
+            margin-top: 2rem;
+            margin-bottom: 0.6rem;
+        }
+        .homepage-content > h3 {
+            font-size: 1rem;
+            font-weight: 700;
+            margin-top: 1.5rem;
+            margin-bottom: 0.4rem;
+        }
+        .homepage-content > ul {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 1.25rem;
+            list-style: none;
+            padding: 0;
+            margin: 1.5rem 0;
+        }
+        .homepage-content > ul > li {
+            padding: 1rem 1.25rem;
+            border: 1px solid #e0ddd5;
+            background: #f7f4ee;
+        }
+        .homepage-content > ul > li strong {
+            display: block;
+            font-size: 1.5rem;
+            color: #a00000;
+            line-height: 1;
+            margin-bottom: 0.2rem;
+        }
+        .homepage-content blockquote {
+            margin: 1.5rem 0 1.5rem 2rem;
+            padding: 0;
+            border: none;
+            font-style: italic;
+            color: #333;
+        }
+        .homepage-content > hr {
+            border: none;
+            margin: 2rem auto;
+            width: 40%;
+        }
+        .homepage-content > hr::before {
+            content: '\00a7';
+            display: block;
+            text-align: center;
+            font-size: 1.2rem;
+            color: #999;
+        }
+        .homepage-content pre {
+            background: #f7f4ee;
+            color: #111;
+            padding: 1rem 1.25rem;
+            overflow-x: auto;
+            font-size: 0.8rem;
+            line-height: 1.55;
+            font-family: ui-monospace, 'SFMono-Regular', 'SF Mono', Menlo, Consolas, monospace;
+            border: 1px solid #e0ddd5;
+            margin: 1.5rem 0;
+        }
+        .homepage-content pre code { background: none; color: inherit; padding: 0; border: none; font-size: inherit; }
+
         /* === ARTICLE LISTING (index pages) === */
-        .article-list article { margin-bottom: 1.75rem; }
-        .article-list article h3 {
+        main > section { margin-bottom: 2rem; }
+        main > section > h2 {
+            font-variant: small-caps;
+            letter-spacing: 0.01em;
+            font-size: 1.1rem;
+            font-weight: 400;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.25rem;
+            border-bottom: 1px solid #e0ddd5;
+        }
+        section > article { margin-bottom: 1.75rem; }
+        section > article h3 {
             margin: 0 0 0.1rem;
             font-size: 1.05rem;
             font-weight: 400;
         }
-        .article-list article h3 a { color: #111; text-decoration: none; }
-        .article-list article h3 a:hover { color: #a00000; }
-        .article-list article p { color: #666; font-size: 0.9rem; margin: 0.2rem 0 0; line-height: 1.5; }
-        .article-list article time { font-size: 0.75rem; color: #999; font-style: italic; }
+        section > article h3 a { color: #111; text-decoration: none; }
+        section > article h3 a:hover { color: #a00000; }
+        section > article p { color: #666; font-size: 0.9rem; margin: 0.2rem 0 0; line-height: 1.5; }
+        section > article time { font-size: 0.75rem; color: #999; font-style: italic; }
 
         /* === SINGLE ARTICLE — scholarly typesetting === */
 
@@ -782,6 +879,7 @@
             header { max-width: 100%; }
             main { width: 100%; }
             footer { max-width: 100%; }
+            .homepage-content > ul { grid-template-columns: 1fr; }
 
             /* Footnotes go inline when no margin space */
             .footnote-definition {
@@ -808,6 +906,7 @@
             pre { font-size: 0.75rem; padding: 0.75rem; }
             .cert-grid { grid-template-columns: 1fr; }
             .roadmap-items { grid-template-columns: 1fr; }
+            .homepage-content > h1:first-child { font-size: 1.5rem; }
         }
     </style>
     {% block extra_css %}{% endblock %}
@@ -854,19 +953,38 @@
         var basePath = {{ site.base_path | json_encode() }};
         var indexUrl = basePath + {% if lang != default_language %}('/' + {{ lang | json_encode() }} + '/search-index.json'){% else %}'/search-index.json'{% endif %};
         function load(cb) { if (index) { cb(); return; } fetch(indexUrl).then(function(r){return r.json();}).then(function(d){index=d;cb();}).catch(function(){index=[];}); }
-        function search(q) {
+        function doSearch(q) {
             q = q.toLowerCase().trim();
-            if (!q) { results.innerHTML = ''; return; }
+            if (!q) { results.textContent = ''; return; }
             var hits = index.filter(function(e){
                 return (e.title||'').toLowerCase().includes(q) || (e.description||'').toLowerCase().includes(q) || (e.tags||[]).some(function(t){return t.toLowerCase().includes(q);});
             }).slice(0, 8);
-            if (!hits.length) { results.innerHTML = '<div class="no-results">{{ t.no_results }}</div>'; return; }
-            results.innerHTML = hits.map(function(e){
-                var meta = [e.collection, e.date].filter(Boolean).join(' · ');
-                return '<a href="' + basePath + e.url + '"><strong>' + e.title + '</strong>' + (meta ? '<div class="result-meta">' + meta + '</div>' : '') + '</a>';
-            }).join('');
+            if (!hits.length) {
+                var noRes = document.createElement('div');
+                noRes.className = 'no-results';
+                noRes.textContent = '{{ t.no_results }}';
+                results.textContent = '';
+                results.appendChild(noRes);
+                return;
+            }
+            results.textContent = '';
+            hits.forEach(function(e){
+                var a = document.createElement('a');
+                a.href = basePath + e.url;
+                var strong = document.createElement('strong');
+                strong.textContent = e.title;
+                a.appendChild(strong);
+                var meta = [e.collection, e.date].filter(Boolean).join(' \u00b7 ');
+                if (meta) {
+                    var div = document.createElement('div');
+                    div.className = 'result-meta';
+                    div.textContent = meta;
+                    a.appendChild(div);
+                }
+                results.appendChild(a);
+            });
         }
-        input.addEventListener('input', function(){ load(function(){ search(input.value); }); });
+        input.addEventListener('input', function(){ load(function(){ doSearch(input.value); }); });
     })();
     </script>
     {% block footer %}{% endblock %}

--- a/src/themes/bento.tera
+++ b/src/themes/bento.tera
@@ -38,9 +38,12 @@
     {% if page.collection %}{% set _bc_col_url = site.base_url ~ lang_prefix ~ "/" ~ page.collection %}<script type="application/ld+json">
     {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
     </script>{% endif %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
         *, *::before, *::after { box-sizing: border-box; }
-        body { max-width: 1000px; margin: 0 auto; padding: 2rem 1.25rem; font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; color: #1a1a1a; background: #f4f0eb; }
+        body { max-width: 1000px; margin: 0 auto; padding: 2rem 1.25rem; font-family: 'Manrope', system-ui, -apple-system, sans-serif; line-height: 1.6; color: #1a1a1a; background: #f4f0eb; }
         a { color: #5046e5; text-decoration: none; }
         a:hover { text-decoration: underline; }
         header { margin-bottom: 2.5rem; }
@@ -68,6 +71,15 @@
         #search-results strong { color: #1a1a1a; }
         #search-results .result-meta { font-size: 0.75rem; color: #9ca3af; margin-top: 0.1rem; }
         #search-results .no-results { padding: 0.6rem 1rem; color: #9ca3af; font-size: 0.9rem; }
+        .homepage-content { margin-bottom: 2.5rem; padding-bottom: 2rem; }
+        .homepage-content > h1:first-child { font-size: 2.4rem; font-weight: 700; letter-spacing: -0.03em; margin-bottom: 0.5rem; line-height: 1.15; }
+        .homepage-content > p { font-size: 1.05rem; line-height: 1.7; color: #555; margin-bottom: 0.75rem; }
+        .homepage-content > h2 { font-size: 1.3rem; font-weight: 600; margin-top: 1.75rem; margin-bottom: 0.5rem; }
+        .homepage-content > h3 { font-size: 1.1rem; font-weight: 600; margin-top: 1.25rem; margin-bottom: 0.4rem; }
+        .homepage-content > ul { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; list-style: none; padding: 0; margin: 1.5rem 0; }
+        .homepage-content > ul > li { padding: 1.25rem; background: #f8f9fa; border-radius: 16px; text-align: center; }
+        .homepage-content > ul > li strong { display: block; font-size: 1.8rem; font-weight: 700; margin-bottom: 0.15rem; }
+        .homepage-content blockquote { border-left: none; background: #f8f9fa; border-radius: 16px; padding: 1.25rem 1.5rem; margin: 1.5rem 0; color: #555; font-style: italic; }
 
         /* Bento grid: sections become grids, articles become cards */
         main section { margin-bottom: 2.5rem; }
@@ -302,19 +314,38 @@
         var basePath = {{ site.base_path | json_encode() }};
         var indexUrl = basePath + {% if lang != default_language %}('/' + {{ lang | json_encode() }} + '/search-index.json'){% else %}'/search-index.json'{% endif %};
         function load(cb) { if (index) { cb(); return; } fetch(indexUrl).then(function(r){return r.json();}).then(function(d){index=d;cb();}).catch(function(){index=[];}); }
-        function search(q) {
+        function doSearch(q) {
             q = q.toLowerCase().trim();
-            if (!q) { results.innerHTML = ''; return; }
+            if (!q) { results.textContent = ''; return; }
             var hits = index.filter(function(e){
                 return (e.title||'').toLowerCase().includes(q) || (e.description||'').toLowerCase().includes(q) || (e.tags||[]).some(function(t){return t.toLowerCase().includes(q);});
             }).slice(0, 8);
-            if (!hits.length) { results.innerHTML = '<div class="no-results">{{ t.no_results }}</div>'; return; }
-            results.innerHTML = hits.map(function(e){
-                var meta = [e.collection, e.date].filter(Boolean).join(' · ');
-                return '<a href="' + basePath + e.url + '"><strong>' + e.title + '</strong>' + (meta ? '<div class="result-meta">' + meta + '</div>' : '') + '</a>';
-            }).join('');
+            if (!hits.length) {
+                var noRes = document.createElement('div');
+                noRes.className = 'no-results';
+                noRes.textContent = '{{ t.no_results }}';
+                results.textContent = '';
+                results.appendChild(noRes);
+                return;
+            }
+            results.textContent = '';
+            hits.forEach(function(e){
+                var a = document.createElement('a');
+                a.href = basePath + e.url;
+                var strong = document.createElement('strong');
+                strong.textContent = e.title;
+                a.appendChild(strong);
+                var meta = [e.collection, e.date].filter(Boolean).join(' \u00b7 ');
+                if (meta) {
+                    var div = document.createElement('div');
+                    div.className = 'result-meta';
+                    div.textContent = meta;
+                    a.appendChild(div);
+                }
+                results.appendChild(a);
+            });
         }
-        input.addEventListener('input', function(){ load(function(){ search(input.value); }); });
+        input.addEventListener('input', function(){ load(function(){ doSearch(input.value); }); });
     })();
     </script>
     {% block footer %}{% endblock %}

--- a/src/themes/brutalist.tera
+++ b/src/themes/brutalist.tera
@@ -38,9 +38,12 @@
     {% if page.collection %}{% set _bc_col_url = site.base_url ~ lang_prefix ~ "/" ~ page.collection %}<script type="application/ld+json">
     {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
     </script>{% endif %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;700;900&family=DM+Mono:wght@400&display=swap" rel="stylesheet">
     <style>
         *, *::before, *::after { box-sizing: border-box; }
-        body { max-width: 780px; margin: 0 auto; padding: 2rem 1rem; font-family: system-ui, -apple-system, sans-serif; line-height: 1.5; color: #000000; background: #fffef0; }
+        body { max-width: 780px; margin: 0 auto; padding: 2rem 1rem; font-family: 'Archivo', system-ui, -apple-system, sans-serif; line-height: 1.5; color: #000000; background: #fffef0; }
         a { color: #000000; text-decoration: underline; text-underline-offset: 3px; }
         a:hover { background: #ffe600; text-decoration: none; }
         header { border: 3px solid #000; padding: 1.5rem; margin-bottom: 2rem; box-shadow: 6px 6px 0 #000; }
@@ -70,6 +73,15 @@
         #search-results strong { color: #000; }
         #search-results .result-meta { font-size: 0.75rem; color: #555; font-weight: 400; margin-top: 0.1rem; }
         #search-results .no-results { padding: 0.5rem 0.75rem; font-size: 0.9rem; font-weight: 700; }
+        .homepage-content { margin-bottom: 2.5rem; padding-bottom: 2rem; border-bottom: 3px solid #111; }
+        .homepage-content > h1:first-child { font-size: 2.5rem; font-weight: 900; text-transform: uppercase; letter-spacing: -0.02em; margin-bottom: 0.5rem; line-height: 1.1; }
+        .homepage-content > p { font-size: 1.05rem; line-height: 1.7; margin-bottom: 0.75rem; }
+        .homepage-content > h2 { font-size: 1.3rem; font-weight: 700; text-transform: uppercase; margin-top: 1.75rem; margin-bottom: 0.5rem; }
+        .homepage-content > h3 { font-size: 1.1rem; font-weight: 700; margin-top: 1.25rem; margin-bottom: 0.4rem; }
+        .homepage-content > ul { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; list-style: none; padding: 0; margin: 1.5rem 0; }
+        .homepage-content > ul > li { padding: 1rem; border: 3px solid #111; box-shadow: 6px 6px 0 #111; }
+        .homepage-content > ul > li strong { display: block; font-size: 1.8rem; font-weight: 900; color: #111; margin-bottom: 0.1rem; }
+        .homepage-content blockquote { border-left: 6px solid #ffe600; padding-left: 1rem; margin: 1.5rem 0; font-weight: 500; }
         main section { border: 3px solid #000; padding: 1.5rem; margin-bottom: 2rem; box-shadow: 5px 5px 0 #000; }
         main section h2 { margin: 0 0 1rem; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.12em; font-weight: 900; background: #000; color: #ffe600; display: inline-block; padding: 0.2rem 0.6rem; }
         article { border-top: 2px solid #000; padding: 1rem 0; }
@@ -278,19 +290,38 @@
         var basePath = {{ site.base_path | json_encode() }};
         var indexUrl = basePath + {% if lang != default_language %}('/' + {{ lang | json_encode() }} + '/search-index.json'){% else %}'/search-index.json'{% endif %};
         function load(cb) { if (index) { cb(); return; } fetch(indexUrl).then(function(r){return r.json();}).then(function(d){index=d;cb();}).catch(function(){index=[];}); }
-        function search(q) {
+        function doSearch(q) {
             q = q.toLowerCase().trim();
-            if (!q) { results.innerHTML = ''; return; }
+            if (!q) { results.textContent = ''; return; }
             var hits = index.filter(function(e){
                 return (e.title||'').toLowerCase().includes(q) || (e.description||'').toLowerCase().includes(q) || (e.tags||[]).some(function(t){return t.toLowerCase().includes(q);});
             }).slice(0, 8);
-            if (!hits.length) { results.innerHTML = '<div class="no-results">{{ t.no_results }}</div>'; return; }
-            results.innerHTML = hits.map(function(e){
-                var meta = [e.collection, e.date].filter(Boolean).join(' · ');
-                return '<a href="' + basePath + e.url + '"><strong>' + e.title + '</strong>' + (meta ? '<div class="result-meta">' + meta + '</div>' : '') + '</a>';
-            }).join('');
+            if (!hits.length) {
+                var noRes = document.createElement('div');
+                noRes.className = 'no-results';
+                noRes.textContent = '{{ t.no_results }}';
+                results.textContent = '';
+                results.appendChild(noRes);
+                return;
+            }
+            results.textContent = '';
+            hits.forEach(function(e){
+                var a = document.createElement('a');
+                a.href = basePath + e.url;
+                var strong = document.createElement('strong');
+                strong.textContent = e.title;
+                a.appendChild(strong);
+                var meta = [e.collection, e.date].filter(Boolean).join(' \u00b7 ');
+                if (meta) {
+                    var div = document.createElement('div');
+                    div.className = 'result-meta';
+                    div.textContent = meta;
+                    a.appendChild(div);
+                }
+                results.appendChild(a);
+            });
         }
-        input.addEventListener('input', function(){ load(function(){ search(input.value); }); });
+        input.addEventListener('input', function(){ load(function(){ doSearch(input.value); }); });
     })();
     </script>
     {% block footer %}{% endblock %}

--- a/src/themes/dark.tera
+++ b/src/themes/dark.tera
@@ -38,9 +38,12 @@
     {% if page.collection %}{% set _bc_col_url = site.base_url ~ lang_prefix ~ "/" ~ page.collection %}<script type="application/ld+json">
     {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
     </script>{% endif %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
         *, *::before, *::after { box-sizing: border-box; }
-        body { max-width: 720px; margin: 2rem auto; padding: 0 1rem; font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; color: #e8e8e8; background: #0a0a0a; }
+        body { max-width: 720px; margin: 2rem auto; padding: 0 1rem; font-family: 'Sora', system-ui, -apple-system, sans-serif; line-height: 1.6; color: #e8e8e8; background: #0a0a0a; }
         a { color: #8b5cf6; text-decoration: none; }
         a:hover { color: #a78bfa; text-decoration: underline; }
         header { margin-bottom: 2rem; border-bottom: 1px solid #1e1e1e; padding-bottom: 1.5rem; }
@@ -67,6 +70,15 @@
         #search-results strong { color: #e8e8e8; }
         #search-results .result-meta { font-size: 0.78rem; color: #555; margin-top: 0.1rem; }
         #search-results .no-results { padding: 0.5rem 0.75rem; color: #555; font-size: 0.9rem; }
+        .homepage-content { margin-bottom: 2.5rem; padding-bottom: 2rem; border-bottom: 1px solid #1e1e1e; }
+        .homepage-content > h1:first-child { font-size: 2.2rem; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 0.5rem; line-height: 1.2; color: #e8e8e8; }
+        .homepage-content > p { font-size: 1.05rem; line-height: 1.7; color: #9ca3af; margin-bottom: 0.75rem; }
+        .homepage-content > h2 { font-size: 1.3rem; font-weight: 600; margin-top: 1.75rem; margin-bottom: 0.5rem; color: #e8e8e8; }
+        .homepage-content > h3 { font-size: 1.1rem; font-weight: 600; margin-top: 1.25rem; margin-bottom: 0.4rem; color: #e8e8e8; }
+        .homepage-content > ul { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; list-style: none; padding: 0; margin: 1.5rem 0; }
+        .homepage-content > ul > li { padding: 1rem; background: #111111; border: 1px solid #1e1e1e; border-radius: 8px; }
+        .homepage-content > ul > li strong { display: block; font-size: 1.5rem; color: #8b5cf6; margin-bottom: 0.15rem; }
+        .homepage-content blockquote { border-left: 3px solid #8b5cf6; padding-left: 1rem; margin: 1.5rem 0; color: #9ca3af; font-style: italic; }
         article { margin-bottom: 2rem; }
         article h1 { font-size: 2rem; }
         article h2 { font-size: 1.4rem; margin-top: 2rem; }
@@ -268,19 +280,38 @@
         var basePath = {{ site.base_path | json_encode() }};
         var indexUrl = basePath + {% if lang != default_language %}('/' + {{ lang | json_encode() }} + '/search-index.json'){% else %}'/search-index.json'{% endif %};
         function load(cb) { if (index) { cb(); return; } fetch(indexUrl).then(function(r){return r.json();}).then(function(d){index=d;cb();}).catch(function(){index=[];}); }
-        function search(q) {
+        function doSearch(q) {
             q = q.toLowerCase().trim();
-            if (!q) { results.innerHTML = ''; return; }
+            if (!q) { results.textContent = ''; return; }
             var hits = index.filter(function(e){
                 return (e.title||'').toLowerCase().includes(q) || (e.description||'').toLowerCase().includes(q) || (e.tags||[]).some(function(t){return t.toLowerCase().includes(q);});
             }).slice(0, 8);
-            if (!hits.length) { results.innerHTML = '<div class="no-results">{{ t.no_results }}</div>'; return; }
-            results.innerHTML = hits.map(function(e){
-                var meta = [e.collection, e.date].filter(Boolean).join(' · ');
-                return '<a href="' + basePath + e.url + '"><strong>' + e.title + '</strong>' + (meta ? '<div class="result-meta">' + meta + '</div>' : '') + '</a>';
-            }).join('');
+            if (!hits.length) {
+                var noRes = document.createElement('div');
+                noRes.className = 'no-results';
+                noRes.textContent = '{{ t.no_results }}';
+                results.textContent = '';
+                results.appendChild(noRes);
+                return;
+            }
+            results.textContent = '';
+            hits.forEach(function(e){
+                var a = document.createElement('a');
+                a.href = basePath + e.url;
+                var strong = document.createElement('strong');
+                strong.textContent = e.title;
+                a.appendChild(strong);
+                var meta = [e.collection, e.date].filter(Boolean).join(' \u00b7 ');
+                if (meta) {
+                    var div = document.createElement('div');
+                    div.className = 'result-meta';
+                    div.textContent = meta;
+                    a.appendChild(div);
+                }
+                results.appendChild(a);
+            });
         }
-        input.addEventListener('input', function(){ load(function(){ search(input.value); }); });
+        input.addEventListener('input', function(){ load(function(){ doSearch(input.value); }); });
     })();
     </script>
     {% block footer %}{% endblock %}

--- a/src/themes/default.tera
+++ b/src/themes/default.tera
@@ -38,9 +38,12 @@
     {% if page.collection %}{% set _bc_col_url = site.base_url ~ lang_prefix ~ "/" ~ page.collection %}<script type="application/ld+json">
     {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
     </script>{% endif %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
     <style>
         *, *::before, *::after { box-sizing: border-box; }
-        body { max-width: 720px; margin: 2rem auto; padding: 0 1rem; font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; color: #222; }
+        body { max-width: 720px; margin: 2rem auto; padding: 0 1rem; font-family: 'Outfit', system-ui, -apple-system, sans-serif; line-height: 1.6; color: #222; }
         a { color: #0057b7; }
         a:hover { color: #003d82; }
         header { margin-bottom: 2rem; }
@@ -66,6 +69,15 @@
         #search-results a:hover { background: #f6f6f6; }
         #search-results .result-meta { font-size: 0.78rem; color: #888; margin-top: 0.1rem; }
         #search-results .no-results { padding: 0.5rem 0.75rem; color: #888; font-size: 0.9rem; }
+        .homepage-content { margin-bottom: 2.5rem; padding-bottom: 2rem; border-bottom: 1px solid #eee; }
+        .homepage-content > h1:first-child { font-size: 2.2rem; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 0.5rem; line-height: 1.2; }
+        .homepage-content > p { font-size: 1.05rem; line-height: 1.7; color: #444; margin-bottom: 0.75rem; }
+        .homepage-content > h2 { font-size: 1.3rem; font-weight: 600; margin-top: 1.75rem; margin-bottom: 0.5rem; }
+        .homepage-content > h3 { font-size: 1.1rem; font-weight: 600; margin-top: 1.25rem; margin-bottom: 0.4rem; }
+        .homepage-content > ul { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; list-style: none; padding: 0; margin: 1.5rem 0; }
+        .homepage-content > ul > li { padding: 1rem; background: #f8f9fa; border-radius: 8px; }
+        .homepage-content > ul > li strong { display: block; font-size: 1.5rem; color: #0057b7; margin-bottom: 0.15rem; }
+        .homepage-content blockquote { border-left: 3px solid #0057b7; padding-left: 1rem; margin: 1.5rem 0; color: #555; font-style: italic; }
         article { margin-bottom: 2rem; }
         time { color: #666; font-size: 0.9rem; }
         .reading-time { color: #666; font-size: 0.85rem; }
@@ -262,19 +274,38 @@
         var basePath = {{ site.base_path | json_encode() }};
         var indexUrl = basePath + {% if lang != default_language %}('/' + {{ lang | json_encode() }} + '/search-index.json'){% else %}'/search-index.json'{% endif %};
         function load(cb) { if (index) { cb(); return; } fetch(indexUrl).then(function(r){return r.json();}).then(function(d){index=d;cb();}).catch(function(){index=[];}); }
-        function search(q) {
+        function doSearch(q) {
             q = q.toLowerCase().trim();
-            if (!q) { results.innerHTML = ''; return; }
+            if (!q) { results.textContent = ''; return; }
             var hits = index.filter(function(e){
                 return (e.title||'').toLowerCase().includes(q) || (e.description||'').toLowerCase().includes(q) || (e.tags||[]).some(function(t){return t.toLowerCase().includes(q);});
             }).slice(0, 8);
-            if (!hits.length) { results.innerHTML = '<div class="no-results">{{ t.no_results }}</div>'; return; }
-            results.innerHTML = hits.map(function(e){
-                var meta = [e.collection, e.date].filter(Boolean).join(' · ');
-                return '<a href="' + basePath + e.url + '"><strong>' + e.title + '</strong>' + (meta ? '<div class="result-meta">' + meta + '</div>' : '') + '</a>';
-            }).join('');
+            if (!hits.length) {
+                var noRes = document.createElement('div');
+                noRes.className = 'no-results';
+                noRes.textContent = '{{ t.no_results }}';
+                results.textContent = '';
+                results.appendChild(noRes);
+                return;
+            }
+            results.textContent = '';
+            hits.forEach(function(e){
+                var a = document.createElement('a');
+                a.href = basePath + e.url;
+                var strong = document.createElement('strong');
+                strong.textContent = e.title;
+                a.appendChild(strong);
+                var meta = [e.collection, e.date].filter(Boolean).join(' \u00b7 ');
+                if (meta) {
+                    var div = document.createElement('div');
+                    div.className = 'result-meta';
+                    div.textContent = meta;
+                    a.appendChild(div);
+                }
+                results.appendChild(a);
+            });
         }
-        input.addEventListener('input', function(){ load(function(){ search(input.value); }); });
+        input.addEventListener('input', function(){ load(function(){ doSearch(input.value); }); });
     })();
     </script>
     {% block footer %}{% endblock %}

--- a/src/themes/docs.tera
+++ b/src/themes/docs.tera
@@ -38,9 +38,12 @@
     {% if page.collection %}{% set _bc_col_url = site.base_url ~ lang_prefix ~ "/" ~ page.collection %}<script type="application/ld+json">
     {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
     </script>{% endif %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
     <style>
         *, *::before, *::after { box-sizing: border-box; }
-        body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #24292e; display: flex; min-height: 100vh; }
+        body { margin: 0; font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #24292e; display: flex; min-height: 100vh; }
         a { color: #0366d6; text-decoration: none; }
         a:hover { text-decoration: underline; }
         .sidebar { width: 260px; padding: 2rem 1.5rem; background: #f6f8fa; border-right: 1px solid #e1e4e8; position: fixed; top: 0; bottom: 0; overflow-y: auto; }
@@ -61,6 +64,15 @@
         #search-results strong { color: #24292e; font-size: 0.85rem; }
         #search-results .result-meta { font-size: 0.75rem; color: #888; margin-top: 0.1rem; }
         #search-results .no-results { padding: 0.4rem 0.6rem; color: #888; font-size: 0.85rem; }
+        .homepage-content { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e7eb; }
+        .homepage-content > h1:first-child { font-size: 2rem; font-weight: 600; margin-bottom: 0.5rem; line-height: 1.3; }
+        .homepage-content > p { font-size: 1rem; line-height: 1.7; color: #4b5563; margin-bottom: 0.75rem; }
+        .homepage-content > h2 { font-size: 1.3rem; font-weight: 600; margin-top: 1.5rem; margin-bottom: 0.5rem; }
+        .homepage-content > h3 { font-size: 1.1rem; font-weight: 600; margin-top: 1.25rem; margin-bottom: 0.4rem; }
+        .homepage-content > ul { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; list-style: none; padding: 0; margin: 1.5rem 0; }
+        .homepage-content > ul > li { padding: 0.75rem 1rem; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; }
+        .homepage-content > ul > li strong { display: block; font-size: 1.25rem; color: #0969da; margin-bottom: 0.1rem; }
+        .homepage-content blockquote { border-left: 3px solid #0969da; padding-left: 1rem; margin: 1.5rem 0; color: #6b7280; }
         .sidebar nav.site-nav { margin-top: 1rem; margin-bottom: 0.5rem; }
         .sidebar nav.site-nav a { color: #0366d6; font-size: 0.9rem; display: block; padding: 0.2rem 0.5rem; border-radius: 4px; }
         .sidebar nav.site-nav a:hover { background: #e1e4e8; text-decoration: none; }
@@ -292,19 +304,38 @@
         var basePath = {{ site.base_path | json_encode() }};
         var indexUrl = basePath + {% if lang != default_language %}('/' + {{ lang | json_encode() }} + '/search-index.json'){% else %}'/search-index.json'{% endif %};
         function load(cb) { if (index) { cb(); return; } fetch(indexUrl).then(function(r){return r.json();}).then(function(d){index=d;cb();}).catch(function(){index=[];}); }
-        function search(q) {
+        function doSearch(q) {
             q = q.toLowerCase().trim();
-            if (!q) { results.innerHTML = ''; return; }
+            if (!q) { results.textContent = ''; return; }
             var hits = index.filter(function(e){
                 return (e.title||'').toLowerCase().includes(q) || (e.description||'').toLowerCase().includes(q) || (e.tags||[]).some(function(t){return t.toLowerCase().includes(q);});
             }).slice(0, 8);
-            if (!hits.length) { results.innerHTML = '<div class="no-results">{{ t.no_results }}</div>'; return; }
-            results.innerHTML = hits.map(function(e){
-                var meta = [e.collection, e.date].filter(Boolean).join(' · ');
-                return '<a href="' + basePath + e.url + '"><strong>' + e.title + '</strong>' + (meta ? '<div class="result-meta">' + meta + '</div>' : '') + '</a>';
-            }).join('');
+            if (!hits.length) {
+                var noRes = document.createElement('div');
+                noRes.className = 'no-results';
+                noRes.textContent = '{{ t.no_results }}';
+                results.textContent = '';
+                results.appendChild(noRes);
+                return;
+            }
+            results.textContent = '';
+            hits.forEach(function(e){
+                var a = document.createElement('a');
+                a.href = basePath + e.url;
+                var strong = document.createElement('strong');
+                strong.textContent = e.title;
+                a.appendChild(strong);
+                var meta = [e.collection, e.date].filter(Boolean).join(' \u00b7 ');
+                if (meta) {
+                    var div = document.createElement('div');
+                    div.className = 'result-meta';
+                    div.textContent = meta;
+                    a.appendChild(div);
+                }
+                results.appendChild(a);
+            });
         }
-        input.addEventListener('input', function(){ load(function(){ search(input.value); }); });
+        input.addEventListener('input', function(){ load(function(){ doSearch(input.value); }); });
     })();
     </script>
     {% block footer %}{% endblock %}

--- a/src/themes/landing.tera
+++ b/src/themes/landing.tera
@@ -39,252 +39,580 @@
     {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
     </script>{% endif %}
     <style>
-        *, *::before, *::after { box-sizing: border-box; }
-        body { margin: 0; padding: 0; font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; color: #1a1a2e; background: #fff; }
-        a { color: #0d9488; }
-        a:hover { color: #0f766e; }
+        /* ============================================
+           LANDING THEME — Modern SaaS / Product Marketing
+           Near-black bg, indigo-purple-pink gradient accent,
+           glassmorphism nav, glow effects, grid pattern.
+           ============================================ */
 
-        /* Header / Navbar */
-        .site-header { max-width: 1100px; margin: 0 auto; padding: 1.25rem 1.5rem; display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 0.75rem; }
-        .site-header h1 { margin: 0; font-size: 1.25rem; font-weight: 800; }
-        .site-header h1 a { color: #1a1a2e; text-decoration: none; }
+        *, *::before, *::after { box-sizing: border-box; }
+
+        body {
+            margin: 0; padding: 0;
+            font-family: system-ui, -apple-system, sans-serif;
+            line-height: 1.7; color: #f5f5f5; background: #050505;
+            background-image:
+                linear-gradient(rgba(255,255,255,0.02) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(255,255,255,0.02) 1px, transparent 1px);
+            background-size: 60px 60px;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        a { color: #818cf8; text-decoration: none; transition: color 0.2s; }
+        a:hover { color: #a78bfa; }
+
+        /* ---------- Glassmorphism Sticky Nav ---------- */
+        .site-header-wrap {
+            position: sticky; top: 0; z-index: 100;
+            backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+            background: rgba(5,5,5,0.8);
+            border-bottom: 1px solid rgba(255,255,255,0.06);
+        }
+        .site-header {
+            max-width: 1100px; margin: 0 auto;
+            padding: 0.9rem 1.5rem;
+            display: flex; align-items: center; justify-content: space-between;
+            flex-wrap: wrap; gap: 0.75rem;
+        }
+        .site-header h1 { margin: 0; font-size: 1.25rem; font-weight: 700; }
+        .site-header h1 a {
+            text-decoration: none;
+            background: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
+            -webkit-background-clip: text; background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
         .site-header p { display: none; }
         .header-right { display: flex; align-items: center; gap: 1rem; }
-        nav.site-nav { display: flex; gap: 0.25rem; }
-        nav.site-nav a { text-decoration: none; font-weight: 500; font-size: 0.9rem; color: #64748b; padding: 0.35rem 0.75rem; border-radius: 6px; transition: color 0.15s, background 0.15s; }
-        nav.site-nav a:hover { color: #0d9488; background: #f0fdfa; }
+
+        nav.site-nav { display: flex; gap: 0.2rem; }
+        nav.site-nav a {
+            text-decoration: none; font-weight: 500; font-size: 0.9rem;
+            color: #888; padding: 0.35rem 0.75rem; border-radius: 6px;
+            transition: color 0.2s, background 0.2s;
+        }
+        nav.site-nav a:hover { color: #f5f5f5; background: rgba(255,255,255,0.06); }
+
         .lang-switcher { display: inline-flex; gap: 0.35rem; font-size: 0.8rem; }
-        .lang-switcher a { text-decoration: none; color: #94a3b8; padding: 0.15rem 0.45rem; border-radius: 4px; border: 1px solid #e2e8f0; }
-        .lang-switcher a:hover { border-color: #0d9488; color: #0d9488; }
-        .lang-switcher strong { padding: 0.15rem 0.45rem; background: #0d9488; color: #fff; border-radius: 4px; }
+        .lang-switcher a {
+            text-decoration: none; color: #666;
+            padding: 0.15rem 0.5rem; border-radius: 4px;
+            border: 1px solid rgba(255,255,255,0.08);
+            transition: border-color 0.2s, color 0.2s;
+        }
+        .lang-switcher a:hover { border-color: #6366f1; color: #818cf8; }
+        .lang-switcher strong {
+            padding: 0.15rem 0.5rem; border-radius: 4px;
+            background: linear-gradient(135deg, #6366f1, #a855f7);
+            color: #fff; font-size: 0.8rem;
+        }
 
-        /* Hero section — used on homepage when page.content exists */
-        .hero { max-width: 1100px; margin: 0 auto; padding: 4rem 1.5rem 3rem; text-align: center; }
-        .hero h2 { font-size: 3rem; font-weight: 800; line-height: 1.15; margin: 0 0 1rem; letter-spacing: -0.02em; color: #1a1a2e; }
-        .hero p { font-size: 1.2rem; color: #64748b; max-width: 640px; margin: 0 auto 2rem; }
+        /* ---------- Hero Section ---------- */
+        .hero {
+            position: relative;
+            max-width: 1100px; margin: 0 auto;
+            padding: 5rem 1.5rem 4rem; text-align: center;
+        }
+        .hero::before {
+            content: ''; position: absolute; top: -80px; left: 50%;
+            transform: translateX(-50%); width: 100%; height: 600px;
+            background: radial-gradient(600px circle at 50% 0%, rgba(99,102,241,0.15), transparent 70%);
+            pointer-events: none; z-index: 0;
+        }
+        .hero > * { position: relative; z-index: 1; }
+        .hero h2 {
+            font-size: clamp(2.2rem, 5vw, 3.5rem); font-weight: 800;
+            line-height: 1.1; margin: 0 0 1.25rem; letter-spacing: -0.03em;
+            background: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
+            -webkit-background-clip: text; background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+        .hero p { font-size: 1.2rem; color: #888; max-width: 640px; margin: 0 auto 2.5rem; line-height: 1.7; }
         .hero .cta-group { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
-        .cta-primary { display: inline-block; background: #0d9488; color: #fff; padding: 0.75rem 2rem; border-radius: 8px; font-weight: 600; text-decoration: none; font-size: 1rem; transition: background 0.15s; }
-        .cta-primary:hover { background: #0f766e; color: #fff; text-decoration: none; }
-        .cta-secondary { display: inline-block; color: #0d9488; padding: 0.75rem 2rem; border-radius: 8px; font-weight: 600; text-decoration: none; font-size: 1rem; border: 2px solid #0d9488; transition: background 0.15s; }
-        .cta-secondary:hover { background: #f0fdfa; text-decoration: none; }
 
-        /* Content wrapper */
+        .cta-primary {
+            display: inline-block; color: #fff;
+            padding: 0.8rem 2.25rem; border-radius: 10px;
+            font-weight: 600; font-size: 1rem; text-decoration: none;
+            background: linear-gradient(135deg, #6366f1, #a855f7);
+            box-shadow: 0 0 20px rgba(99,102,241,0.25);
+            transition: box-shadow 0.3s, transform 0.2s;
+        }
+        .cta-primary:hover {
+            color: #fff; text-decoration: none;
+            box-shadow: 0 0 30px rgba(99,102,241,0.4);
+            transform: scale(1.02);
+        }
+        .cta-secondary {
+            display: inline-block; color: #818cf8;
+            padding: 0.8rem 2.25rem; border-radius: 10px;
+            font-weight: 600; font-size: 1rem; text-decoration: none;
+            border: 1px solid rgba(99,102,241,0.3);
+            background: rgba(99,102,241,0.05);
+            transition: border-color 0.3s, background 0.3s;
+        }
+        .cta-secondary:hover {
+            text-decoration: none; border-color: rgba(99,102,241,0.5);
+            background: rgba(99,102,241,0.1);
+        }
+
+        /* ---------- Content Wrapper ---------- */
         .content-wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem; }
 
-        /* Sections with alternating backgrounds */
-        .section { padding: 3rem 0; }
-        .section:nth-child(even) { background: #f8fafc; }
+        /* ---------- Sections ---------- */
+        .section { padding: 3.5rem 0; }
+        .section:nth-child(even) { background: rgba(255,255,255,0.015); }
         .section-inner { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem; }
-        .section h2 { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.1em; color: #0d9488; font-weight: 700; margin: 0 0 1.5rem; }
+        .section h2 {
+            font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.12em;
+            font-weight: 700; margin: 0 0 1.75rem;
+            background: linear-gradient(135deg, #6366f1, #a855f7);
+            -webkit-background-clip: text; background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
 
-        /* Article grid for collection listings */
-        .article-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 1.5rem; }
-        article { background: #fff; border: 1px solid #e2e8f0; border-radius: 12px; padding: 1.75rem; transition: border-color 0.15s, box-shadow 0.15s; }
-        article:hover { border-color: #0d9488; box-shadow: 0 4px 20px rgba(13,148,136,0.08); }
-        article h3 { margin: 0 0 0.4rem; font-size: 1.15rem; font-weight: 700; }
-        article h3 a { color: #1a1a2e; text-decoration: none; }
-        article h3 a:hover { color: #0d9488; }
-        article p { color: #64748b; font-size: 0.9rem; margin: 0.5rem 0 0; }
+        /* ---------- Article Grid (Index/Listings) ---------- */
+        .article-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+            gap: 1.5rem;
+        }
+        article {
+            background: rgba(255,255,255,0.03);
+            border: 1px solid rgba(255,255,255,0.06);
+            border-radius: 14px; padding: 1.75rem;
+            transition: border-color 0.3s, box-shadow 0.3s, transform 0.2s;
+        }
+        article:hover {
+            border-color: rgba(99,102,241,0.3);
+            box-shadow: 0 0 30px rgba(99,102,241,0.08);
+            transform: translateY(-2px);
+        }
+        article h3 { margin: 0 0 0.4rem; font-size: 1.1rem; font-weight: 600; }
+        article h3 a { color: #f5f5f5; text-decoration: none; transition: color 0.2s; }
+        article h3 a:hover { color: #818cf8; }
+        article p { color: #888; font-size: 0.9rem; margin: 0.5rem 0 0; }
 
-        /* Single article pages — centered reading column */
-        main > article { max-width: 720px; margin: 2rem auto; border: none; box-shadow: none; padding: 0 1.5rem; }
-        main > article:hover { border-color: transparent; box-shadow: none; }
-        main > article h1 { font-size: 2.2rem; font-weight: 800; margin: 0 0 0.5rem; line-height: 1.2; letter-spacing: -0.01em; }
-        main > article h2 { font-size: 1.4rem; font-weight: 700; margin-top: 2.5rem; color: #1a1a2e; }
-        main > article h3 { font-size: 1.1rem; font-weight: 600; margin-top: 1.5rem; }
-        time { font-size: 0.8rem; color: #94a3b8; }
-        .reading-time { color: #94a3b8; font-size: 0.85rem; }
-        .tags a, .tags span { background: #f0fdfa; color: #0d9488; border: 1px solid #ccfbf1; padding: 0.1rem 0.55rem; border-radius: 9999px; margin-right: 0.3rem; font-size: 0.75rem; font-weight: 600; text-decoration: none; }
-        .tags a:hover { background: #ccfbf1; }
+        /* ---------- Single Article (Reading View) ---------- */
+        main > article {
+            max-width: 720px; margin: 2.5rem auto;
+            border: none; box-shadow: none; padding: 0 1.5rem;
+            background: transparent;
+        }
+        main > article:hover { border-color: transparent; box-shadow: none; transform: none; }
+        main > article h1 {
+            font-size: clamp(1.8rem, 4vw, 2.5rem); font-weight: 800;
+            margin: 0 0 0.5rem; line-height: 1.15; letter-spacing: -0.02em;
+            background: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
+            -webkit-background-clip: text; background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+        main > article h2 { font-size: 1.4rem; font-weight: 700; margin-top: 2.5rem; color: #f5f5f5; }
+        main > article h3 { font-size: 1.1rem; font-weight: 600; margin-top: 1.5rem; color: #e0e0e0; }
 
-        /* Search */
+        time { font-size: 0.8rem; color: #666; }
+        .reading-time { color: #666; font-size: 0.85rem; }
+
+        .tags a, .tags span {
+            background: rgba(99,102,241,0.08);
+            border: 1px solid rgba(99,102,241,0.15);
+            color: #818cf8; padding: 0.1rem 0.6rem; border-radius: 9999px;
+            margin-right: 0.3rem; font-size: 0.75rem; font-weight: 600;
+            text-decoration: none; transition: background 0.2s, border-color 0.2s;
+        }
+        .tags a:hover { background: rgba(99,102,241,0.15); border-color: rgba(99,102,241,0.3); }
+
+        /* ---------- Search ---------- */
         .search-form { margin: 0; }
-        .search-form input { width: 200px; padding: 0.4rem 0.75rem; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.85rem; font-family: inherit; background: #f8fafc; color: #1a1a2e; }
-        .search-form input:focus { outline: none; border-color: #0d9488; background: #fff; box-shadow: 0 0 0 3px rgba(13,148,136,0.1); }
-        #search-results { position: absolute; right: 1.5rem; top: 100%; width: 360px; border: 1px solid #e2e8f0; border-radius: 10px; background: #fff; box-shadow: 0 8px 30px rgba(0,0,0,0.1); z-index: 50; overflow: hidden; }
-        #search-results a { display: block; padding: 0.6rem 1rem; text-decoration: none; border-bottom: 1px solid #f1f5f9; font-size: 0.9rem; color: #0d9488; }
+        .search-form input {
+            width: 200px; padding: 0.4rem 0.75rem;
+            border: 1px solid rgba(255,255,255,0.08); border-radius: 8px;
+            font-size: 0.85rem; font-family: inherit;
+            background: rgba(255,255,255,0.04); color: #f5f5f5;
+            transition: border-color 0.2s, box-shadow 0.2s;
+        }
+        .search-form input::placeholder { color: #555; }
+        .search-form input:focus {
+            outline: none; border-color: rgba(99,102,241,0.5);
+            background: rgba(255,255,255,0.06);
+            box-shadow: 0 0 0 3px rgba(99,102,241,0.15);
+        }
+        #search-results {
+            position: absolute; right: 1.5rem; top: 100%; width: 380px;
+            border: 1px solid rgba(255,255,255,0.08); border-radius: 12px;
+            background: rgba(10,10,10,0.95); backdrop-filter: blur(12px);
+            box-shadow: 0 8px 40px rgba(0,0,0,0.5); z-index: 50; overflow: hidden;
+        }
+        #search-results a {
+            display: block; padding: 0.65rem 1rem; text-decoration: none;
+            border-bottom: 1px solid rgba(255,255,255,0.04); font-size: 0.9rem;
+            color: #818cf8; transition: background 0.15s;
+        }
         #search-results a:last-child { border-bottom: none; }
-        #search-results a:hover { background: #f0fdfa; }
-        #search-results strong { color: #1a1a2e; }
-        #search-results .result-meta { font-size: 0.75rem; color: #94a3b8; margin-top: 0.1rem; }
-        #search-results .no-results { padding: 0.6rem 1rem; color: #94a3b8; font-size: 0.9rem; }
+        #search-results a:hover { background: rgba(99,102,241,0.08); }
+        #search-results strong { color: #f5f5f5; }
+        #search-results .result-meta { font-size: 0.75rem; color: #555; margin-top: 0.15rem; }
+        #search-results .no-results { padding: 0.65rem 1rem; color: #555; font-size: 0.9rem; }
 
-        /* Typography */
-        pre { background: #1e293b; color: #e2e8f0; padding: 1rem; border-radius: 8px; overflow-x: auto; }
-        pre code { background: none; color: inherit; font-size: 0.9em; padding: 0; }
-        code { font-size: 0.9em; background: #f0fdfa; color: #0d9488; padding: 0.15em 0.4em; border-radius: 4px; }
-        blockquote { border-left: 4px solid #0d9488; margin-left: 0; padding: 0.75rem 1rem; background: #f0fdfa; border-radius: 0 8px 8px 0; color: #334155; }
-        img { max-width: 100%; height: auto; border-radius: 8px; }
-        figure { margin: 1.5rem 0; }
+        /* ---------- Typography ---------- */
+        pre {
+            background: rgba(255,255,255,0.03); color: #e2e8f0;
+            padding: 1.25rem; border-radius: 10px; overflow-x: auto;
+            border: 1px solid rgba(255,255,255,0.06);
+            font-size: 0.9em;
+        }
+        pre code { background: none; color: inherit; font-size: inherit; padding: 0; border: none; }
+        code {
+            font-size: 0.9em; padding: 0.15em 0.4em; border-radius: 5px;
+            background: rgba(99,102,241,0.1); color: #a5b4fc;
+            border: 1px solid rgba(99,102,241,0.1);
+        }
+        blockquote {
+            border-left: 3px solid #6366f1; margin-left: 0;
+            padding: 0.75rem 1.25rem; border-radius: 0 10px 10px 0;
+            background: rgba(99,102,241,0.05); color: #aaa;
+        }
+        blockquote p:first-child { margin-top: 0; }
+        blockquote p:last-child { margin-bottom: 0; }
+        img { max-width: 100%; height: auto; border-radius: 10px; }
+        figure { margin: 2rem 0; }
         figure img { display: block; }
-        figcaption { font-size: 0.85rem; color: #64748b; margin-top: 0.5rem; }
-        hr { border: none; border-top: 1px solid #e2e8f0; margin: 2rem 0; }
+        figcaption { font-size: 0.85rem; color: #666; margin-top: 0.5rem; text-align: center; }
+        hr { border: none; border-top: 1px solid rgba(255,255,255,0.06); margin: 2.5rem 0; }
 
-        /* Embeds */
-        .video-embed { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin: 1.5rem 0; border-radius: 8px; }
+        /* ---------- Embeds ---------- */
+        .video-embed {
+            position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;
+            margin: 2rem 0; border-radius: 12px;
+            border: 1px solid rgba(255,255,255,0.06);
+        }
         .video-embed iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
         .gist-embed { margin: 1.5rem 0; }
 
-        /* Callouts */
-        .callout { padding: 1rem 1.25rem; margin: 1.5rem 0; border-radius: 8px; border-left: 4px solid #0d9488; background: #f0fdfa; }
-        .callout-title { font-weight: 700; margin-bottom: 0.5rem; font-size: 0.85rem; }
-        .callout-info { border-left-color: #0d9488; background: #f0fdfa; }
-        .callout-warning { border-left-color: #d97706; background: #fffbeb; }
-        .callout-danger { border-left-color: #dc2626; background: #fef2f2; }
-        .callout-tip { border-left-color: #16a34a; background: #f0fdf4; }
-        .callout-note { border-left-color: #6b7280; background: #f9fafb; }
+        /* ---------- Callouts ---------- */
+        .callout {
+            padding: 1rem 1.25rem; margin: 1.5rem 0; border-radius: 10px;
+            border-left: 3px solid #6366f1;
+            background: rgba(99,102,241,0.05);
+            border: 1px solid rgba(255,255,255,0.06);
+            border-left-width: 3px;
+        }
+        .callout-title { font-weight: 700; margin-bottom: 0.5rem; font-size: 0.85rem; color: #f5f5f5; }
+        .callout-info { border-left-color: #6366f1; }
+        .callout-warning { border-left-color: #f59e0b; background: rgba(245,158,11,0.05); }
+        .callout-danger { border-left-color: #ef4444; background: rgba(239,68,68,0.05); }
+        .callout-tip { border-left-color: #22c55e; background: rgba(34,197,94,0.05); }
+        .callout-note { border-left-color: #888; background: rgba(136,136,136,0.05); }
         .callout p:last-child { margin-bottom: 0; }
 
-        /* Contact form */
+        /* ---------- Contact Form ---------- */
         .contact-form { max-width: 480px; }
-        .contact-form-field { margin-bottom: 1rem; }
-        .contact-form-field label { display: block; font-weight: 600; margin-bottom: 0.25rem; font-size: 0.9rem; }
-        .contact-form-field input, .contact-form-field textarea { width: 100%; padding: 0.6rem 0.75rem; border: 1px solid #e2e8f0; border-radius: 8px; font: inherit; box-sizing: border-box; }
-        .contact-form-field input:focus, .contact-form-field textarea:focus { outline: none; border-color: #0d9488; box-shadow: 0 0 0 3px rgba(13,148,136,0.1); }
-        .contact-form-submit { background: #0d9488; color: #fff; border: none; padding: 0.6rem 1.5rem; border-radius: 8px; font: inherit; font-weight: 600; cursor: pointer; }
-        .contact-form-submit:hover { background: #0f766e; }
+        .contact-form-field { margin-bottom: 1.25rem; }
+        .contact-form-field label {
+            display: block; font-weight: 600; margin-bottom: 0.35rem;
+            font-size: 0.9rem; color: #ccc;
+        }
+        .contact-form-field input, .contact-form-field textarea {
+            width: 100%; padding: 0.65rem 0.85rem;
+            border: 1px solid rgba(255,255,255,0.08); border-radius: 10px;
+            font: inherit; box-sizing: border-box;
+            background: rgba(255,255,255,0.03); color: #f5f5f5;
+            transition: border-color 0.2s, box-shadow 0.2s;
+        }
+        .contact-form-field input:focus, .contact-form-field textarea:focus {
+            outline: none; border-color: rgba(99,102,241,0.5);
+            box-shadow: 0 0 0 3px rgba(99,102,241,0.15);
+        }
+        .contact-form-submit {
+            background: linear-gradient(135deg, #6366f1, #a855f7);
+            color: #fff; border: none;
+            padding: 0.7rem 1.75rem; border-radius: 10px;
+            font: inherit; font-weight: 600; cursor: pointer;
+            box-shadow: 0 0 15px rgba(99,102,241,0.2);
+            transition: box-shadow 0.3s, transform 0.2s;
+        }
+        .contact-form-submit:hover {
+            box-shadow: 0 0 25px rgba(99,102,241,0.4);
+            transform: scale(1.02);
+        }
         .contact-form-honeypot { display: none; }
-        .contact-form-embed { min-height: 400px; border-radius: 8px; }
-        .contact-form-error { color: #dc2626; background: #fef2f2; padding: 1rem; border-radius: 8px; border-left: 4px solid #dc2626; }
+        .contact-form-embed { min-height: 400px; border-radius: 10px; }
+        .contact-form-error {
+            color: #f87171; background: rgba(239,68,68,0.08);
+            padding: 1rem; border-radius: 10px;
+            border-left: 3px solid #ef4444;
+        }
 
-        /* Trust center */
+        /* ---------- Trust Center ---------- */
         .trust-hub { max-width: 1100px; margin: 0 auto; }
         .trust-hero { margin-bottom: 2.5rem; }
-        .trust-hero h1 { font-size: 2.2rem; font-weight: 800; margin-bottom: 0.5rem; }
+        .trust-hero h1 {
+            font-size: 2.2rem; font-weight: 800; margin-bottom: 0.5rem;
+            background: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
+            -webkit-background-clip: text; background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
         .trust-section { margin-bottom: 2.5rem; }
-        .trust-section h2 { font-size: 1.4rem; margin-bottom: 1rem; border-bottom: 1px solid #e2e8f0; padding-bottom: 0.5rem; }
-        .trust-breadcrumb { font-size: 0.85rem; color: #94a3b8; margin-bottom: 1.5rem; }
-        .trust-breadcrumb a { color: #0d9488; text-decoration: none; }
-        .trust-breadcrumb a:hover { text-decoration: underline; }
-        .trust-description { color: #64748b; margin-bottom: 1.5rem; line-height: 1.7; }
+        .trust-section h2 {
+            font-size: 1.4rem; margin-bottom: 1rem; color: #f5f5f5;
+            border-bottom: 1px solid rgba(255,255,255,0.06); padding-bottom: 0.5rem;
+        }
+        .trust-breadcrumb { font-size: 0.85rem; color: #666; margin-bottom: 1.5rem; }
+        .trust-breadcrumb a { color: #818cf8; text-decoration: none; }
+        .trust-breadcrumb a:hover { color: #a78bfa; text-decoration: underline; }
+        .trust-description { color: #888; margin-bottom: 1.5rem; line-height: 1.7; }
         .cert-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.5rem; }
-        .cert-card { border: 1px solid #e2e8f0; border-radius: 12px; padding: 1.5rem; background: #fff; transition: border-color 0.15s, box-shadow 0.15s; }
-        .cert-card:hover { border-color: #0d9488; box-shadow: 0 4px 20px rgba(13,148,136,0.08); }
+        .cert-card {
+            border: 1px solid rgba(255,255,255,0.06); border-radius: 14px;
+            padding: 1.5rem; background: rgba(255,255,255,0.03);
+            transition: border-color 0.3s, box-shadow 0.3s;
+        }
+        .cert-card:hover {
+            border-color: rgba(99,102,241,0.3);
+            box-shadow: 0 0 25px rgba(99,102,241,0.08);
+        }
         .cert-card__header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
-        .cert-card__title { font-weight: 700; font-size: 1.05rem; color: #1a1a2e; }
-        .cert-card__desc { font-size: 0.9rem; color: #64748b; margin-bottom: 0.75rem; }
-        .cert-card__link { font-size: 0.85rem; color: #0d9488; text-decoration: none; font-weight: 600; }
-        .cert-card__link:hover { text-decoration: underline; }
-        .cert-status { display: inline-block; font-size: 0.7rem; font-weight: 700; padding: 0.15rem 0.5rem; border-radius: 9999px; text-transform: uppercase; letter-spacing: 0.03em; }
-        .cert-status--active { background: #dcfce7; color: #166534; }
-        .cert-status--in_progress { background: #fef9c3; color: #854d0e; }
-        .cert-status--planned { background: #f3f4f6; color: #6b7280; }
-        .cert-detail { margin-bottom: 2rem; padding: 1.5rem; border: 1px solid #e2e8f0; border-radius: 12px; background: #f8fafc; }
-        .cert-meta { font-size: 0.9rem; color: #64748b; margin-bottom: 0.35rem; }
-        .cert-meta strong { color: #1a1a2e; }
-        .trust-item { padding: 0.75rem 0; border-bottom: 1px solid #e2e8f0; }
+        .cert-card__title { font-weight: 700; font-size: 1.05rem; color: #f5f5f5; }
+        .cert-card__desc { font-size: 0.9rem; color: #888; margin-bottom: 0.75rem; }
+        .cert-card__link { font-size: 0.85rem; color: #818cf8; text-decoration: none; font-weight: 600; }
+        .cert-card__link:hover { color: #a78bfa; text-decoration: underline; }
+        .cert-status {
+            display: inline-block; font-size: 0.7rem; font-weight: 700;
+            padding: 0.15rem 0.55rem; border-radius: 9999px;
+            text-transform: uppercase; letter-spacing: 0.03em;
+        }
+        .cert-status--active { background: rgba(34,197,94,0.12); color: #4ade80; }
+        .cert-status--in_progress { background: rgba(245,158,11,0.12); color: #fbbf24; }
+        .cert-status--planned { background: rgba(255,255,255,0.06); color: #666; }
+        .cert-detail {
+            margin-bottom: 2rem; padding: 1.5rem;
+            border: 1px solid rgba(255,255,255,0.06); border-radius: 14px;
+            background: rgba(255,255,255,0.02);
+        }
+        .cert-meta { font-size: 0.9rem; color: #888; margin-bottom: 0.35rem; }
+        .cert-meta strong { color: #f5f5f5; }
+        .trust-item { padding: 0.75rem 0; border-bottom: 1px solid rgba(255,255,255,0.06); }
         .trust-item:last-child { border-bottom: none; }
         .subprocessor-table-wrap { overflow-x: auto; margin: 1.5rem 0; }
         .subprocessor-table { border-collapse: collapse; width: 100%; }
-        .subprocessor-table th, .subprocessor-table td { border: 1px solid #e2e8f0; padding: 0.5rem 0.75rem; text-align: left; font-size: 0.9rem; }
-        .subprocessor-table th { background: #f8fafc; font-weight: 600; }
+        .subprocessor-table th, .subprocessor-table td {
+            border: 1px solid rgba(255,255,255,0.06);
+            padding: 0.55rem 0.85rem; text-align: left; font-size: 0.9rem;
+        }
+        .subprocessor-table th { background: rgba(255,255,255,0.04); font-weight: 600; color: #f5f5f5; }
+        .subprocessor-table td { color: #888; }
         .faq-section { margin-top: 2rem; }
-        .faq-item { border-bottom: 1px solid #e2e8f0; }
-        .faq-item summary { padding: 0.75rem 0; cursor: pointer; font-weight: 500; color: #1a1a2e; }
-        .faq-item summary:hover { color: #0d9488; }
-        .faq-answer { padding: 0 0 1rem; color: #64748b; line-height: 1.7; }
+        .faq-item { border-bottom: 1px solid rgba(255,255,255,0.06); }
+        .faq-item summary { padding: 0.75rem 0; cursor: pointer; font-weight: 500; color: #f5f5f5; transition: color 0.2s; }
+        .faq-item summary:hover { color: #818cf8; }
+        .faq-answer { padding: 0 0 1rem; color: #888; line-height: 1.7; }
         .trust-page { margin-bottom: 2rem; }
 
-        /* Changelog */
+        /* ---------- Changelog ---------- */
         .changelog-entry-header { margin-bottom: 1.5rem; }
-        .changelog-meta { display: flex; align-items: center; gap: 1rem; margin-top: 0.5rem; color: #94a3b8; font-size: 0.9rem; }
-        .changelog-summary { color: #64748b; font-size: 1.05rem; margin-bottom: 1.5rem; }
+        .changelog-meta { display: flex; align-items: center; gap: 1rem; margin-top: 0.5rem; color: #666; font-size: 0.9rem; }
+        .changelog-summary { color: #888; font-size: 1.05rem; margin-bottom: 1.5rem; }
         .changelog-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
-        .changelog-tag { display: inline-block; padding: 0.15rem 0.6rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; }
-        .changelog-tag--new { background: #dcfce7; color: #166534; }
-        .changelog-tag--fix { background: #dbeafe; color: #1e40af; }
-        .changelog-tag--breaking { background: #fee2e2; color: #991b1b; }
-        .changelog-tag--improvement { background: #f3e8ff; color: #6b21a8; }
-        .changelog-tag--deprecated { background: #f3f4f6; color: #4b5563; }
-        .changelog-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 1rem; margin-bottom: 2rem; }
+        .changelog-tag {
+            display: inline-block; padding: 0.15rem 0.6rem; border-radius: 9999px;
+            font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em;
+        }
+        .changelog-tag--new { background: rgba(34,197,94,0.12); color: #4ade80; }
+        .changelog-tag--fix { background: rgba(96,165,250,0.12); color: #60a5fa; }
+        .changelog-tag--breaking { background: rgba(248,113,113,0.12); color: #f87171; }
+        .changelog-tag--improvement { background: rgba(192,132,252,0.12); color: #c084fc; }
+        .changelog-tag--deprecated { background: rgba(255,255,255,0.06); color: #666; }
+        .changelog-header {
+            display: flex; justify-content: space-between; align-items: baseline;
+            flex-wrap: wrap; gap: 1rem; margin-bottom: 2rem;
+        }
         .changelog-header h1 { margin-bottom: 0; }
-        .changelog-rss { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.8rem; color: #94a3b8; text-decoration: none; padding: 0.3rem 0.7rem; border: 1px solid #e2e8f0; border-radius: 6px; }
-        .changelog-rss:hover { color: #0d9488; border-color: #0d9488; }
+        .changelog-rss {
+            display: inline-flex; align-items: center; gap: 0.4rem;
+            font-size: 0.8rem; color: #666; text-decoration: none;
+            padding: 0.3rem 0.7rem; border: 1px solid rgba(255,255,255,0.08);
+            border-radius: 8px; transition: color 0.2s, border-color 0.2s;
+        }
+        .changelog-rss:hover { color: #818cf8; border-color: rgba(99,102,241,0.3); }
         .changelog-back { margin-bottom: 1.5rem; }
-        .changelog-back a { color: #94a3b8; text-decoration: none; font-size: 0.9rem; }
-        .changelog-back a:hover { color: #0d9488; }
+        .changelog-back a { color: #666; text-decoration: none; font-size: 0.9rem; transition: color 0.2s; }
+        .changelog-back a:hover { color: #818cf8; }
         .changelog-timeline { position: relative; padding-left: 2rem; }
-        .changelog-timeline::before { content: ''; position: absolute; left: 0; top: 0.5rem; bottom: 0; width: 2px; background: #e2e8f0; }
-        .changelog-item { position: relative; padding: 1.25rem; border: 1px solid #e2e8f0; border-radius: 12px; background: #fff; margin-bottom: 1.5rem; }
-        .changelog-item::before { content: ''; position: absolute; left: -2rem; top: 1.25rem; width: 10px; height: 10px; border-radius: 50%; background: #0d9488; transform: translateX(-4px); }
+        .changelog-timeline::before {
+            content: ''; position: absolute; left: 0; top: 0.5rem; bottom: 0;
+            width: 2px; background: rgba(255,255,255,0.06);
+        }
+        .changelog-item {
+            position: relative; padding: 1.25rem;
+            border: 1px solid rgba(255,255,255,0.06); border-radius: 14px;
+            background: rgba(255,255,255,0.03); margin-bottom: 1.5rem;
+            transition: border-color 0.2s;
+        }
+        .changelog-item:hover { border-color: rgba(99,102,241,0.2); }
+        .changelog-item::before {
+            content: ''; position: absolute; left: -2rem; top: 1.25rem;
+            width: 10px; height: 10px; border-radius: 50%;
+            background: #6366f1; transform: translateX(-4px);
+            box-shadow: 0 0 10px rgba(99,102,241,0.4);
+        }
         .changelog-item:last-child { margin-bottom: 0; }
-        .changelog-item-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 0.5rem; }
+        .changelog-item-header {
+            display: flex; justify-content: space-between; align-items: baseline;
+            flex-wrap: wrap; gap: 0.5rem;
+        }
         .changelog-item-header h2 { margin: 0; font-size: 1.25rem; }
-        .changelog-item-header time { color: #94a3b8; font-size: 0.85rem; white-space: nowrap; }
+        .changelog-item-header time { color: #666; font-size: 0.85rem; white-space: nowrap; }
         .changelog-item .changelog-tags { margin-top: 0.5rem; }
-        .changelog-item p, .changelog-item .excerpt { margin-top: 0.5rem; color: #64748b; }
+        .changelog-item p, .changelog-item .excerpt { margin-top: 0.5rem; color: #888; }
         .changelog-feed .changelog-item::before { display: none; }
         .changelog-feed { display: flex; flex-direction: column; gap: 1.5rem; }
 
-        /* Roadmap */
+        /* ---------- Roadmap ---------- */
         .roadmap-back { margin-bottom: 1.5rem; }
-        .roadmap-back a { color: #94a3b8; text-decoration: none; font-size: 0.9rem; }
-        .roadmap-back a:hover { color: #0d9488; }
+        .roadmap-back a { color: #666; text-decoration: none; font-size: 0.9rem; }
+        .roadmap-back a:hover { color: #818cf8; }
         .roadmap-entry-header { margin-bottom: 1.5rem; }
-        .roadmap-summary { color: #64748b; font-size: 1.05rem; margin-bottom: 1.5rem; }
+        .roadmap-summary { color: #888; font-size: 1.05rem; margin-bottom: 1.5rem; }
         .roadmap-status-badges { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
-        .roadmap-status { display: inline-block; padding: 0.2rem 0.7rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; }
-        .roadmap-status--planned { background: #dbeafe; color: #1e40af; }
-        .roadmap-status--in-progress { background: #fef3c7; color: #92400e; }
-        .roadmap-status--done { background: #dcfce7; color: #166534; }
-        .roadmap-status--cancelled { background: #f3f4f6; color: #4b5563; text-decoration: line-through; }
+        .roadmap-status {
+            display: inline-block; padding: 0.2rem 0.7rem; border-radius: 9999px;
+            font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em;
+        }
+        .roadmap-status--planned { background: rgba(96,165,250,0.12); color: #60a5fa; }
+        .roadmap-status--in-progress { background: rgba(251,191,36,0.12); color: #fbbf24; }
+        .roadmap-status--done { background: rgba(74,222,128,0.12); color: #4ade80; }
+        .roadmap-status--cancelled { background: rgba(255,255,255,0.06); color: #555; text-decoration: line-through; }
         .roadmap-grouped { display: flex; flex-direction: column; gap: 2rem; }
         .roadmap-section-header { display: flex; align-items: center; gap: 0.75rem; font-size: 1.1rem; margin-bottom: 1rem; }
         .roadmap-items { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; }
-        .roadmap-card { padding: 1.25rem; border: 1px solid #e2e8f0; border-radius: 12px; background: #fff; transition: border-color 0.15s; }
-        .roadmap-card:hover { border-color: #0d9488; }
+        .roadmap-card {
+            padding: 1.25rem; border: 1px solid rgba(255,255,255,0.06);
+            border-radius: 14px; background: rgba(255,255,255,0.03);
+            transition: border-color 0.3s, box-shadow 0.3s;
+        }
+        .roadmap-card:hover {
+            border-color: rgba(99,102,241,0.3);
+            box-shadow: 0 0 20px rgba(99,102,241,0.06);
+        }
         .roadmap-card h3 { margin: 0 0 0.25rem; font-size: 1rem; }
-        .roadmap-card p, .roadmap-card .excerpt { margin: 0; color: #64748b; font-size: 0.9rem; }
+        .roadmap-card p, .roadmap-card .excerpt { margin: 0; color: #888; font-size: 0.9rem; }
         .roadmap-kanban { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; }
         .roadmap-column-header { font-size: 1rem; margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem; }
-        .roadmap-count { font-size: 0.8rem; color: #94a3b8; font-weight: 400; }
+        .roadmap-count { font-size: 0.8rem; color: #555; font-weight: 400; }
         .roadmap-timeline { position: relative; padding-left: 2rem; }
-        .roadmap-timeline::before { content: ''; position: absolute; left: 0.5rem; top: 0; bottom: 0; width: 2px; background: #e2e8f0; }
+        .roadmap-timeline::before {
+            content: ''; position: absolute; left: 0.5rem; top: 0; bottom: 0;
+            width: 2px; background: rgba(255,255,255,0.06);
+        }
         .roadmap-milestone { position: relative; margin-bottom: 2rem; }
-        .roadmap-milestone-dot { position: absolute; left: -1.75rem; top: 0.3rem; width: 12px; height: 12px; border-radius: 50%; border: 2px solid #0d9488; background: #fff; }
+        .roadmap-milestone-dot {
+            position: absolute; left: -1.75rem; top: 0.3rem;
+            width: 12px; height: 12px; border-radius: 50%;
+            border: 2px solid #6366f1; background: #050505;
+            box-shadow: 0 0 8px rgba(99,102,241,0.3);
+        }
         .roadmap-milestone-dot .roadmap-status { display: none; }
         .roadmap-milestone-content h3 { margin: 0 0 0.25rem; }
-        .roadmap-milestone-content p { margin: 0.25rem 0 0; color: #64748b; font-size: 0.9rem; }
+        .roadmap-milestone-content p { margin: 0.25rem 0 0; color: #888; font-size: 0.9rem; }
         @media (max-width: 768px) { .roadmap-kanban { grid-template-columns: 1fr; } }
 
-        /* Tables */
+        /* ---------- Tables ---------- */
         table { border-collapse: collapse; width: 100%; margin: 1.5rem 0; }
-        th, td { border: 1px solid #e2e8f0; padding: 0.5rem 0.75rem; text-align: left; }
-        th { background: #f8fafc; font-weight: 600; }
+        th, td { border: 1px solid rgba(255,255,255,0.06); padding: 0.55rem 0.85rem; text-align: left; }
+        th { background: rgba(255,255,255,0.04); font-weight: 600; }
+        td { color: #ccc; }
+
+        /* ---------- Task Lists ---------- */
         ul.contains-task-list, ol.contains-task-list { list-style: none; padding-left: 0; }
         li.task-list-item { display: flex; align-items: baseline; gap: 0.5rem; }
-        li.task-list-item input[type="checkbox"] { margin: 0; pointer-events: none; }
-        .footnote-definition { font-size: 0.85rem; color: #64748b; border-top: 1px solid #e2e8f0; margin-top: 2rem; padding-top: 0.75rem; }
-        .footnote-definition p { display: inline; }
-        sup.footnote-reference a { text-decoration: none; color: #0d9488; font-weight: 600; }
+        li.task-list-item input[type="checkbox"] { margin: 0; pointer-events: none; accent-color: #6366f1; }
 
-        /* TOC & Pagination */
-        .toc { margin: 1.5rem 0; padding: 1rem 1.25rem; border: 1px solid #e2e8f0; border-radius: 8px; background: #f8fafc; }
+        /* ---------- Footnotes ---------- */
+        .footnote-definition {
+            font-size: 0.85rem; color: #888;
+            border-top: 1px solid rgba(255,255,255,0.06);
+            margin-top: 2rem; padding-top: 0.75rem;
+        }
+        .footnote-definition p { display: inline; }
+        sup.footnote-reference a { text-decoration: none; color: #818cf8; font-weight: 600; }
+
+        /* ---------- TOC ---------- */
+        .toc {
+            margin: 1.5rem 0; padding: 1rem 1.25rem;
+            border: 1px solid rgba(255,255,255,0.06); border-radius: 12px;
+            background: rgba(255,255,255,0.02);
+        }
         .toc > ul { margin: 0; padding-left: 1.25rem; }
         .toc ul ul { padding-left: 1rem; }
         .toc li { margin: 0.25rem 0; }
-        .toc a { text-decoration: none; }
-        .toc a:hover { text-decoration: underline; }
-        .pagination { display: flex; justify-content: space-between; align-items: center; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #e2e8f0; }
-        .pagination a { text-decoration: none; }
-        .pagination a:hover { text-decoration: underline; }
-        .pagination span { color: #94a3b8; font-size: 0.9rem; }
+        .toc a { text-decoration: none; color: #888; transition: color 0.15s; }
+        .toc a:hover { color: #818cf8; text-decoration: underline; }
 
-        /* Footer */
-        .site-footer { max-width: 1100px; margin: 4rem auto 0; padding: 1.5rem 1.5rem; border-top: 1px solid #e2e8f0; color: #94a3b8; font-size: 0.85rem; }
+        /* ---------- Pagination ---------- */
+        .pagination {
+            display: flex; justify-content: space-between; align-items: center;
+            margin-top: 2.5rem; padding-top: 1.25rem;
+            border-top: 1px solid rgba(255,255,255,0.06);
+        }
+        .pagination a {
+            text-decoration: none; color: #818cf8;
+            padding: 0.5rem 1rem; border-radius: 8px;
+            border: 1px solid rgba(99,102,241,0.2);
+            transition: background 0.2s, border-color 0.2s;
+        }
+        .pagination a:hover { background: rgba(99,102,241,0.08); border-color: rgba(99,102,241,0.4); }
+        .pagination span { color: #555; font-size: 0.9rem; }
+
+        /* ---------- Footer ---------- */
+        .site-footer {
+            max-width: 1100px; margin: 5rem auto 0;
+            padding: 2rem 1.5rem;
+            border-top: 1px solid rgba(255,255,255,0.06);
+            color: #555; font-size: 0.85rem;
+        }
         .site-footer nav { margin-bottom: 0.5rem; }
-        .site-footer nav a { color: #64748b; text-decoration: none; }
-        .site-footer nav a:hover { color: #0d9488; }
+        .site-footer nav a { color: #666; text-decoration: none; transition: color 0.2s; }
+        .site-footer nav a:hover { color: #818cf8; }
 
-        /* Accessibility */
-        .skip-link { position: absolute; top: -100%; left: 0; padding: 0.5rem 1rem; background: #0d9488; color: #fff; z-index: 100; text-decoration: none; border-radius: 0 0 8px 0; }
+        /* ---------- Code Copy Button ---------- */
+        .code-block-wrapper { position: relative; }
+        .code-block-wrapper .copy-button {
+            position: absolute; top: 0.5rem; right: 0.5rem;
+            background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.08);
+            color: #888; padding: 0.25rem 0.5rem; border-radius: 6px;
+            font-size: 0.75rem; cursor: pointer; transition: background 0.2s, color 0.2s;
+        }
+        .code-block-wrapper .copy-button:hover { background: rgba(99,102,241,0.15); color: #818cf8; }
+
+        /* ---------- Accessibility ---------- */
+        .skip-link {
+            position: absolute; top: -100%; left: 0;
+            padding: 0.5rem 1rem; z-index: 200; text-decoration: none;
+            background: linear-gradient(135deg, #6366f1, #a855f7);
+            color: #fff; border-radius: 0 0 10px 0;
+            font-weight: 600;
+        }
         .skip-link:focus { top: 0; }
-        :focus-visible { outline: 2px solid #0d9488; outline-offset: 2px; }
-        @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } }
+        :focus-visible { outline: 2px solid #6366f1; outline-offset: 2px; }
+
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                animation-duration: 0.01ms !important;
+                transition-duration: 0.01ms !important;
+                scroll-behavior: auto !important;
+            }
+        }
+
+        /* ---------- Responsive ---------- */
         @media (max-width: 700px) {
             .hero h2 { font-size: 2rem; }
+            .hero { padding: 3rem 1.5rem 2rem; }
             .article-grid { grid-template-columns: 1fr; }
             .site-header { flex-direction: column; align-items: flex-start; }
+            .header-right { width: 100%; flex-wrap: wrap; }
+            .search-form input { width: 100%; }
+            #search-results { right: 0; left: 0; width: auto; }
+            .cert-grid { grid-template-columns: 1fr; }
         }
     </style>
     {% block extra_css %}{% endblock %}
@@ -294,23 +622,25 @@
     <a href="#main" class="skip-link">{{ t.skip_to_content }}</a>
     <header>
     {% block header %}
-        <div class="site-header" style="position: relative;">
-            <h1><a href="{{ lang_prefix }}/">{{ site.title }}</a></h1>
-            <div class="header-right">
-                {% if data.nav %}
-                <nav class="site-nav" aria-label="Main navigation">
-                    {% for item in data.nav %}{% if item.external %}<a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.title }}</a>{% else %}<a href="{{ lang_prefix }}{{ item.url }}">{{ item.title }}</a>{% endif %}{% endfor %}
-                </nav>
-                {% endif %}
-                {% if translations | length > 1 %}
-                <nav class="lang-switcher">
-                    {% for t in translations %}{% if t.lang == lang %}<strong>{{ t.lang | upper }}</strong>{% else %}<a href="{{ t.url }}">{{ t.lang | upper }}</a>{% endif %}{% endfor %}
-                </nav>
-                {% endif %}
-                <form class="search-form" role="search" aria-label="{{ t.search_label }}" onsubmit="return false">
-                    <input type="search" id="search-input" placeholder="{{ t.search_placeholder }}" autocomplete="off" aria-label="{{ t.search_label }}">
-                </form>
-                <div id="search-results" aria-live="polite"></div>
+        <div class="site-header-wrap">
+            <div class="site-header" style="position: relative;">
+                <h1><a href="{{ lang_prefix }}/">{{ site.title }}</a></h1>
+                <div class="header-right">
+                    {% if data.nav %}
+                    <nav class="site-nav" aria-label="Main navigation">
+                        {% for item in data.nav %}{% if item.external %}<a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.title }}</a>{% else %}<a href="{{ lang_prefix }}{{ item.url }}">{{ item.title }}</a>{% endif %}{% endfor %}
+                    </nav>
+                    {% endif %}
+                    {% if translations | length > 1 %}
+                    <nav class="lang-switcher">
+                        {% for t in translations %}{% if t.lang == lang %}<strong>{{ t.lang | upper }}</strong>{% else %}<a href="{{ t.url }}">{{ t.lang | upper }}</a>{% endif %}{% endfor %}
+                    </nav>
+                    {% endif %}
+                    <form class="search-form" role="search" aria-label="{{ t.search_label }}" onsubmit="return false">
+                        <input type="search" id="search-input" placeholder="{{ t.search_placeholder }}" autocomplete="off" aria-label="{{ t.search_label }}">
+                    </form>
+                    <div id="search-results" aria-live="polite"></div>
+                </div>
             </div>
         </div>
     {% endblock %}

--- a/src/themes/landing.tera
+++ b/src/themes/landing.tera
@@ -11,13 +11,16 @@
     <meta property="og:url" content="{{ site.base_url }}{{ page.url | default(value='/') }}">
     <meta property="og:title" content="{{ page.title | default(value=site.title) }}">
     <meta property="og:description" content="{{ page.description | default(value=site.description) }}">
-    {% if page.image %}<meta property="og:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    {% if page.image %}{% set _abs_image = page.image %}{% if not page.image is starting_with("http") %}{% set _abs_image = site.base_url ~ page.image %}{% endif %}<meta property="og:image" content="{{ _abs_image }}">
+    <meta property="og:image:width" content="1200"><meta property="og:image:height" content="630">{% endif %}
     <meta property="og:site_name" content="{{ site.title }}">
     <meta property="og:locale" content="{{ lang }}">
+    {% if page.collection and page.date %}<meta property="article:published_time" content="{{ page.date }}">{% endif %}
+    {% if page.collection and page.updated %}<meta property="article:modified_time" content="{{ page.updated }}">{% endif %}
     <meta name="twitter:card" content="{% if page.image %}summary_large_image{% else %}summary{% endif %}">
     <meta name="twitter:title" content="{{ page.title | default(value=site.title) }}">
     <meta name="twitter:description" content="{{ page.description | default(value=site.description) }}">
-    {% if page.image %}<meta name="twitter:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    {% if page.image %}<meta name="twitter:image" content="{{ _abs_image }}">{% endif %}
     {% if page.robots %}<meta name="robots" content="{{ page.robots }}">{% endif %}
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ lang_prefix }}/feed.xml">
     <link rel="alternate" type="text/plain" title="LLM Summary" href="{{ lang_prefix }}/llms.txt">
@@ -32,6 +35,9 @@
     {% else %}{"@context":"https://schema.org","@type":"WebSite","name":{{ site.title | json_encode() }},"description":{{ site.description | json_encode() }},"url":{{ site.base_url | json_encode() }}}
     {% endif %}
     </script>
+    {% if page.collection %}{% set _bc_col_url = site.base_url ~ lang_prefix ~ "/" ~ page.collection %}<script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
+    </script>{% endif %}
     <style>
         *, *::before, *::after { box-sizing: border-box; }
         body { margin: 0; padding: 0; font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; color: #1a1a2e; background: #fff; }

--- a/src/themes/landing.tera
+++ b/src/themes/landing.tera
@@ -38,271 +38,440 @@
     {% if page.collection %}{% set _bc_col_url = site.base_url ~ lang_prefix ~ "/" ~ page.collection %}<script type="application/ld+json">
     {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
     </script>{% endif %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;1,9..144,400&family=Outfit:wght@400;500;600;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
     <style>
         /* ============================================
-           LANDING THEME — Modern SaaS / Product Marketing
-           Near-black bg, indigo-purple-pink gradient accent,
-           glassmorphism nav, glow effects, grid pattern.
+           PRISM — 2026 Premium Landing Theme
+           Warm cream + indigo accent + orange CTAs.
+           Fraunces display serif, Outfit body sans.
+           Bento article grid, multi-column stats.
            ============================================ */
 
+        :root {
+            --bg: #faf8f5;
+            --bg-hero: linear-gradient(160deg, #f0ecfa 0%, #fef7ed 40%, #fdf2f8 70%, #faf8f5 100%);
+            --surface: #ffffff;
+            --surface-hover: #fefefe;
+            --text: #1b1b1f;
+            --text-bright: #0d0d0f;
+            --dim: #636370;
+            --muted: #9e9ea8;
+            --accent: #4f46e5;
+            --accent-light: #6366f1;
+            --accent-subtle: rgba(79,70,229,0.06);
+            --accent-glow: rgba(79,70,229,0.12);
+            --pop: #ea580c;
+            --pop-light: #f97316;
+            --pop-subtle: rgba(234,88,12,0.06);
+            --green: #16a34a;
+            --green-subtle: rgba(22,163,74,0.06);
+            --blue: #2563eb;
+            --blue-subtle: rgba(37,99,235,0.06);
+            --red: #dc2626;
+            --red-subtle: rgba(220,38,38,0.06);
+            --border: rgba(0,0,0,0.07);
+            --border-hover: rgba(0,0,0,0.14);
+            --radius: 16px;
+            --radius-sm: 8px;
+            --radius-lg: 24px;
+            --shadow-sm: 0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.03);
+            --shadow-md: 0 4px 20px rgba(0,0,0,0.06), 0 2px 6px rgba(0,0,0,0.03);
+            --shadow-lg: 0 16px 50px rgba(0,0,0,0.08), 0 6px 12px rgba(0,0,0,0.03);
+        }
+
         *, *::before, *::after { box-sizing: border-box; }
+        ::selection { background: rgba(79,70,229,0.15); color: var(--text-bright); }
 
         body {
             margin: 0; padding: 0;
-            font-family: system-ui, -apple-system, sans-serif;
-            line-height: 1.7; color: #f5f5f5; background: #050505;
-            background-image:
-                linear-gradient(rgba(255,255,255,0.02) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(255,255,255,0.02) 1px, transparent 1px);
-            background-size: 60px 60px;
+            font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+            font-size: 1rem; line-height: 1.7;
+            color: var(--text); background-color: var(--bg);
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
         }
 
-        a { color: #818cf8; text-decoration: none; transition: color 0.2s; }
-        a:hover { color: #a78bfa; }
+        ::-webkit-scrollbar { width: 8px; }
+        ::-webkit-scrollbar-track { background: var(--bg); }
+        ::-webkit-scrollbar-thumb { background: rgba(0,0,0,0.12); border-radius: 4px; }
+        ::-webkit-scrollbar-thumb:hover { background: rgba(0,0,0,0.2); }
 
-        /* ---------- Glassmorphism Sticky Nav ---------- */
+        a { color: var(--accent); text-decoration: none; transition: color 0.2s; }
+        a:hover { color: var(--accent-light); }
+
+        /* ---------- Sticky Header ---------- */
         .site-header-wrap {
             position: sticky; top: 0; z-index: 100;
-            backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
-            background: rgba(5,5,5,0.8);
-            border-bottom: 1px solid rgba(255,255,255,0.06);
+            background: rgba(250,248,245,0.82);
+            backdrop-filter: blur(16px) saturate(180%);
+            -webkit-backdrop-filter: blur(16px) saturate(180%);
+            border-bottom: 1px solid var(--border);
         }
         .site-header {
-            max-width: 1100px; margin: 0 auto;
-            padding: 0.9rem 1.5rem;
+            max-width: 1200px; margin: 0 auto;
+            padding: 0.85rem 2rem;
             display: flex; align-items: center; justify-content: space-between;
             flex-wrap: wrap; gap: 0.75rem;
         }
-        .site-header h1 { margin: 0; font-size: 1.25rem; font-weight: 700; }
+        .site-header h1 { margin: 0; font-size: 1.3rem; }
         .site-header h1 a {
+            font-family: 'Fraunces', Georgia, serif;
+            font-weight: 600;
+            color: var(--text-bright);
             text-decoration: none;
-            background: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
-            -webkit-background-clip: text; background-clip: text;
-            -webkit-text-fill-color: transparent;
+            letter-spacing: -0.02em;
         }
         .site-header p { display: none; }
         .header-right { display: flex; align-items: center; gap: 1rem; }
 
-        nav.site-nav { display: flex; gap: 0.2rem; }
+        nav.site-nav { display: flex; gap: 0.15rem; }
         nav.site-nav a {
-            text-decoration: none; font-weight: 500; font-size: 0.9rem;
-            color: #888; padding: 0.35rem 0.75rem; border-radius: 6px;
+            text-decoration: none; font-weight: 500; font-size: 0.88rem;
+            color: var(--dim); padding: 0.35rem 0.75rem; border-radius: var(--radius-sm);
             transition: color 0.2s, background 0.2s;
         }
-        nav.site-nav a:hover { color: #f5f5f5; background: rgba(255,255,255,0.06); }
+        nav.site-nav a:hover { color: var(--text); background: rgba(0,0,0,0.04); }
 
         .lang-switcher { display: inline-flex; gap: 0.35rem; font-size: 0.8rem; }
         .lang-switcher a {
-            text-decoration: none; color: #666;
-            padding: 0.15rem 0.5rem; border-radius: 4px;
-            border: 1px solid rgba(255,255,255,0.08);
+            text-decoration: none; color: var(--muted);
+            padding: 0.15rem 0.5rem; border-radius: 6px;
+            border: 1px solid var(--border);
             transition: border-color 0.2s, color 0.2s;
         }
-        .lang-switcher a:hover { border-color: #6366f1; color: #818cf8; }
+        .lang-switcher a:hover { border-color: var(--accent); color: var(--accent); }
         .lang-switcher strong {
-            padding: 0.15rem 0.5rem; border-radius: 4px;
-            background: linear-gradient(135deg, #6366f1, #a855f7);
-            color: #fff; font-size: 0.8rem;
+            padding: 0.15rem 0.5rem; border-radius: 6px;
+            background: var(--accent); color: #fff; font-size: 0.8rem;
         }
 
-        /* ---------- Hero Section ---------- */
-        .hero {
+        /* ---------- Homepage Content ---------- */
+        .homepage-content {
             position: relative;
-            max-width: 1100px; margin: 0 auto;
-            padding: 5rem 1.5rem 4rem; text-align: center;
+            max-width: 1200px; margin: 0 auto;
+            padding: 4rem 2rem 2rem;
         }
-        .hero::before {
-            content: ''; position: absolute; top: -80px; left: 50%;
-            transform: translateX(-50%); width: 100%; height: 600px;
-            background: radial-gradient(600px circle at 50% 0%, rgba(99,102,241,0.15), transparent 70%);
-            pointer-events: none; z-index: 0;
-        }
-        .hero > * { position: relative; z-index: 1; }
-        .hero h2 {
-            font-size: clamp(2.2rem, 5vw, 3.5rem); font-weight: 800;
-            line-height: 1.1; margin: 0 0 1.25rem; letter-spacing: -0.03em;
-            background: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
-            -webkit-background-clip: text; background-clip: text;
-            -webkit-text-fill-color: transparent;
-        }
-        .hero p { font-size: 1.2rem; color: #888; max-width: 640px; margin: 0 auto 2.5rem; line-height: 1.7; }
-        .hero .cta-group { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
-
-        .cta-primary {
-            display: inline-block; color: #fff;
-            padding: 0.8rem 2.25rem; border-radius: 10px;
-            font-weight: 600; font-size: 1rem; text-decoration: none;
-            background: linear-gradient(135deg, #6366f1, #a855f7);
-            box-shadow: 0 0 20px rgba(99,102,241,0.25);
-            transition: box-shadow 0.3s, transform 0.2s;
-        }
-        .cta-primary:hover {
-            color: #fff; text-decoration: none;
-            box-shadow: 0 0 30px rgba(99,102,241,0.4);
-            transform: scale(1.02);
-        }
-        .cta-secondary {
-            display: inline-block; color: #818cf8;
-            padding: 0.8rem 2.25rem; border-radius: 10px;
-            font-weight: 600; font-size: 1rem; text-decoration: none;
-            border: 1px solid rgba(99,102,241,0.3);
-            background: rgba(99,102,241,0.05);
-            transition: border-color 0.3s, background 0.3s;
-        }
-        .cta-secondary:hover {
-            text-decoration: none; border-color: rgba(99,102,241,0.5);
-            background: rgba(99,102,241,0.1);
+        /* Soft gradient glow behind hero */
+        .homepage-content::before {
+            content: ''; position: absolute;
+            top: -6rem; left: 50%; transform: translateX(-50%);
+            width: 140%; height: 700px;
+            background: radial-gradient(ellipse at 35% 40%, rgba(99,102,241,0.09) 0%, transparent 55%),
+                        radial-gradient(ellipse at 65% 60%, rgba(234,88,12,0.06) 0%, transparent 50%);
+            pointer-events: none; z-index: -1;
         }
 
-        /* ---------- Content Wrapper ---------- */
-        .content-wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem; }
-
-        /* ---------- Sections ---------- */
-        .section { padding: 3.5rem 0; }
-        .section:nth-child(even) { background: rgba(255,255,255,0.015); }
-        .section-inner { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem; }
-        .section h2 {
-            font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.12em;
-            font-weight: 700; margin: 0 0 1.75rem;
-            background: linear-gradient(135deg, #6366f1, #a855f7);
-            -webkit-background-clip: text; background-clip: text;
-            -webkit-text-fill-color: transparent;
+        /* Main headline */
+        .homepage-content > h1:first-child {
+            font-family: 'Fraunces', Georgia, serif;
+            font-size: clamp(2.6rem, 5.5vw, 4.2rem);
+            font-weight: 600; font-style: normal;
+            line-height: 1.08; letter-spacing: -0.025em;
+            text-align: center;
+            margin: 0 auto 1.5rem;
+            max-width: 800px;
+            color: var(--text-bright);
+            animation: fadeInUp 0.7s cubic-bezier(0.16,1,0.3,1) 0.1s both;
         }
 
-        /* ---------- Article Grid (Index/Listings) ---------- */
-        .article-grid {
+        /* Paragraphs in homepage (intro, CTA links) */
+        .homepage-content > p {
+            text-align: center;
+            max-width: 640px; margin: 0 auto 1rem;
+            color: var(--dim); font-size: 1.05rem; line-height: 1.8;
+        }
+        .homepage-content > p strong { color: var(--text); }
+        .homepage-content > p a {
+            font-weight: 600;
+            padding: 0.1rem 0;
+            border-bottom: 2px solid var(--accent-subtle);
+            transition: border-color 0.2s, color 0.2s;
+        }
+        .homepage-content > p a:hover { border-color: var(--accent); }
+
+        /* Horizontal rules = section breaks */
+        .homepage-content > hr {
+            border: none; height: 1px;
+            background: var(--border);
+            margin: 3.5rem 0;
+            max-width: 200px;
+            margin-left: auto; margin-right: auto;
+        }
+
+        /* Section headings */
+        .homepage-content > h2 {
+            font-family: 'Fraunces', Georgia, serif;
+            font-size: 1.6rem; font-weight: 500;
+            text-align: center; letter-spacing: -0.01em;
+            margin: 0 0 2rem;
+            color: var(--text-bright);
+        }
+
+        /* Feature h3 headings as inline cards */
+        .homepage-content > h3 {
+            font-family: 'Outfit', system-ui, sans-serif;
+            font-size: 1.05rem; font-weight: 700;
+            color: var(--text-bright);
+            margin: 0 0 0.35rem;
+            padding-left: 1.25rem;
+            border-left: 3px solid var(--accent);
+        }
+        .homepage-content > h3 + p {
+            text-align: left;
+            max-width: none;
+            padding-left: 1.25rem;
+            margin-bottom: 1.75rem;
+            color: var(--dim);
+            font-size: 0.95rem;
+        }
+
+        /* Stats list → 4-column grid */
+        .homepage-content > ul {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-            gap: 1.5rem;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 1rem;
+            list-style: none; padding: 0;
+            margin: 1.5rem 0 2rem;
         }
-        article {
-            background: rgba(255,255,255,0.03);
-            border: 1px solid rgba(255,255,255,0.06);
-            border-radius: 14px; padding: 1.75rem;
-            transition: border-color 0.3s, box-shadow 0.3s, transform 0.2s;
+        .homepage-content > ul > li {
+            text-align: center;
+            padding: 1.75rem 1rem;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-sm);
+            transition: box-shadow 0.3s, transform 0.3s;
         }
-        article:hover {
-            border-color: rgba(99,102,241,0.3);
-            box-shadow: 0 0 30px rgba(99,102,241,0.08);
+        .homepage-content > ul > li:hover {
+            box-shadow: var(--shadow-md);
             transform: translateY(-2px);
         }
-        article h3 { margin: 0 0 0.4rem; font-size: 1.1rem; font-weight: 600; }
-        article h3 a { color: #f5f5f5; text-decoration: none; transition: color 0.2s; }
-        article h3 a:hover { color: #818cf8; }
-        article p { color: #888; font-size: 0.9rem; margin: 0.5rem 0 0; }
+        .homepage-content > ul > li strong {
+            display: block;
+            font-family: 'Fraunces', Georgia, serif;
+            font-size: 2.2rem; font-weight: 700;
+            color: var(--accent);
+            line-height: 1; margin-bottom: 0.4rem;
+        }
+
+        /* Testimonial blockquotes */
+        .homepage-content > blockquote {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            padding: 1.75rem 2rem;
+            margin: 0 0 1rem;
+            border-left: 3px solid var(--accent);
+            box-shadow: var(--shadow-sm);
+            font-style: italic;
+            color: var(--dim);
+            text-align: left; max-width: none;
+        }
+        .homepage-content > blockquote p:first-child { margin-top: 0; }
+        .homepage-content > blockquote p:last-child { margin-bottom: 0; }
+        .homepage-content > blockquote strong { color: var(--text); font-style: normal; }
+
+        /* Code blocks in homepage */
+        .homepage-content > pre {
+            max-width: 600px;
+            margin: 1.5rem auto 1.5rem;
+        }
+
+        /* ---------- Collection Sections (Bento Grid) ---------- */
+        main > section {
+            max-width: 1200px; margin: 0 auto 3rem;
+            padding: 0 2rem;
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 1.25rem;
+        }
+        main > section > h2 {
+            grid-column: 1 / -1;
+            font-size: 0.72rem; text-transform: uppercase;
+            letter-spacing: 0.14em; font-weight: 700;
+            color: var(--muted); margin: 0 0 0.5rem;
+        }
+        main > section > p {
+            grid-column: 1 / -1;
+            color: var(--dim);
+        }
+
+        /* Featured first card spans 2 columns */
+        main > section > article:first-of-type {
+            grid-column: 1 / 3;
+            grid-row: span 2;
+            padding: 2.5rem;
+            display: flex; flex-direction: column; justify-content: center;
+        }
+        main > section > article:first-of-type h3 {
+            font-family: 'Fraunces', Georgia, serif;
+            font-size: 1.5rem; font-weight: 500;
+            line-height: 1.2; letter-spacing: -0.01em;
+        }
+        main > section > article:first-of-type p,
+        main > section > article:first-of-type .excerpt {
+            font-size: 1rem; line-height: 1.75;
+        }
+
+        /* Article cards */
+        section > article {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius); padding: 1.75rem;
+            box-shadow: var(--shadow-sm);
+            transition: box-shadow 0.35s cubic-bezier(0.4,0,0.2,1),
+                        border-color 0.35s cubic-bezier(0.4,0,0.2,1),
+                        transform 0.3s cubic-bezier(0.4,0,0.2,1);
+            animation: fadeInUp 0.6s cubic-bezier(0.16,1,0.3,1) both;
+        }
+        section > article:nth-child(2) { animation-delay: 0.04s; }
+        section > article:nth-child(3) { animation-delay: 0.08s; }
+        section > article:nth-child(4) { animation-delay: 0.12s; }
+        section > article:nth-child(5) { animation-delay: 0.16s; }
+        section > article:nth-child(6) { animation-delay: 0.20s; }
+        section > article:hover {
+            box-shadow: var(--shadow-lg);
+            border-color: var(--border-hover);
+            transform: translateY(-4px);
+        }
+        section > article h3 { margin: 0 0 0.35rem; font-size: 1.1rem; font-weight: 600; }
+        section > article h3 a { color: var(--text-bright); text-decoration: none; transition: color 0.2s; }
+        section > article h3 a:hover { color: var(--accent); }
+        section > article time { font-size: 0.78rem; color: var(--muted); display: block; margin-bottom: 0.4rem; }
+        section > article p,
+        section > article .excerpt { color: var(--dim); font-size: 0.9rem; margin: 0.3rem 0 0; }
 
         /* ---------- Single Article (Reading View) ---------- */
         main > article {
-            max-width: 720px; margin: 2.5rem auto;
-            border: none; box-shadow: none; padding: 0 1.5rem;
-            background: transparent;
+            max-width: 720px; margin: 3rem auto;
+            padding: 0 2rem;
         }
-        main > article:hover { border-color: transparent; box-shadow: none; transform: none; }
         main > article h1 {
-            font-size: clamp(1.8rem, 4vw, 2.5rem); font-weight: 800;
-            margin: 0 0 0.5rem; line-height: 1.15; letter-spacing: -0.02em;
-            background: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
-            -webkit-background-clip: text; background-clip: text;
-            -webkit-text-fill-color: transparent;
+            font-family: 'Fraunces', Georgia, serif;
+            font-size: clamp(2rem, 4.5vw, 2.8rem);
+            font-weight: 500; line-height: 1.12;
+            letter-spacing: -0.02em;
+            margin: 0 0 0.6rem;
+            color: var(--text-bright);
         }
-        main > article h2 { font-size: 1.4rem; font-weight: 700; margin-top: 2.5rem; color: #f5f5f5; }
-        main > article h3 { font-size: 1.1rem; font-weight: 600; margin-top: 1.5rem; color: #e0e0e0; }
+        main > article h2 {
+            font-family: 'Fraunces', Georgia, serif;
+            font-size: 1.4rem; font-weight: 500;
+            margin-top: 2.5rem; color: var(--text-bright);
+            padding-bottom: 0.4rem;
+            border-bottom: 1px solid var(--border);
+        }
+        main > article h3 {
+            font-size: 1.05rem; font-weight: 700;
+            margin-top: 1.5rem; color: var(--text);
+        }
 
-        time { font-size: 0.8rem; color: #666; }
-        .reading-time { color: #666; font-size: 0.85rem; }
+        time { font-size: 0.8rem; color: var(--muted); }
+        .reading-time { color: var(--muted); font-size: 0.85rem; }
 
         .tags a, .tags span {
-            background: rgba(99,102,241,0.08);
-            border: 1px solid rgba(99,102,241,0.15);
-            color: #818cf8; padding: 0.1rem 0.6rem; border-radius: 9999px;
-            margin-right: 0.3rem; font-size: 0.75rem; font-weight: 600;
-            text-decoration: none; transition: background 0.2s, border-color 0.2s;
+            background: var(--accent-subtle);
+            border: 1px solid rgba(79,70,229,0.12);
+            color: var(--accent); padding: 0.12rem 0.6rem;
+            border-radius: 9999px; margin-right: 0.3rem;
+            font-size: 0.72rem; font-weight: 600;
+            text-decoration: none; letter-spacing: 0.01em;
+            transition: background 0.2s, border-color 0.2s;
         }
-        .tags a:hover { background: rgba(99,102,241,0.15); border-color: rgba(99,102,241,0.3); }
+        .tags a:hover { background: rgba(79,70,229,0.1); border-color: rgba(79,70,229,0.25); }
 
         /* ---------- Search ---------- */
         .search-form { margin: 0; }
         .search-form input {
-            width: 200px; padding: 0.4rem 0.75rem;
-            border: 1px solid rgba(255,255,255,0.08); border-radius: 8px;
+            width: 200px; padding: 0.4rem 0.8rem;
+            border: 1px solid var(--border); border-radius: var(--radius-sm);
             font-size: 0.85rem; font-family: inherit;
-            background: rgba(255,255,255,0.04); color: #f5f5f5;
+            background: var(--surface); color: var(--text);
+            box-shadow: var(--shadow-sm);
             transition: border-color 0.2s, box-shadow 0.2s;
         }
-        .search-form input::placeholder { color: #555; }
+        .search-form input::placeholder { color: var(--muted); }
         .search-form input:focus {
-            outline: none; border-color: rgba(99,102,241,0.5);
-            background: rgba(255,255,255,0.06);
-            box-shadow: 0 0 0 3px rgba(99,102,241,0.15);
+            outline: none; border-color: var(--accent);
+            box-shadow: 0 0 0 3px var(--accent-glow);
         }
         #search-results {
-            position: absolute; right: 1.5rem; top: 100%; width: 380px;
-            border: 1px solid rgba(255,255,255,0.08); border-radius: 12px;
-            background: rgba(10,10,10,0.95); backdrop-filter: blur(12px);
-            box-shadow: 0 8px 40px rgba(0,0,0,0.5); z-index: 50; overflow: hidden;
+            position: absolute; right: 2rem; top: 100%; width: 400px;
+            border: 1px solid var(--border); border-radius: var(--radius);
+            background: rgba(255,255,255,0.97);
+            backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px);
+            box-shadow: var(--shadow-lg); z-index: 50; overflow: hidden;
         }
         #search-results a {
             display: block; padding: 0.65rem 1rem; text-decoration: none;
-            border-bottom: 1px solid rgba(255,255,255,0.04); font-size: 0.9rem;
-            color: #818cf8; transition: background 0.15s;
+            border-bottom: 1px solid rgba(0,0,0,0.04); font-size: 0.9rem;
+            color: var(--accent); transition: background 0.15s;
         }
         #search-results a:last-child { border-bottom: none; }
-        #search-results a:hover { background: rgba(99,102,241,0.08); }
-        #search-results strong { color: #f5f5f5; }
-        #search-results .result-meta { font-size: 0.75rem; color: #555; margin-top: 0.15rem; }
-        #search-results .no-results { padding: 0.65rem 1rem; color: #555; font-size: 0.9rem; }
+        #search-results a:hover { background: var(--accent-subtle); }
+        #search-results strong { color: var(--text-bright); }
+        #search-results .result-meta { font-size: 0.75rem; color: var(--muted); margin-top: 0.12rem; }
+        #search-results .no-results { padding: 0.65rem 1rem; color: var(--muted); font-size: 0.9rem; }
 
         /* ---------- Typography ---------- */
         pre {
-            background: rgba(255,255,255,0.03); color: #e2e8f0;
-            padding: 1.25rem; border-radius: 10px; overflow-x: auto;
-            border: 1px solid rgba(255,255,255,0.06);
-            font-size: 0.9em;
+            background: #1e1e2e; color: #cdd6f4;
+            padding: 1.15rem 1.4rem; border-radius: var(--radius);
+            overflow-x: auto; border: 1px solid rgba(0,0,0,0.1);
+            font-size: 0.88em;
+            font-family: 'JetBrains Mono', 'Fira Code', monospace;
+            box-shadow: var(--shadow-md);
         }
         pre code { background: none; color: inherit; font-size: inherit; padding: 0; border: none; }
         code {
-            font-size: 0.9em; padding: 0.15em 0.4em; border-radius: 5px;
-            background: rgba(99,102,241,0.1); color: #a5b4fc;
-            border: 1px solid rgba(99,102,241,0.1);
+            font-size: 0.88em; padding: 0.12em 0.4em; border-radius: 5px;
+            background: var(--accent-subtle); color: var(--accent);
+            border: 1px solid rgba(79,70,229,0.1);
+            font-family: 'JetBrains Mono', 'Fira Code', monospace;
         }
         blockquote {
-            border-left: 3px solid #6366f1; margin-left: 0;
-            padding: 0.75rem 1.25rem; border-radius: 0 10px 10px 0;
-            background: rgba(99,102,241,0.05); color: #aaa;
+            border-left: 3px solid var(--accent); margin-left: 0;
+            padding: 0.75rem 1.5rem;
+            border-radius: 0 var(--radius) var(--radius) 0;
+            background: var(--accent-subtle);
+            color: var(--dim); font-style: italic;
         }
         blockquote p:first-child { margin-top: 0; }
         blockquote p:last-child { margin-bottom: 0; }
-        img { max-width: 100%; height: auto; border-radius: 10px; }
+        img { max-width: 100%; height: auto; border-radius: var(--radius); }
         figure { margin: 2rem 0; }
         figure img { display: block; }
-        figcaption { font-size: 0.85rem; color: #666; margin-top: 0.5rem; text-align: center; }
-        hr { border: none; border-top: 1px solid rgba(255,255,255,0.06); margin: 2.5rem 0; }
+        figcaption {
+            font-size: 0.82rem; color: var(--muted);
+            margin-top: 0.5rem; text-align: center; font-style: italic;
+        }
+        hr { border: none; border-top: 1px solid var(--border); margin: 2.5rem 0; }
 
         /* ---------- Embeds ---------- */
         .video-embed {
             position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;
-            margin: 2rem 0; border-radius: 12px;
-            border: 1px solid rgba(255,255,255,0.06);
+            margin: 2rem 0; border-radius: var(--radius);
+            border: 1px solid var(--border); box-shadow: var(--shadow-md);
         }
         .video-embed iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
         .gist-embed { margin: 1.5rem 0; }
 
         /* ---------- Callouts ---------- */
         .callout {
-            padding: 1rem 1.25rem; margin: 1.5rem 0; border-radius: 10px;
-            border-left: 3px solid #6366f1;
-            background: rgba(99,102,241,0.05);
-            border: 1px solid rgba(255,255,255,0.06);
-            border-left-width: 3px;
+            padding: 1.15rem 1.35rem; margin: 1.5rem 0;
+            border-radius: var(--radius);
+            background: var(--surface);
+            border: 1px solid var(--border); border-left-width: 3px;
+            box-shadow: var(--shadow-sm);
         }
-        .callout-title { font-weight: 700; margin-bottom: 0.5rem; font-size: 0.85rem; color: #f5f5f5; }
-        .callout-info { border-left-color: #6366f1; }
-        .callout-warning { border-left-color: #f59e0b; background: rgba(245,158,11,0.05); }
-        .callout-danger { border-left-color: #ef4444; background: rgba(239,68,68,0.05); }
-        .callout-tip { border-left-color: #22c55e; background: rgba(34,197,94,0.05); }
-        .callout-note { border-left-color: #888; background: rgba(136,136,136,0.05); }
+        .callout-title { font-weight: 700; margin-bottom: 0.5rem; font-size: 0.85rem; color: var(--text-bright); }
+        .callout-info { border-left-color: var(--accent); background: rgba(79,70,229,0.03); }
+        .callout-warning { border-left-color: #d97706; background: rgba(217,119,6,0.03); }
+        .callout-danger { border-left-color: var(--red); background: rgba(220,38,38,0.03); }
+        .callout-tip { border-left-color: var(--green); background: rgba(22,163,74,0.03); }
+        .callout-note { border-left-color: var(--dim); }
         .callout p:last-child { margin-bottom: 0; }
 
         /* ---------- Contact Form ---------- */
@@ -310,118 +479,120 @@
         .contact-form-field { margin-bottom: 1.25rem; }
         .contact-form-field label {
             display: block; font-weight: 600; margin-bottom: 0.35rem;
-            font-size: 0.9rem; color: #ccc;
+            font-size: 0.9rem; color: var(--text);
         }
         .contact-form-field input, .contact-form-field textarea {
-            width: 100%; padding: 0.65rem 0.85rem;
-            border: 1px solid rgba(255,255,255,0.08); border-radius: 10px;
+            width: 100%; padding: 0.7rem 0.9rem;
+            border: 1px solid var(--border); border-radius: var(--radius-sm);
             font: inherit; box-sizing: border-box;
-            background: rgba(255,255,255,0.03); color: #f5f5f5;
+            background: var(--surface); color: var(--text);
+            box-shadow: var(--shadow-sm);
             transition: border-color 0.2s, box-shadow 0.2s;
         }
         .contact-form-field input:focus, .contact-form-field textarea:focus {
-            outline: none; border-color: rgba(99,102,241,0.5);
-            box-shadow: 0 0 0 3px rgba(99,102,241,0.15);
+            outline: none; border-color: var(--accent);
+            box-shadow: 0 0 0 3px var(--accent-glow);
         }
         .contact-form-submit {
-            background: linear-gradient(135deg, #6366f1, #a855f7);
-            color: #fff; border: none;
-            padding: 0.7rem 1.75rem; border-radius: 10px;
-            font: inherit; font-weight: 600; cursor: pointer;
-            box-shadow: 0 0 15px rgba(99,102,241,0.2);
-            transition: box-shadow 0.3s, transform 0.2s;
+            background: var(--pop); color: #fff; border: none;
+            padding: 0.75rem 1.8rem; border-radius: var(--radius-sm);
+            font: inherit; font-weight: 700; cursor: pointer;
+            box-shadow: 0 2px 8px rgba(234,88,12,0.2);
+            transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
         }
         .contact-form-submit:hover {
-            box-shadow: 0 0 25px rgba(99,102,241,0.4);
-            transform: scale(1.02);
+            background: var(--pop-light);
+            box-shadow: 0 4px 16px rgba(234,88,12,0.25);
+            transform: translateY(-1px);
         }
         .contact-form-honeypot { display: none; }
-        .contact-form-embed { min-height: 400px; border-radius: 10px; }
+        .contact-form-embed { min-height: 400px; border-radius: var(--radius); }
         .contact-form-error {
-            color: #f87171; background: rgba(239,68,68,0.08);
-            padding: 1rem; border-radius: 10px;
-            border-left: 3px solid #ef4444;
+            color: var(--red); background: var(--red-subtle);
+            padding: 1rem; border-radius: var(--radius);
+            border-left: 3px solid var(--red);
         }
 
         /* ---------- Trust Center ---------- */
-        .trust-hub { max-width: 1100px; margin: 0 auto; }
+        .trust-hub { max-width: 1200px; margin: 0 auto; }
         .trust-hero { margin-bottom: 2.5rem; }
         .trust-hero h1 {
-            font-size: 2.2rem; font-weight: 800; margin-bottom: 0.5rem;
-            background: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
-            -webkit-background-clip: text; background-clip: text;
-            -webkit-text-fill-color: transparent;
+            font-family: 'Fraunces', Georgia, serif;
+            font-size: 2.2rem; font-weight: 500;
+            margin-bottom: 0.5rem; color: var(--text-bright);
         }
         .trust-section { margin-bottom: 2.5rem; }
         .trust-section h2 {
-            font-size: 1.4rem; margin-bottom: 1rem; color: #f5f5f5;
-            border-bottom: 1px solid rgba(255,255,255,0.06); padding-bottom: 0.5rem;
+            font-family: 'Fraunces', Georgia, serif;
+            font-size: 1.3rem; margin-bottom: 1rem; color: var(--text-bright);
+            border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;
         }
-        .trust-breadcrumb { font-size: 0.85rem; color: #666; margin-bottom: 1.5rem; }
-        .trust-breadcrumb a { color: #818cf8; text-decoration: none; }
-        .trust-breadcrumb a:hover { color: #a78bfa; text-decoration: underline; }
-        .trust-description { color: #888; margin-bottom: 1.5rem; line-height: 1.7; }
-        .cert-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.5rem; }
+        .trust-breadcrumb { font-size: 0.85rem; color: var(--dim); margin-bottom: 1.5rem; }
+        .trust-breadcrumb a { color: var(--accent); text-decoration: none; }
+        .trust-breadcrumb a:hover { text-decoration: underline; }
+        .trust-description { color: var(--dim); margin-bottom: 1.5rem; line-height: 1.7; }
+        .cert-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.25rem; }
         .cert-card {
-            border: 1px solid rgba(255,255,255,0.06); border-radius: 14px;
-            padding: 1.5rem; background: rgba(255,255,255,0.03);
-            transition: border-color 0.3s, box-shadow 0.3s;
+            border: 1px solid var(--border); border-radius: var(--radius);
+            padding: 1.5rem; background: var(--surface);
+            box-shadow: var(--shadow-sm);
+            transition: box-shadow 0.3s, border-color 0.3s;
         }
         .cert-card:hover {
-            border-color: rgba(99,102,241,0.3);
-            box-shadow: 0 0 25px rgba(99,102,241,0.08);
+            box-shadow: var(--shadow-md);
+            border-color: var(--border-hover);
         }
         .cert-card__header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
-        .cert-card__title { font-weight: 700; font-size: 1.05rem; color: #f5f5f5; }
-        .cert-card__desc { font-size: 0.9rem; color: #888; margin-bottom: 0.75rem; }
-        .cert-card__link { font-size: 0.85rem; color: #818cf8; text-decoration: none; font-weight: 600; }
-        .cert-card__link:hover { color: #a78bfa; text-decoration: underline; }
+        .cert-card__title { font-weight: 700; font-size: 1.05rem; color: var(--text-bright); }
+        .cert-card__desc { font-size: 0.9rem; color: var(--dim); margin-bottom: 0.75rem; }
+        .cert-card__link { font-size: 0.85rem; color: var(--accent); text-decoration: none; font-weight: 600; }
+        .cert-card__link:hover { text-decoration: underline; }
         .cert-status {
             display: inline-block; font-size: 0.7rem; font-weight: 700;
             padding: 0.15rem 0.55rem; border-radius: 9999px;
             text-transform: uppercase; letter-spacing: 0.03em;
         }
-        .cert-status--active { background: rgba(34,197,94,0.12); color: #4ade80; }
-        .cert-status--in_progress { background: rgba(245,158,11,0.12); color: #fbbf24; }
-        .cert-status--planned { background: rgba(255,255,255,0.06); color: #666; }
+        .cert-status--active { background: var(--green-subtle); color: var(--green); }
+        .cert-status--in_progress { background: rgba(217,119,6,0.08); color: #b45309; }
+        .cert-status--planned { background: rgba(0,0,0,0.04); color: var(--muted); }
         .cert-detail {
             margin-bottom: 2rem; padding: 1.5rem;
-            border: 1px solid rgba(255,255,255,0.06); border-radius: 14px;
-            background: rgba(255,255,255,0.02);
+            border: 1px solid var(--border); border-radius: var(--radius);
+            background: var(--surface); box-shadow: var(--shadow-sm);
         }
-        .cert-meta { font-size: 0.9rem; color: #888; margin-bottom: 0.35rem; }
-        .cert-meta strong { color: #f5f5f5; }
-        .trust-item { padding: 0.75rem 0; border-bottom: 1px solid rgba(255,255,255,0.06); }
+        .cert-meta { font-size: 0.9rem; color: var(--dim); margin-bottom: 0.35rem; }
+        .cert-meta strong { color: var(--text-bright); }
+        .trust-item { padding: 0.75rem 0; border-bottom: 1px solid var(--border); }
         .trust-item:last-child { border-bottom: none; }
         .subprocessor-table-wrap { overflow-x: auto; margin: 1.5rem 0; }
         .subprocessor-table { border-collapse: collapse; width: 100%; }
         .subprocessor-table th, .subprocessor-table td {
-            border: 1px solid rgba(255,255,255,0.06);
+            border: 1px solid var(--border);
             padding: 0.55rem 0.85rem; text-align: left; font-size: 0.9rem;
         }
-        .subprocessor-table th { background: rgba(255,255,255,0.04); font-weight: 600; color: #f5f5f5; }
-        .subprocessor-table td { color: #888; }
+        .subprocessor-table th { background: rgba(0,0,0,0.02); font-weight: 600; color: var(--text-bright); }
+        .subprocessor-table td { color: var(--dim); }
         .faq-section { margin-top: 2rem; }
-        .faq-item { border-bottom: 1px solid rgba(255,255,255,0.06); }
-        .faq-item summary { padding: 0.75rem 0; cursor: pointer; font-weight: 500; color: #f5f5f5; transition: color 0.2s; }
-        .faq-item summary:hover { color: #818cf8; }
-        .faq-answer { padding: 0 0 1rem; color: #888; line-height: 1.7; }
+        .faq-item { border-bottom: 1px solid var(--border); }
+        .faq-item summary { padding: 0.75rem 0; cursor: pointer; font-weight: 500; color: var(--text-bright); transition: color 0.2s; }
+        .faq-item summary:hover { color: var(--accent); }
+        .faq-answer { padding: 0 0 1rem; color: var(--dim); line-height: 1.7; }
         .trust-page { margin-bottom: 2rem; }
 
         /* ---------- Changelog ---------- */
         .changelog-entry-header { margin-bottom: 1.5rem; }
-        .changelog-meta { display: flex; align-items: center; gap: 1rem; margin-top: 0.5rem; color: #666; font-size: 0.9rem; }
-        .changelog-summary { color: #888; font-size: 1.05rem; margin-bottom: 1.5rem; }
+        .changelog-meta { display: flex; align-items: center; gap: 1rem; margin-top: 0.5rem; color: var(--dim); font-size: 0.9rem; }
+        .changelog-summary { color: var(--dim); font-size: 1.05rem; margin-bottom: 1.5rem; }
         .changelog-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
         .changelog-tag {
             display: inline-block; padding: 0.15rem 0.6rem; border-radius: 9999px;
             font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em;
         }
-        .changelog-tag--new { background: rgba(34,197,94,0.12); color: #4ade80; }
-        .changelog-tag--fix { background: rgba(96,165,250,0.12); color: #60a5fa; }
-        .changelog-tag--breaking { background: rgba(248,113,113,0.12); color: #f87171; }
-        .changelog-tag--improvement { background: rgba(192,132,252,0.12); color: #c084fc; }
-        .changelog-tag--deprecated { background: rgba(255,255,255,0.06); color: #666; }
+        .changelog-tag--new { background: var(--green-subtle); color: var(--green); }
+        .changelog-tag--fix { background: var(--blue-subtle); color: var(--blue); }
+        .changelog-tag--breaking { background: var(--red-subtle); color: var(--red); }
+        .changelog-tag--improvement { background: var(--accent-subtle); color: var(--accent); }
+        .changelog-tag--deprecated { background: rgba(0,0,0,0.04); color: var(--muted); }
         .changelog-header {
             display: flex; justify-content: space-between; align-items: baseline;
             flex-wrap: wrap; gap: 1rem; margin-bottom: 2rem;
@@ -429,31 +600,32 @@
         .changelog-header h1 { margin-bottom: 0; }
         .changelog-rss {
             display: inline-flex; align-items: center; gap: 0.4rem;
-            font-size: 0.8rem; color: #666; text-decoration: none;
-            padding: 0.3rem 0.7rem; border: 1px solid rgba(255,255,255,0.08);
-            border-radius: 8px; transition: color 0.2s, border-color 0.2s;
+            font-size: 0.8rem; color: var(--dim); text-decoration: none;
+            padding: 0.3rem 0.7rem; border: 1px solid var(--border);
+            border-radius: var(--radius-sm); transition: color 0.2s, border-color 0.2s;
         }
-        .changelog-rss:hover { color: #818cf8; border-color: rgba(99,102,241,0.3); }
+        .changelog-rss:hover { color: var(--accent); border-color: rgba(79,70,229,0.25); }
         .changelog-back { margin-bottom: 1.5rem; }
-        .changelog-back a { color: #666; text-decoration: none; font-size: 0.9rem; transition: color 0.2s; }
-        .changelog-back a:hover { color: #818cf8; }
+        .changelog-back a { color: var(--dim); text-decoration: none; font-size: 0.9rem; transition: color 0.2s; }
+        .changelog-back a:hover { color: var(--accent); }
         .changelog-timeline { position: relative; padding-left: 2rem; }
         .changelog-timeline::before {
             content: ''; position: absolute; left: 0; top: 0.5rem; bottom: 0;
-            width: 2px; background: rgba(255,255,255,0.06);
+            width: 2px; background: var(--border);
         }
         .changelog-item {
             position: relative; padding: 1.25rem;
-            border: 1px solid rgba(255,255,255,0.06); border-radius: 14px;
-            background: rgba(255,255,255,0.03); margin-bottom: 1.5rem;
-            transition: border-color 0.2s;
+            border: 1px solid var(--border); border-radius: var(--radius);
+            background: var(--surface); margin-bottom: 1.5rem;
+            box-shadow: var(--shadow-sm);
+            transition: box-shadow 0.3s, border-color 0.3s;
         }
-        .changelog-item:hover { border-color: rgba(99,102,241,0.2); }
+        .changelog-item:hover { box-shadow: var(--shadow-md); border-color: var(--border-hover); }
         .changelog-item::before {
             content: ''; position: absolute; left: -2rem; top: 1.25rem;
             width: 10px; height: 10px; border-radius: 50%;
-            background: #6366f1; transform: translateX(-4px);
-            box-shadow: 0 0 10px rgba(99,102,241,0.4);
+            background: var(--accent); transform: translateX(-4px);
+            box-shadow: 0 0 0 3px var(--bg);
         }
         .changelog-item:last-child { margin-bottom: 0; }
         .changelog-item-header {
@@ -461,139 +633,143 @@
             flex-wrap: wrap; gap: 0.5rem;
         }
         .changelog-item-header h2 { margin: 0; font-size: 1.25rem; }
-        .changelog-item-header time { color: #666; font-size: 0.85rem; white-space: nowrap; }
+        .changelog-item-header time { color: var(--dim); font-size: 0.85rem; white-space: nowrap; }
         .changelog-item .changelog-tags { margin-top: 0.5rem; }
-        .changelog-item p, .changelog-item .excerpt { margin-top: 0.5rem; color: #888; }
+        .changelog-item p, .changelog-item .excerpt { margin-top: 0.5rem; color: var(--dim); }
         .changelog-feed .changelog-item::before { display: none; }
         .changelog-feed { display: flex; flex-direction: column; gap: 1.5rem; }
 
         /* ---------- Roadmap ---------- */
         .roadmap-back { margin-bottom: 1.5rem; }
-        .roadmap-back a { color: #666; text-decoration: none; font-size: 0.9rem; }
-        .roadmap-back a:hover { color: #818cf8; }
+        .roadmap-back a { color: var(--dim); text-decoration: none; font-size: 0.9rem; }
+        .roadmap-back a:hover { color: var(--accent); }
         .roadmap-entry-header { margin-bottom: 1.5rem; }
-        .roadmap-summary { color: #888; font-size: 1.05rem; margin-bottom: 1.5rem; }
+        .roadmap-summary { color: var(--dim); font-size: 1.05rem; margin-bottom: 1.5rem; }
         .roadmap-status-badges { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
         .roadmap-status {
             display: inline-block; padding: 0.2rem 0.7rem; border-radius: 9999px;
             font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em;
         }
-        .roadmap-status--planned { background: rgba(96,165,250,0.12); color: #60a5fa; }
-        .roadmap-status--in-progress { background: rgba(251,191,36,0.12); color: #fbbf24; }
-        .roadmap-status--done { background: rgba(74,222,128,0.12); color: #4ade80; }
-        .roadmap-status--cancelled { background: rgba(255,255,255,0.06); color: #555; text-decoration: line-through; }
+        .roadmap-status--planned { background: var(--blue-subtle); color: var(--blue); }
+        .roadmap-status--in-progress { background: rgba(217,119,6,0.08); color: #b45309; }
+        .roadmap-status--done { background: var(--green-subtle); color: var(--green); }
+        .roadmap-status--cancelled { background: rgba(0,0,0,0.04); color: var(--muted); text-decoration: line-through; }
         .roadmap-grouped { display: flex; flex-direction: column; gap: 2rem; }
         .roadmap-section-header { display: flex; align-items: center; gap: 0.75rem; font-size: 1.1rem; margin-bottom: 1rem; }
         .roadmap-items { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; }
         .roadmap-card {
-            padding: 1.25rem; border: 1px solid rgba(255,255,255,0.06);
-            border-radius: 14px; background: rgba(255,255,255,0.03);
-            transition: border-color 0.3s, box-shadow 0.3s;
+            padding: 1.25rem; border: 1px solid var(--border);
+            border-radius: var(--radius); background: var(--surface);
+            box-shadow: var(--shadow-sm);
+            transition: box-shadow 0.3s, border-color 0.3s;
         }
-        .roadmap-card:hover {
-            border-color: rgba(99,102,241,0.3);
-            box-shadow: 0 0 20px rgba(99,102,241,0.06);
-        }
+        .roadmap-card:hover { box-shadow: var(--shadow-md); border-color: var(--border-hover); }
         .roadmap-card h3 { margin: 0 0 0.25rem; font-size: 1rem; }
-        .roadmap-card p, .roadmap-card .excerpt { margin: 0; color: #888; font-size: 0.9rem; }
+        .roadmap-card p, .roadmap-card .excerpt { margin: 0; color: var(--dim); font-size: 0.9rem; }
         .roadmap-kanban { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; }
         .roadmap-column-header { font-size: 1rem; margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem; }
-        .roadmap-count { font-size: 0.8rem; color: #555; font-weight: 400; }
+        .roadmap-count { font-size: 0.8rem; color: var(--muted); font-weight: 400; }
         .roadmap-timeline { position: relative; padding-left: 2rem; }
         .roadmap-timeline::before {
             content: ''; position: absolute; left: 0.5rem; top: 0; bottom: 0;
-            width: 2px; background: rgba(255,255,255,0.06);
+            width: 2px; background: var(--border);
         }
         .roadmap-milestone { position: relative; margin-bottom: 2rem; }
         .roadmap-milestone-dot {
             position: absolute; left: -1.75rem; top: 0.3rem;
             width: 12px; height: 12px; border-radius: 50%;
-            border: 2px solid #6366f1; background: #050505;
-            box-shadow: 0 0 8px rgba(99,102,241,0.3);
+            border: 2px solid var(--accent); background: var(--bg);
+            box-shadow: 0 0 0 3px var(--accent-subtle);
         }
         .roadmap-milestone-dot .roadmap-status { display: none; }
         .roadmap-milestone-content h3 { margin: 0 0 0.25rem; }
-        .roadmap-milestone-content p { margin: 0.25rem 0 0; color: #888; font-size: 0.9rem; }
+        .roadmap-milestone-content p { margin: 0.25rem 0 0; color: var(--dim); font-size: 0.9rem; }
         @media (max-width: 768px) { .roadmap-kanban { grid-template-columns: 1fr; } }
 
         /* ---------- Tables ---------- */
         table { border-collapse: collapse; width: 100%; margin: 1.5rem 0; }
-        th, td { border: 1px solid rgba(255,255,255,0.06); padding: 0.55rem 0.85rem; text-align: left; }
-        th { background: rgba(255,255,255,0.04); font-weight: 600; }
-        td { color: #ccc; }
+        th, td { border: 1px solid var(--border); padding: 0.55rem 0.85rem; text-align: left; }
+        th { background: rgba(0,0,0,0.02); font-weight: 600; color: var(--text-bright); }
+        td { color: var(--text); }
 
         /* ---------- Task Lists ---------- */
         ul.contains-task-list, ol.contains-task-list { list-style: none; padding-left: 0; }
         li.task-list-item { display: flex; align-items: baseline; gap: 0.5rem; }
-        li.task-list-item input[type="checkbox"] { margin: 0; pointer-events: none; accent-color: #6366f1; }
+        li.task-list-item input[type="checkbox"] { margin: 0; pointer-events: none; accent-color: var(--accent); }
 
         /* ---------- Footnotes ---------- */
         .footnote-definition {
-            font-size: 0.85rem; color: #888;
-            border-top: 1px solid rgba(255,255,255,0.06);
+            font-size: 0.85rem; color: var(--dim);
+            border-top: 1px solid var(--border);
             margin-top: 2rem; padding-top: 0.75rem;
         }
         .footnote-definition p { display: inline; }
-        sup.footnote-reference a { text-decoration: none; color: #818cf8; font-weight: 600; }
+        sup.footnote-reference a { text-decoration: none; color: var(--accent); font-weight: 600; }
 
         /* ---------- TOC ---------- */
         .toc {
-            margin: 1.5rem 0; padding: 1rem 1.25rem;
-            border: 1px solid rgba(255,255,255,0.06); border-radius: 12px;
-            background: rgba(255,255,255,0.02);
+            margin: 1.5rem 0; padding: 1.15rem 1.35rem;
+            border: 1px solid var(--border); border-radius: var(--radius);
+            background: var(--surface); box-shadow: var(--shadow-sm);
         }
         .toc > ul { margin: 0; padding-left: 1.25rem; }
         .toc ul ul { padding-left: 1rem; }
         .toc li { margin: 0.25rem 0; }
-        .toc a { text-decoration: none; color: #888; transition: color 0.15s; }
-        .toc a:hover { color: #818cf8; text-decoration: underline; }
+        .toc a { text-decoration: none; color: var(--dim); transition: color 0.2s; }
+        .toc a:hover { color: var(--accent); text-decoration: underline; }
 
         /* ---------- Pagination ---------- */
         .pagination {
             display: flex; justify-content: space-between; align-items: center;
-            margin-top: 2.5rem; padding-top: 1.25rem;
-            border-top: 1px solid rgba(255,255,255,0.06);
+            max-width: 1200px; margin: 0 auto;
+            padding: 1.25rem 2rem 2rem;
+            border-top: 1px solid var(--border);
         }
         .pagination a {
-            text-decoration: none; color: #818cf8;
-            padding: 0.5rem 1rem; border-radius: 8px;
-            border: 1px solid rgba(99,102,241,0.2);
+            text-decoration: none; color: var(--accent);
+            padding: 0.5rem 1rem; border-radius: var(--radius-sm);
+            border: 1px solid rgba(79,70,229,0.15);
             transition: background 0.2s, border-color 0.2s;
         }
-        .pagination a:hover { background: rgba(99,102,241,0.08); border-color: rgba(99,102,241,0.4); }
-        .pagination span { color: #555; font-size: 0.9rem; }
+        .pagination a:hover { background: var(--accent-subtle); border-color: rgba(79,70,229,0.3); }
+        .pagination span { color: var(--muted); font-size: 0.9rem; }
 
         /* ---------- Footer ---------- */
         .site-footer {
-            max-width: 1100px; margin: 5rem auto 0;
-            padding: 2rem 1.5rem;
-            border-top: 1px solid rgba(255,255,255,0.06);
-            color: #555; font-size: 0.85rem;
+            max-width: 1200px; margin: 4rem auto 0;
+            padding: 2rem;
+            border-top: 1px solid var(--border);
+            color: var(--muted); font-size: 0.85rem;
         }
         .site-footer nav { margin-bottom: 0.5rem; }
-        .site-footer nav a { color: #666; text-decoration: none; transition: color 0.2s; }
-        .site-footer nav a:hover { color: #818cf8; }
+        .site-footer nav a { color: var(--dim); text-decoration: none; transition: color 0.2s; }
+        .site-footer nav a:hover { color: var(--accent); }
 
         /* ---------- Code Copy Button ---------- */
         .code-block-wrapper { position: relative; }
         .code-block-wrapper .copy-button {
             position: absolute; top: 0.5rem; right: 0.5rem;
-            background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.08);
-            color: #888; padding: 0.25rem 0.5rem; border-radius: 6px;
+            background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.1);
+            color: rgba(255,255,255,0.5); padding: 0.25rem 0.5rem; border-radius: 6px;
             font-size: 0.75rem; cursor: pointer; transition: background 0.2s, color 0.2s;
         }
-        .code-block-wrapper .copy-button:hover { background: rgba(99,102,241,0.15); color: #818cf8; }
+        .code-block-wrapper .copy-button:hover { background: rgba(255,255,255,0.15); color: rgba(255,255,255,0.8); }
 
         /* ---------- Accessibility ---------- */
         .skip-link {
             position: absolute; top: -100%; left: 0;
             padding: 0.5rem 1rem; z-index: 200; text-decoration: none;
-            background: linear-gradient(135deg, #6366f1, #a855f7);
-            color: #fff; border-radius: 0 0 10px 0;
-            font-weight: 600;
+            background: var(--accent); color: #fff;
+            border-radius: 0 0 var(--radius-sm) 0; font-weight: 700;
         }
         .skip-link:focus { top: 0; }
-        :focus-visible { outline: 2px solid #6366f1; outline-offset: 2px; }
+        :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+        /* ---------- Animations ---------- */
+        @keyframes fadeInUp {
+            from { opacity: 0; transform: translateY(20px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
 
         @media (prefers-reduced-motion: reduce) {
             *, *::before, *::after {
@@ -604,14 +780,44 @@
         }
 
         /* ---------- Responsive ---------- */
-        @media (max-width: 700px) {
-            .hero h2 { font-size: 2rem; }
-            .hero { padding: 3rem 1.5rem 2rem; }
-            .article-grid { grid-template-columns: 1fr; }
-            .site-header { flex-direction: column; align-items: flex-start; }
+        @media (max-width: 900px) {
+            main > section {
+                grid-template-columns: repeat(2, 1fr);
+            }
+            main > section > article:first-of-type {
+                grid-column: 1 / -1;
+                grid-row: auto;
+            }
+            .homepage-content > ul {
+                grid-template-columns: repeat(2, 1fr);
+            }
+        }
+        @media (max-width: 600px) {
+            main > section {
+                grid-template-columns: 1fr;
+                padding: 0 1.25rem;
+            }
+            .homepage-content {
+                padding: 2.5rem 1.25rem 1.5rem;
+            }
+            .homepage-content > h1:first-child {
+                font-size: 2rem;
+            }
+            .homepage-content > ul {
+                grid-template-columns: 1fr 1fr;
+            }
+            .homepage-content > ul > li strong {
+                font-size: 1.6rem;
+            }
+            .site-header {
+                padding: 0.75rem 1.25rem;
+                flex-direction: column; align-items: flex-start;
+            }
             .header-right { width: 100%; flex-wrap: wrap; }
             .search-form input { width: 100%; }
             #search-results { right: 0; left: 0; width: auto; }
+            .site-footer { padding: 1.5rem 1.25rem; }
+            .pagination { padding: 1rem 1.25rem 1.5rem; }
             .cert-grid { grid-template-columns: 1fr; }
         }
     </style>

--- a/src/themes/landing.tera
+++ b/src/themes/landing.tera
@@ -1,0 +1,349 @@
+<!DOCTYPE html>
+<html lang="{{ lang }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="/favicon.ico">
+    <title>{% block title %}{{ site.title }}{% endblock %}</title>
+    <meta name="description" content="{{ page.description | default(value=site.description) }}">
+    <link rel="canonical" href="{{ site.base_url }}{{ page.url | default(value='/') }}">
+    <meta property="og:type" content="{% if page.collection %}article{% else %}website{% endif %}">
+    <meta property="og:url" content="{{ site.base_url }}{{ page.url | default(value='/') }}">
+    <meta property="og:title" content="{{ page.title | default(value=site.title) }}">
+    <meta property="og:description" content="{{ page.description | default(value=site.description) }}">
+    {% if page.image %}<meta property="og:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    <meta property="og:site_name" content="{{ site.title }}">
+    <meta property="og:locale" content="{{ lang }}">
+    <meta name="twitter:card" content="{% if page.image %}summary_large_image{% else %}summary{% endif %}">
+    <meta name="twitter:title" content="{{ page.title | default(value=site.title) }}">
+    <meta name="twitter:description" content="{{ page.description | default(value=site.description) }}">
+    {% if page.image %}<meta name="twitter:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    {% if page.robots %}<meta name="robots" content="{{ page.robots }}">{% endif %}
+    <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ lang_prefix }}/feed.xml">
+    <link rel="alternate" type="text/plain" title="LLM Summary" href="{{ lang_prefix }}/llms.txt">
+    {% if page.url %}<link rel="alternate" type="text/markdown" title="Markdown" href="{{ site.base_url }}{{ page.url }}.md">{% endif %}
+    {% if translations %}{% for t in translations %}<link rel="alternate" hreflang="{{ t.lang }}" href="{{ site.base_url }}{{ t.url }}">
+    {% endfor %}<link rel="alternate" hreflang="x-default" href="{{ site.base_url }}{{ page.url | default(value='/') }}">
+    {% endif %}
+    <script type="application/ld+json">
+    {% set _ld_url = page.url | default(value='/') %}{% set _ld_href = site.base_url ~ _ld_url %}{% set _ld_title = page.title | default(value=site.title) %}{% set _ld_desc = page.description | default(value=site.description) %}
+    {% if page.collection == 'posts' %}{"@context":"https://schema.org","@type":"BlogPosting","headline":{{ _ld_title | json_encode() }},"description":{{ _ld_desc | json_encode() }},"datePublished":{{ page.date | default(value='') | json_encode() }}{% if page.updated %},"dateModified":{{ page.updated | json_encode() }}{% endif %},"author":{"@type":"Person","name":{{ site.author | json_encode() }}},"publisher":{"@type":"Organization","name":{{ site.title | json_encode() }}},"url":{{ _ld_href | json_encode() }}}
+    {% elif page.collection %}{"@context":"https://schema.org","@type":"Article","headline":{{ _ld_title | json_encode() }},"description":{{ _ld_desc | json_encode() }}{% if page.updated %},"dateModified":{{ page.updated | json_encode() }}{% endif %},"author":{"@type":"Person","name":{{ site.author | json_encode() }}},"publisher":{"@type":"Organization","name":{{ site.title | json_encode() }}},"url":{{ _ld_href | json_encode() }}}
+    {% else %}{"@context":"https://schema.org","@type":"WebSite","name":{{ site.title | json_encode() }},"description":{{ site.description | json_encode() }},"url":{{ site.base_url | json_encode() }}}
+    {% endif %}
+    </script>
+    <style>
+        *, *::before, *::after { box-sizing: border-box; }
+        body { margin: 0; padding: 0; font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; color: #1a1a2e; background: #fff; }
+        a { color: #0d9488; }
+        a:hover { color: #0f766e; }
+
+        /* Header / Navbar */
+        .site-header { max-width: 1100px; margin: 0 auto; padding: 1.25rem 1.5rem; display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 0.75rem; }
+        .site-header h1 { margin: 0; font-size: 1.25rem; font-weight: 800; }
+        .site-header h1 a { color: #1a1a2e; text-decoration: none; }
+        .site-header p { display: none; }
+        .header-right { display: flex; align-items: center; gap: 1rem; }
+        nav.site-nav { display: flex; gap: 0.25rem; }
+        nav.site-nav a { text-decoration: none; font-weight: 500; font-size: 0.9rem; color: #64748b; padding: 0.35rem 0.75rem; border-radius: 6px; transition: color 0.15s, background 0.15s; }
+        nav.site-nav a:hover { color: #0d9488; background: #f0fdfa; }
+        .lang-switcher { display: inline-flex; gap: 0.35rem; font-size: 0.8rem; }
+        .lang-switcher a { text-decoration: none; color: #94a3b8; padding: 0.15rem 0.45rem; border-radius: 4px; border: 1px solid #e2e8f0; }
+        .lang-switcher a:hover { border-color: #0d9488; color: #0d9488; }
+        .lang-switcher strong { padding: 0.15rem 0.45rem; background: #0d9488; color: #fff; border-radius: 4px; }
+
+        /* Hero section — used on homepage when page.content exists */
+        .hero { max-width: 1100px; margin: 0 auto; padding: 4rem 1.5rem 3rem; text-align: center; }
+        .hero h2 { font-size: 3rem; font-weight: 800; line-height: 1.15; margin: 0 0 1rem; letter-spacing: -0.02em; color: #1a1a2e; }
+        .hero p { font-size: 1.2rem; color: #64748b; max-width: 640px; margin: 0 auto 2rem; }
+        .hero .cta-group { display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap; }
+        .cta-primary { display: inline-block; background: #0d9488; color: #fff; padding: 0.75rem 2rem; border-radius: 8px; font-weight: 600; text-decoration: none; font-size: 1rem; transition: background 0.15s; }
+        .cta-primary:hover { background: #0f766e; color: #fff; text-decoration: none; }
+        .cta-secondary { display: inline-block; color: #0d9488; padding: 0.75rem 2rem; border-radius: 8px; font-weight: 600; text-decoration: none; font-size: 1rem; border: 2px solid #0d9488; transition: background 0.15s; }
+        .cta-secondary:hover { background: #f0fdfa; text-decoration: none; }
+
+        /* Content wrapper */
+        .content-wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem; }
+
+        /* Sections with alternating backgrounds */
+        .section { padding: 3rem 0; }
+        .section:nth-child(even) { background: #f8fafc; }
+        .section-inner { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem; }
+        .section h2 { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.1em; color: #0d9488; font-weight: 700; margin: 0 0 1.5rem; }
+
+        /* Article grid for collection listings */
+        .article-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 1.5rem; }
+        article { background: #fff; border: 1px solid #e2e8f0; border-radius: 12px; padding: 1.75rem; transition: border-color 0.15s, box-shadow 0.15s; }
+        article:hover { border-color: #0d9488; box-shadow: 0 4px 20px rgba(13,148,136,0.08); }
+        article h3 { margin: 0 0 0.4rem; font-size: 1.15rem; font-weight: 700; }
+        article h3 a { color: #1a1a2e; text-decoration: none; }
+        article h3 a:hover { color: #0d9488; }
+        article p { color: #64748b; font-size: 0.9rem; margin: 0.5rem 0 0; }
+
+        /* Single article pages — centered reading column */
+        main > article { max-width: 720px; margin: 2rem auto; border: none; box-shadow: none; padding: 0 1.5rem; }
+        main > article:hover { border-color: transparent; box-shadow: none; }
+        main > article h1 { font-size: 2.2rem; font-weight: 800; margin: 0 0 0.5rem; line-height: 1.2; letter-spacing: -0.01em; }
+        main > article h2 { font-size: 1.4rem; font-weight: 700; margin-top: 2.5rem; color: #1a1a2e; }
+        main > article h3 { font-size: 1.1rem; font-weight: 600; margin-top: 1.5rem; }
+        time { font-size: 0.8rem; color: #94a3b8; }
+        .reading-time { color: #94a3b8; font-size: 0.85rem; }
+        .tags a, .tags span { background: #f0fdfa; color: #0d9488; border: 1px solid #ccfbf1; padding: 0.1rem 0.55rem; border-radius: 9999px; margin-right: 0.3rem; font-size: 0.75rem; font-weight: 600; text-decoration: none; }
+        .tags a:hover { background: #ccfbf1; }
+
+        /* Search */
+        .search-form { margin: 0; }
+        .search-form input { width: 200px; padding: 0.4rem 0.75rem; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.85rem; font-family: inherit; background: #f8fafc; color: #1a1a2e; }
+        .search-form input:focus { outline: none; border-color: #0d9488; background: #fff; box-shadow: 0 0 0 3px rgba(13,148,136,0.1); }
+        #search-results { position: absolute; right: 1.5rem; top: 100%; width: 360px; border: 1px solid #e2e8f0; border-radius: 10px; background: #fff; box-shadow: 0 8px 30px rgba(0,0,0,0.1); z-index: 50; overflow: hidden; }
+        #search-results a { display: block; padding: 0.6rem 1rem; text-decoration: none; border-bottom: 1px solid #f1f5f9; font-size: 0.9rem; color: #0d9488; }
+        #search-results a:last-child { border-bottom: none; }
+        #search-results a:hover { background: #f0fdfa; }
+        #search-results strong { color: #1a1a2e; }
+        #search-results .result-meta { font-size: 0.75rem; color: #94a3b8; margin-top: 0.1rem; }
+        #search-results .no-results { padding: 0.6rem 1rem; color: #94a3b8; font-size: 0.9rem; }
+
+        /* Typography */
+        pre { background: #1e293b; color: #e2e8f0; padding: 1rem; border-radius: 8px; overflow-x: auto; }
+        pre code { background: none; color: inherit; font-size: 0.9em; padding: 0; }
+        code { font-size: 0.9em; background: #f0fdfa; color: #0d9488; padding: 0.15em 0.4em; border-radius: 4px; }
+        blockquote { border-left: 4px solid #0d9488; margin-left: 0; padding: 0.75rem 1rem; background: #f0fdfa; border-radius: 0 8px 8px 0; color: #334155; }
+        img { max-width: 100%; height: auto; border-radius: 8px; }
+        figure { margin: 1.5rem 0; }
+        figure img { display: block; }
+        figcaption { font-size: 0.85rem; color: #64748b; margin-top: 0.5rem; }
+        hr { border: none; border-top: 1px solid #e2e8f0; margin: 2rem 0; }
+
+        /* Embeds */
+        .video-embed { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin: 1.5rem 0; border-radius: 8px; }
+        .video-embed iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
+        .gist-embed { margin: 1.5rem 0; }
+
+        /* Callouts */
+        .callout { padding: 1rem 1.25rem; margin: 1.5rem 0; border-radius: 8px; border-left: 4px solid #0d9488; background: #f0fdfa; }
+        .callout-title { font-weight: 700; margin-bottom: 0.5rem; font-size: 0.85rem; }
+        .callout-info { border-left-color: #0d9488; background: #f0fdfa; }
+        .callout-warning { border-left-color: #d97706; background: #fffbeb; }
+        .callout-danger { border-left-color: #dc2626; background: #fef2f2; }
+        .callout-tip { border-left-color: #16a34a; background: #f0fdf4; }
+        .callout-note { border-left-color: #6b7280; background: #f9fafb; }
+        .callout p:last-child { margin-bottom: 0; }
+
+        /* Contact form */
+        .contact-form { max-width: 480px; }
+        .contact-form-field { margin-bottom: 1rem; }
+        .contact-form-field label { display: block; font-weight: 600; margin-bottom: 0.25rem; font-size: 0.9rem; }
+        .contact-form-field input, .contact-form-field textarea { width: 100%; padding: 0.6rem 0.75rem; border: 1px solid #e2e8f0; border-radius: 8px; font: inherit; box-sizing: border-box; }
+        .contact-form-field input:focus, .contact-form-field textarea:focus { outline: none; border-color: #0d9488; box-shadow: 0 0 0 3px rgba(13,148,136,0.1); }
+        .contact-form-submit { background: #0d9488; color: #fff; border: none; padding: 0.6rem 1.5rem; border-radius: 8px; font: inherit; font-weight: 600; cursor: pointer; }
+        .contact-form-submit:hover { background: #0f766e; }
+        .contact-form-honeypot { display: none; }
+        .contact-form-embed { min-height: 400px; border-radius: 8px; }
+        .contact-form-error { color: #dc2626; background: #fef2f2; padding: 1rem; border-radius: 8px; border-left: 4px solid #dc2626; }
+
+        /* Trust center */
+        .trust-hub { max-width: 1100px; margin: 0 auto; }
+        .trust-hero { margin-bottom: 2.5rem; }
+        .trust-hero h1 { font-size: 2.2rem; font-weight: 800; margin-bottom: 0.5rem; }
+        .trust-section { margin-bottom: 2.5rem; }
+        .trust-section h2 { font-size: 1.4rem; margin-bottom: 1rem; border-bottom: 1px solid #e2e8f0; padding-bottom: 0.5rem; }
+        .trust-breadcrumb { font-size: 0.85rem; color: #94a3b8; margin-bottom: 1.5rem; }
+        .trust-breadcrumb a { color: #0d9488; text-decoration: none; }
+        .trust-breadcrumb a:hover { text-decoration: underline; }
+        .trust-description { color: #64748b; margin-bottom: 1.5rem; line-height: 1.7; }
+        .cert-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.5rem; }
+        .cert-card { border: 1px solid #e2e8f0; border-radius: 12px; padding: 1.5rem; background: #fff; transition: border-color 0.15s, box-shadow 0.15s; }
+        .cert-card:hover { border-color: #0d9488; box-shadow: 0 4px 20px rgba(13,148,136,0.08); }
+        .cert-card__header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+        .cert-card__title { font-weight: 700; font-size: 1.05rem; color: #1a1a2e; }
+        .cert-card__desc { font-size: 0.9rem; color: #64748b; margin-bottom: 0.75rem; }
+        .cert-card__link { font-size: 0.85rem; color: #0d9488; text-decoration: none; font-weight: 600; }
+        .cert-card__link:hover { text-decoration: underline; }
+        .cert-status { display: inline-block; font-size: 0.7rem; font-weight: 700; padding: 0.15rem 0.5rem; border-radius: 9999px; text-transform: uppercase; letter-spacing: 0.03em; }
+        .cert-status--active { background: #dcfce7; color: #166534; }
+        .cert-status--in_progress { background: #fef9c3; color: #854d0e; }
+        .cert-status--planned { background: #f3f4f6; color: #6b7280; }
+        .cert-detail { margin-bottom: 2rem; padding: 1.5rem; border: 1px solid #e2e8f0; border-radius: 12px; background: #f8fafc; }
+        .cert-meta { font-size: 0.9rem; color: #64748b; margin-bottom: 0.35rem; }
+        .cert-meta strong { color: #1a1a2e; }
+        .trust-item { padding: 0.75rem 0; border-bottom: 1px solid #e2e8f0; }
+        .trust-item:last-child { border-bottom: none; }
+        .subprocessor-table-wrap { overflow-x: auto; margin: 1.5rem 0; }
+        .subprocessor-table { border-collapse: collapse; width: 100%; }
+        .subprocessor-table th, .subprocessor-table td { border: 1px solid #e2e8f0; padding: 0.5rem 0.75rem; text-align: left; font-size: 0.9rem; }
+        .subprocessor-table th { background: #f8fafc; font-weight: 600; }
+        .faq-section { margin-top: 2rem; }
+        .faq-item { border-bottom: 1px solid #e2e8f0; }
+        .faq-item summary { padding: 0.75rem 0; cursor: pointer; font-weight: 500; color: #1a1a2e; }
+        .faq-item summary:hover { color: #0d9488; }
+        .faq-answer { padding: 0 0 1rem; color: #64748b; line-height: 1.7; }
+        .trust-page { margin-bottom: 2rem; }
+
+        /* Changelog */
+        .changelog-entry-header { margin-bottom: 1.5rem; }
+        .changelog-meta { display: flex; align-items: center; gap: 1rem; margin-top: 0.5rem; color: #94a3b8; font-size: 0.9rem; }
+        .changelog-summary { color: #64748b; font-size: 1.05rem; margin-bottom: 1.5rem; }
+        .changelog-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+        .changelog-tag { display: inline-block; padding: 0.15rem 0.6rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; }
+        .changelog-tag--new { background: #dcfce7; color: #166534; }
+        .changelog-tag--fix { background: #dbeafe; color: #1e40af; }
+        .changelog-tag--breaking { background: #fee2e2; color: #991b1b; }
+        .changelog-tag--improvement { background: #f3e8ff; color: #6b21a8; }
+        .changelog-tag--deprecated { background: #f3f4f6; color: #4b5563; }
+        .changelog-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 1rem; margin-bottom: 2rem; }
+        .changelog-header h1 { margin-bottom: 0; }
+        .changelog-rss { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.8rem; color: #94a3b8; text-decoration: none; padding: 0.3rem 0.7rem; border: 1px solid #e2e8f0; border-radius: 6px; }
+        .changelog-rss:hover { color: #0d9488; border-color: #0d9488; }
+        .changelog-back { margin-bottom: 1.5rem; }
+        .changelog-back a { color: #94a3b8; text-decoration: none; font-size: 0.9rem; }
+        .changelog-back a:hover { color: #0d9488; }
+        .changelog-timeline { position: relative; padding-left: 2rem; }
+        .changelog-timeline::before { content: ''; position: absolute; left: 0; top: 0.5rem; bottom: 0; width: 2px; background: #e2e8f0; }
+        .changelog-item { position: relative; padding: 1.25rem; border: 1px solid #e2e8f0; border-radius: 12px; background: #fff; margin-bottom: 1.5rem; }
+        .changelog-item::before { content: ''; position: absolute; left: -2rem; top: 1.25rem; width: 10px; height: 10px; border-radius: 50%; background: #0d9488; transform: translateX(-4px); }
+        .changelog-item:last-child { margin-bottom: 0; }
+        .changelog-item-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 0.5rem; }
+        .changelog-item-header h2 { margin: 0; font-size: 1.25rem; }
+        .changelog-item-header time { color: #94a3b8; font-size: 0.85rem; white-space: nowrap; }
+        .changelog-item .changelog-tags { margin-top: 0.5rem; }
+        .changelog-item p, .changelog-item .excerpt { margin-top: 0.5rem; color: #64748b; }
+        .changelog-feed .changelog-item::before { display: none; }
+        .changelog-feed { display: flex; flex-direction: column; gap: 1.5rem; }
+
+        /* Roadmap */
+        .roadmap-back { margin-bottom: 1.5rem; }
+        .roadmap-back a { color: #94a3b8; text-decoration: none; font-size: 0.9rem; }
+        .roadmap-back a:hover { color: #0d9488; }
+        .roadmap-entry-header { margin-bottom: 1.5rem; }
+        .roadmap-summary { color: #64748b; font-size: 1.05rem; margin-bottom: 1.5rem; }
+        .roadmap-status-badges { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
+        .roadmap-status { display: inline-block; padding: 0.2rem 0.7rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; }
+        .roadmap-status--planned { background: #dbeafe; color: #1e40af; }
+        .roadmap-status--in-progress { background: #fef3c7; color: #92400e; }
+        .roadmap-status--done { background: #dcfce7; color: #166534; }
+        .roadmap-status--cancelled { background: #f3f4f6; color: #4b5563; text-decoration: line-through; }
+        .roadmap-grouped { display: flex; flex-direction: column; gap: 2rem; }
+        .roadmap-section-header { display: flex; align-items: center; gap: 0.75rem; font-size: 1.1rem; margin-bottom: 1rem; }
+        .roadmap-items { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; }
+        .roadmap-card { padding: 1.25rem; border: 1px solid #e2e8f0; border-radius: 12px; background: #fff; transition: border-color 0.15s; }
+        .roadmap-card:hover { border-color: #0d9488; }
+        .roadmap-card h3 { margin: 0 0 0.25rem; font-size: 1rem; }
+        .roadmap-card p, .roadmap-card .excerpt { margin: 0; color: #64748b; font-size: 0.9rem; }
+        .roadmap-kanban { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; }
+        .roadmap-column-header { font-size: 1rem; margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem; }
+        .roadmap-count { font-size: 0.8rem; color: #94a3b8; font-weight: 400; }
+        .roadmap-timeline { position: relative; padding-left: 2rem; }
+        .roadmap-timeline::before { content: ''; position: absolute; left: 0.5rem; top: 0; bottom: 0; width: 2px; background: #e2e8f0; }
+        .roadmap-milestone { position: relative; margin-bottom: 2rem; }
+        .roadmap-milestone-dot { position: absolute; left: -1.75rem; top: 0.3rem; width: 12px; height: 12px; border-radius: 50%; border: 2px solid #0d9488; background: #fff; }
+        .roadmap-milestone-dot .roadmap-status { display: none; }
+        .roadmap-milestone-content h3 { margin: 0 0 0.25rem; }
+        .roadmap-milestone-content p { margin: 0.25rem 0 0; color: #64748b; font-size: 0.9rem; }
+        @media (max-width: 768px) { .roadmap-kanban { grid-template-columns: 1fr; } }
+
+        /* Tables */
+        table { border-collapse: collapse; width: 100%; margin: 1.5rem 0; }
+        th, td { border: 1px solid #e2e8f0; padding: 0.5rem 0.75rem; text-align: left; }
+        th { background: #f8fafc; font-weight: 600; }
+        ul.contains-task-list, ol.contains-task-list { list-style: none; padding-left: 0; }
+        li.task-list-item { display: flex; align-items: baseline; gap: 0.5rem; }
+        li.task-list-item input[type="checkbox"] { margin: 0; pointer-events: none; }
+        .footnote-definition { font-size: 0.85rem; color: #64748b; border-top: 1px solid #e2e8f0; margin-top: 2rem; padding-top: 0.75rem; }
+        .footnote-definition p { display: inline; }
+        sup.footnote-reference a { text-decoration: none; color: #0d9488; font-weight: 600; }
+
+        /* TOC & Pagination */
+        .toc { margin: 1.5rem 0; padding: 1rem 1.25rem; border: 1px solid #e2e8f0; border-radius: 8px; background: #f8fafc; }
+        .toc > ul { margin: 0; padding-left: 1.25rem; }
+        .toc ul ul { padding-left: 1rem; }
+        .toc li { margin: 0.25rem 0; }
+        .toc a { text-decoration: none; }
+        .toc a:hover { text-decoration: underline; }
+        .pagination { display: flex; justify-content: space-between; align-items: center; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #e2e8f0; }
+        .pagination a { text-decoration: none; }
+        .pagination a:hover { text-decoration: underline; }
+        .pagination span { color: #94a3b8; font-size: 0.9rem; }
+
+        /* Footer */
+        .site-footer { max-width: 1100px; margin: 4rem auto 0; padding: 1.5rem 1.5rem; border-top: 1px solid #e2e8f0; color: #94a3b8; font-size: 0.85rem; }
+        .site-footer nav { margin-bottom: 0.5rem; }
+        .site-footer nav a { color: #64748b; text-decoration: none; }
+        .site-footer nav a:hover { color: #0d9488; }
+
+        /* Accessibility */
+        .skip-link { position: absolute; top: -100%; left: 0; padding: 0.5rem 1rem; background: #0d9488; color: #fff; z-index: 100; text-decoration: none; border-radius: 0 0 8px 0; }
+        .skip-link:focus { top: 0; }
+        :focus-visible { outline: 2px solid #0d9488; outline-offset: 2px; }
+        @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } }
+        @media (max-width: 700px) {
+            .hero h2 { font-size: 2rem; }
+            .article-grid { grid-template-columns: 1fr; }
+            .site-header { flex-direction: column; align-items: flex-start; }
+        }
+    </style>
+    {% block extra_css %}{% endblock %}
+    {% block head %}{% endblock %}
+</head>
+<body>
+    <a href="#main" class="skip-link">{{ t.skip_to_content }}</a>
+    <header>
+    {% block header %}
+        <div class="site-header" style="position: relative;">
+            <h1><a href="{{ lang_prefix }}/">{{ site.title }}</a></h1>
+            <div class="header-right">
+                {% if data.nav %}
+                <nav class="site-nav" aria-label="Main navigation">
+                    {% for item in data.nav %}{% if item.external %}<a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.title }}</a>{% else %}<a href="{{ lang_prefix }}{{ item.url }}">{{ item.title }}</a>{% endif %}{% endfor %}
+                </nav>
+                {% endif %}
+                {% if translations | length > 1 %}
+                <nav class="lang-switcher">
+                    {% for t in translations %}{% if t.lang == lang %}<strong>{{ t.lang | upper }}</strong>{% else %}<a href="{{ t.url }}">{{ t.lang | upper }}</a>{% endif %}{% endfor %}
+                </nav>
+                {% endif %}
+                <form class="search-form" role="search" aria-label="{{ t.search_label }}" onsubmit="return false">
+                    <input type="search" id="search-input" placeholder="{{ t.search_placeholder }}" autocomplete="off" aria-label="{{ t.search_label }}">
+                </form>
+                <div id="search-results" aria-live="polite"></div>
+            </div>
+        </div>
+    {% endblock %}
+    </header>
+    <main id="main">
+        {% block content %}{% endblock %}
+    </main>
+    <footer class="site-footer">
+        {% if data.footer %}{% if data.footer.links %}
+        <nav aria-label="Footer navigation">
+            {% for link in data.footer.links %}{% if link.external %}<a href="{{ link.url }}" target="_blank" rel="noopener">{{ link.title }}</a>{% else %}<a href="{{ lang_prefix }}{{ link.url }}">{{ link.title }}</a>{% endif %}{% if not loop.last %} &middot; {% endif %}{% endfor %}
+        </nav>
+        {% endif %}{% endif %}
+        <p>&copy; {% if data.footer %}{% if data.footer.copyright %}{{ data.footer.copyright }}{% else %}{{ site.author }}{% endif %}{% else %}{{ site.author }}{% endif %}</p>
+    </footer>
+    <script>
+    (function(){
+        var index = null;
+        var input = document.getElementById('search-input');
+        var results = document.getElementById('search-results');
+        var basePath = {{ site.base_path | json_encode() }};
+        var indexUrl = basePath + {% if lang != default_language %}('/' + {{ lang | json_encode() }} + '/search-index.json'){% else %}'/search-index.json'{% endif %};
+        function load(cb) { if (index) { cb(); return; } fetch(indexUrl).then(function(r){return r.json();}).then(function(d){index=d;cb();}).catch(function(){index=[];}); }
+        function search(q) {
+            q = q.toLowerCase().trim();
+            if (!q) { results.innerHTML = ''; return; }
+            var hits = index.filter(function(e){
+                return (e.title||'').toLowerCase().includes(q) || (e.description||'').toLowerCase().includes(q) || (e.tags||[]).some(function(t){return t.toLowerCase().includes(q);});
+            }).slice(0, 8);
+            if (!hits.length) { results.innerHTML = '<div class="no-results">{{ t.no_results }}</div>'; return; }
+            results.innerHTML = hits.map(function(e){
+                var meta = [e.collection, e.date].filter(Boolean).join(' · ');
+                return '<a href="' + basePath + e.url + '"><strong>' + e.title + '</strong>' + (meta ? '<div class="result-meta">' + meta + '</div>' : '') + '</a>';
+            }).join('');
+        }
+        input.addEventListener('input', function(){ load(function(){ search(input.value); }); });
+    })();
+    </script>
+    {% block footer %}{% endblock %}
+    {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/src/themes/magazine.tera
+++ b/src/themes/magazine.tera
@@ -39,241 +39,313 @@
     {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
     </script>{% endif %}
     <style>
-        *, *::before, *::after { box-sizing: border-box; }
-        body { margin: 0; padding: 0; font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; color: #1a1a1a; background: #fff; }
-        a { color: #c0392b; text-decoration: none; }
-        a:hover { text-decoration: underline; }
+        /* ===== RESET & FOUNDATION ===== */
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; line-height: 1.6; color: #111; background: #fff; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        a { color: #e63946; text-decoration: none; transition: color 0.15s ease; }
+        a:hover { color: #c1121f; }
+        img { max-width: 100%; height: auto; display: block; }
 
-        /* Masthead — magazine nameplate */
-        .masthead { max-width: 1000px; margin: 0 auto; padding: 1.5rem 1.5rem 0; text-align: center; border-bottom: 3px double #1a1a1a; }
-        .masthead h1 { margin: 0; font-size: 2.5rem; font-weight: 900; letter-spacing: 0.04em; text-transform: uppercase; line-height: 1.1; }
-        .masthead h1 a { color: #1a1a1a; text-decoration: none; }
-        .masthead p { margin: 0.25rem 0 0.75rem; color: #888; font-size: 0.85rem; font-style: italic; }
-        nav.site-nav { display: flex; justify-content: center; gap: 0.25rem; padding: 0.75rem 0; border-top: 1px solid #ddd; margin-top: 0.75rem; }
-        nav.site-nav a { font-size: 0.8rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: #1a1a1a; padding: 0.25rem 0.75rem; }
-        nav.site-nav a:hover { color: #c0392b; text-decoration: none; }
-        .lang-switcher { display: inline-flex; gap: 0.4rem; font-size: 0.75rem; margin-top: 0.5rem; }
-        .lang-switcher a { color: #999; padding: 0.1rem 0.35rem; border: 1px solid #ddd; text-decoration: none; }
-        .lang-switcher a:hover { border-color: #c0392b; color: #c0392b; }
-        .lang-switcher strong { padding: 0.1rem 0.35rem; background: #1a1a1a; color: #fff; }
-        .search-form { display: inline-block; margin-top: 0.5rem; }
-        .search-form input { width: 180px; padding: 0.3rem 0.6rem; border: 1px solid #ddd; font-size: 0.8rem; font-family: inherit; }
-        .search-form input:focus { outline: none; border-color: #c0392b; }
-        #search-results { max-width: 360px; margin: 0.25rem auto; border: 1px solid #ddd; background: #fff; box-shadow: 0 4px 16px rgba(0,0,0,0.08); }
-        #search-results a { display: block; padding: 0.5rem 0.75rem; text-decoration: none; border-bottom: 1px solid #f0f0f0; font-size: 0.85rem; color: #c0392b; }
+        /* ===== MASTHEAD — Editorial Nameplate ===== */
+        .masthead { max-width: 1000px; margin: 0 auto; padding: 2rem 1.5rem 0; text-align: center; }
+        .masthead-rule-top { border: none; border-top: 1px solid #111; margin: 0 0 1rem; }
+        .masthead h1 { font-size: 3rem; font-weight: 900; letter-spacing: -0.03em; text-transform: uppercase; line-height: 1; margin: 0; }
+        .masthead h1 a { color: #111; text-decoration: none; }
+        .masthead h1 a:hover { color: #e63946; }
+        .masthead-desc { font-family: Georgia, 'Times New Roman', serif; font-style: italic; color: #555; font-size: 0.95rem; margin: 0.4rem 0 0; }
+        .masthead-rule-bottom { border: none; border-top: 1px solid #111; margin: 1rem 0 0; }
+
+        /* Navigation — uppercase, small, middot separated */
+        nav.site-nav { display: flex; justify-content: center; align-items: center; flex-wrap: wrap; gap: 0; padding: 0.8rem 0; }
+        nav.site-nav a { font-size: 0.72rem; font-weight: 500; text-transform: uppercase; letter-spacing: 0.1em; color: #111; padding: 0.2rem 0; }
+        nav.site-nav a:hover { color: #e63946; }
+        nav.site-nav .nav-sep { color: #bbb; font-size: 0.5rem; margin: 0 0.75rem; user-select: none; }
+
+        /* Language switcher */
+        .lang-switcher { display: inline-flex; gap: 0.35rem; font-size: 0.7rem; margin-top: 0.5rem; }
+        .lang-switcher a { color: #888; padding: 0.15rem 0.4rem; border: 1px solid #ddd; text-decoration: none; text-transform: uppercase; letter-spacing: 0.05em; transition: all 0.15s ease; }
+        .lang-switcher a:hover { border-color: #e63946; color: #e63946; }
+        .lang-switcher strong { padding: 0.15rem 0.4rem; background: #111; color: #fff; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }
+
+        /* Search — inline editorial */
+        .search-form { display: inline-block; margin-top: 0.6rem; }
+        .search-form input { width: 200px; padding: 0.35rem 0; border: none; border-bottom: 1px solid #ccc; font-size: 0.8rem; font-family: inherit; background: transparent; text-align: center; letter-spacing: 0.02em; transition: border-color 0.15s ease; }
+        .search-form input:focus { outline: none; border-bottom-color: #e63946; }
+        .search-form input::placeholder { color: #bbb; text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.06em; }
+        #search-results { max-width: 400px; margin: 0.25rem auto; background: #fff; border: 1px solid #111; box-shadow: 0 8px 30px rgba(0,0,0,0.12); }
+        #search-results:empty { border: none; box-shadow: none; }
+        #search-results a { display: block; padding: 0.6rem 0.9rem; text-decoration: none; border-bottom: 1px solid #eee; color: #111; transition: background 0.1s ease; }
         #search-results a:last-child { border-bottom: none; }
-        #search-results a:hover { background: #fef6f5; }
-        #search-results strong { color: #1a1a1a; }
-        #search-results .result-meta { font-size: 0.7rem; color: #999; margin-top: 0.1rem; }
-        #search-results .no-results { padding: 0.5rem 0.75rem; color: #999; font-size: 0.85rem; }
+        #search-results a:hover { background: #fef1f2; }
+        #search-results strong { color: #111; font-size: 0.9rem; }
+        #search-results .result-meta { font-size: 0.7rem; color: #888; margin-top: 0.15rem; text-transform: uppercase; letter-spacing: 0.04em; }
+        #search-results .no-results { padding: 0.6rem 0.9rem; color: #888; font-size: 0.85rem; font-style: italic; }
 
-        /* Content area */
-        .content-area { max-width: 1000px; margin: 0 auto; padding: 1.5rem; }
+        /* ===== CONTENT AREA ===== */
+        .content-area { max-width: 1000px; margin: 0 auto; padding: 2rem 1.5rem; }
 
-        /* Article grid — magazine multi-column */
-        main section { margin-bottom: 2rem; }
-        main section > h2 { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.1em; color: #c0392b; font-weight: 700; margin: 0 0 1rem; padding-bottom: 0.5rem; border-bottom: 1px solid #eee; }
-        .article-columns { column-count: 2; column-gap: 2rem; column-rule: 1px solid #eee; }
-        article { break-inside: avoid; margin-bottom: 1.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid #eee; }
-        article:last-child { border-bottom: none; }
-        /* Featured first article spans full width */
-        article:first-child { column-span: all; margin-bottom: 2rem; padding-bottom: 2rem; border-bottom: 2px solid #1a1a1a; }
-        article:first-child h3 { font-size: 1.6rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; line-height: 1.25; }
-        article:first-child p { font-size: 1rem; color: #555; }
-        article h3 { margin: 0 0 0.3rem; font-size: 1.05rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; line-height: 1.3; }
-        article h3 a { color: #1a1a1a; text-decoration: none; }
-        article h3 a:hover { color: #c0392b; }
-        article p { color: #555; font-size: 0.9rem; margin: 0.3rem 0 0; }
-        time { font-size: 0.75rem; color: #999; text-transform: uppercase; letter-spacing: 0.04em; }
-        .reading-time { color: #999; font-size: 0.8rem; }
-        .tags a, .tags span { color: #c0392b; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; margin-right: 0.5rem; }
+        /* Section labels — editorial red uppercase */
+        main section { margin-bottom: 3rem; }
+        main section > h2 { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.12em; color: #e63946; font-weight: 700; margin: 0 0 1.25rem; padding-bottom: 0.6rem; border-bottom: 1px solid #111; display: flex; align-items: center; gap: 0.5rem; }
+
+        /* ===== ARTICLE GRID — 3 Column Magazine Layout ===== */
+        .article-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0; }
+        .article-grid article { padding: 0 1.25rem; border-right: 1px solid #111; }
+        .article-grid article:nth-child(3n) { border-right: none; }
+        .article-grid article:nth-child(n+4) { border-top: 1px solid #111; padding-top: 1.5rem; margin-top: 0; }
+
+        /* Feature article — full span */
+        .article-grid article:first-child { grid-column: 1 / -1; border-right: none; padding: 0 0 1.5rem; margin-bottom: 0.5rem; border-bottom: 2px solid #111; }
+        .article-grid article:first-child h3 { font-size: 2rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; line-height: 1.2; margin: 0 0 0.4rem; }
+        .article-grid article:first-child p { font-size: 1.05rem; color: #555; line-height: 1.6; }
+
+        /* Standard article cards */
+        article { margin-bottom: 1.5rem; padding-bottom: 1.5rem; }
+        article h3 { margin: 0 0 0.3rem; font-size: 1rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; line-height: 1.3; }
+        article h3 a { color: #111; text-decoration: none; }
+        article h3 a:hover { color: #e63946; }
+        article p { color: #555; font-size: 0.88rem; margin: 0.3rem 0 0; line-height: 1.5; }
+        time { font-size: 0.68rem; color: #888; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 500; }
+        .reading-time { color: #888; font-size: 0.78rem; }
+        .tags a, .tags span { color: #e63946; font-size: 0.68rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; margin-right: 0.5rem; }
         .tags a:hover { text-decoration: underline; }
 
-        /* Single article pages — elegant reading column */
-        main > article { max-width: 680px; margin: 0 auto; border-bottom: none; padding-bottom: 0; }
-        main > article:first-child { column-span: none; border-bottom: none; }
-        main > article h1 { font-size: 2.2rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; line-height: 1.2; margin: 0 0 0.5rem; }
-        main > article h2 { font-size: 1.3rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; margin-top: 2.5rem; padding-bottom: 0.3rem; border-bottom: 1px solid #eee; }
-        main > article h3 { font-size: 1.05rem; font-weight: 600; margin-top: 1.5rem; }
-        main > article p { font-size: 1.05rem; line-height: 1.8; color: #333; }
-        main > article > p:first-of-type::first-letter { font-size: 3.2rem; font-family: Georgia, serif; float: left; line-height: 1; margin: 0.1rem 0.15rem 0 0; font-weight: 700; color: #c0392b; }
+        /* ===== SINGLE ARTICLE PAGES — Editorial Reading Column ===== */
+        main > article { max-width: 680px; margin: 0 auto; border-right: none; padding: 0; }
+        main > article:first-child { grid-column: unset; border-bottom: none; margin-bottom: 0; }
+        main > article h1 { font-size: 2.4rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; line-height: 1.15; margin: 0 0 0.6rem; letter-spacing: -0.01em; }
+        main > article h2 { font-size: 1.35rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; margin-top: 2.5rem; margin-bottom: 0.5rem; padding-bottom: 0.35rem; border-bottom: 1px solid #eee; }
+        main > article h3 { font-size: 1.1rem; font-weight: 700; margin-top: 2rem; margin-bottom: 0.4rem; font-family: Georgia, 'Times New Roman', serif; }
+        main > article h4 { font-size: 0.95rem; font-weight: 700; margin-top: 1.5rem; text-transform: uppercase; letter-spacing: 0.04em; }
+        main > article p { font-family: Georgia, 'Times New Roman', serif; font-size: 1.1rem; line-height: 1.8; color: #111; margin-bottom: 1.2rem; }
+        main > article ul, main > article ol { font-family: Georgia, 'Times New Roman', serif; font-size: 1.1rem; line-height: 1.8; color: #111; margin: 0 0 1.2rem 1.5rem; }
+        main > article li { margin-bottom: 0.3rem; }
 
-        /* Typography */
-        pre { background: #1e1e2e; color: #cdd6f4; padding: 1rem; overflow-x: auto; font-size: 0.85rem; }
-        pre code { background: none; color: inherit; padding: 0; }
-        code { font-size: 0.85em; background: #f5f5f5; padding: 0.15em 0.35em; color: #c0392b; }
-        blockquote { border-left: 3px solid #c0392b; margin: 1.5rem 0; padding: 0.5rem 1.5rem; font-family: Georgia, serif; font-style: italic; font-size: 1.1rem; color: #555; }
-        img { max-width: 100%; height: auto; }
-        figure { margin: 1.5rem 0; }
+        /* Drop cap — editorial signature */
+        main > article > p:first-of-type::first-letter {
+            float: left;
+            font-size: 4rem;
+            line-height: 0.8;
+            font-family: Georgia, serif;
+            font-weight: 700;
+            color: #e63946;
+            margin: 0.05em 0.1em 0 0;
+        }
+
+        /* ===== ORNAMENTAL DIVIDERS ===== */
+        hr { border: none; text-align: center; margin: 3rem 0; }
+        hr::before { content: '\25C6\2002\25C6\2002\25C6'; letter-spacing: 0.5em; color: #e63946; font-size: 0.6rem; }
+
+        /* ===== BLOCKQUOTES — Pull-quote Style ===== */
+        blockquote { border-left: 3px solid #e63946; margin: 2rem 0; padding: 0.75rem 0 0.75rem 1.5rem; font-family: Georgia, serif; font-style: italic; font-size: 1.3rem; line-height: 1.5; color: #333; }
+        blockquote p { font-size: inherit; line-height: inherit; color: inherit; margin-bottom: 0.5rem; }
+        blockquote p:last-child { margin-bottom: 0; }
+
+        /* ===== CODE BLOCKS ===== */
+        pre { background: #111; color: #e8e8e8; padding: 1.25rem 1.5rem; overflow-x: auto; font-size: 0.85rem; line-height: 1.65; margin: 1.5rem 0; border-left: 3px solid #e63946; }
+        pre code { background: none; color: inherit; padding: 0; font-size: inherit; border: none; }
+        code { font-size: 0.85em; background: #f5f5f5; padding: 0.15em 0.4em; color: #e63946; border: 1px solid #eee; font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace; }
+
+        /* ===== FIGURES ===== */
+        figure { margin: 2rem 0; }
         figure img { display: block; }
-        figcaption { font-size: 0.8rem; color: #888; margin-top: 0.3rem; font-style: italic; }
-        hr { border: none; height: 1px; background: #ddd; margin: 2rem 0; }
+        figcaption { font-size: 0.78rem; color: #888; margin-top: 0.5rem; font-style: italic; font-family: Georgia, serif; text-align: center; }
 
-        /* Embeds */
-        .video-embed { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin: 1.5rem 0; }
+        /* ===== EMBEDS ===== */
+        .video-embed { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin: 2rem 0; background: #f5f5f5; }
         .video-embed iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
         .gist-embed { margin: 1.5rem 0; }
 
-        /* Callouts */
-        .callout { padding: 1rem 1.25rem; margin: 1.5rem 0; border-left: 3px solid #c0392b; background: #fef6f5; }
-        .callout-title { font-weight: 700; margin-bottom: 0.4rem; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.04em; }
-        .callout-info { border-left-color: #2980b9; background: #eef6fc; }
+        /* ===== CALLOUTS ===== */
+        .callout { padding: 1.1rem 1.35rem; margin: 1.5rem 0; border-left: 3px solid #e63946; background: #fef1f2; font-size: 0.95rem; }
+        .callout-title { font-weight: 700; margin-bottom: 0.4rem; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.06em; color: #111; }
+        .callout-info { border-left-color: #2563eb; background: #eff6ff; }
+        .callout-info .callout-title { color: #1e40af; }
         .callout-warning { border-left-color: #d97706; background: #fffbeb; }
-        .callout-danger { border-left-color: #c0392b; background: #fef6f5; }
-        .callout-tip { border-left-color: #27ae60; background: #f0fdf4; }
-        .callout-note { border-left-color: #7f8c8d; background: #f9fafb; }
+        .callout-warning .callout-title { color: #92400e; }
+        .callout-danger { border-left-color: #e63946; background: #fef1f2; }
+        .callout-danger .callout-title { color: #c1121f; }
+        .callout-tip { border-left-color: #059669; background: #ecfdf5; }
+        .callout-tip .callout-title { color: #065f46; }
+        .callout-note { border-left-color: #6b7280; background: #f9fafb; }
+        .callout-note .callout-title { color: #4b5563; }
         .callout p:last-child { margin-bottom: 0; }
 
-        /* Contact form */
+        /* ===== CONTACT FORM ===== */
         .contact-form { max-width: 480px; }
-        .contact-form-field { margin-bottom: 1rem; }
-        .contact-form-field label { display: block; font-weight: 600; margin-bottom: 0.25rem; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.04em; color: #555; }
-        .contact-form-field input, .contact-form-field textarea { width: 100%; padding: 0.5rem 0.75rem; border: 1px solid #ddd; font: inherit; box-sizing: border-box; }
-        .contact-form-field input:focus, .contact-form-field textarea:focus { outline: none; border-color: #c0392b; }
-        .contact-form-submit { background: #c0392b; color: #fff; border: none; padding: 0.5rem 1.5rem; font: inherit; font-weight: 600; cursor: pointer; text-transform: uppercase; letter-spacing: 0.04em; font-size: 0.85rem; }
-        .contact-form-submit:hover { background: #a93226; }
+        .contact-form-field { margin-bottom: 1.25rem; }
+        .contact-form-field label { display: block; font-weight: 600; margin-bottom: 0.3rem; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: #555; }
+        .contact-form-field input, .contact-form-field textarea { width: 100%; padding: 0.6rem 0.8rem; border: 1px solid #111; font-family: Georgia, serif; font-size: 0.95rem; background: #fff; transition: border-color 0.15s ease; }
+        .contact-form-field input:focus, .contact-form-field textarea:focus { outline: none; border-color: #e63946; box-shadow: 0 0 0 1px #e63946; }
+        .contact-form-submit { background: #e63946; color: #fff; border: none; padding: 0.6rem 2rem; font-family: system-ui, sans-serif; font-weight: 700; cursor: pointer; text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.78rem; transition: background 0.15s ease; }
+        .contact-form-submit:hover { background: #c1121f; }
         .contact-form-honeypot { display: none; }
         .contact-form-embed { min-height: 400px; }
-        .contact-form-error { color: #c0392b; background: #fef6f5; padding: 1rem; border-left: 3px solid #c0392b; }
+        .contact-form-error { color: #c1121f; background: #fef1f2; padding: 1rem; border-left: 3px solid #e63946; font-size: 0.9rem; }
 
-        /* Trust center */
+        /* ===== TABLES ===== */
+        table { border-collapse: collapse; width: 100%; margin: 1.5rem 0; font-size: 0.9rem; }
+        th, td { border: 1px solid #111; padding: 0.55rem 0.85rem; text-align: left; }
+        th { background: #f5f5f5; font-weight: 700; text-transform: uppercase; font-size: 0.72rem; letter-spacing: 0.06em; }
+
+        /* Task lists */
+        ul.contains-task-list, ol.contains-task-list { list-style: none; padding-left: 0; }
+        li.task-list-item { display: flex; align-items: baseline; gap: 0.5rem; }
+        li.task-list-item input[type="checkbox"] { margin: 0; pointer-events: none; accent-color: #e63946; }
+
+        /* Footnotes */
+        .footnote-definition { font-size: 0.85rem; color: #555; border-top: 1px solid #ddd; margin-top: 2.5rem; padding-top: 0.75rem; }
+        .footnote-definition p { display: inline; }
+        sup.footnote-reference a { text-decoration: none; color: #e63946; font-weight: 700; }
+
+        /* ===== TABLE OF CONTENTS ===== */
+        .toc { margin: 2rem 0; padding: 1.1rem 1.35rem; border: 1px solid #111; background: #fff; }
+        .toc::before { content: 'CONTENTS'; display: block; font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.12em; font-weight: 700; color: #e63946; margin-bottom: 0.6rem; }
+        .toc > ul { margin: 0; padding-left: 1.25rem; }
+        .toc ul ul { padding-left: 1rem; }
+        .toc li { margin: 0.3rem 0; font-size: 0.9rem; }
+        .toc a { text-decoration: none; color: #111; }
+        .toc a:hover { color: #e63946; }
+
+        /* ===== PAGINATION ===== */
+        .pagination { display: flex; justify-content: space-between; align-items: center; margin-top: 2.5rem; padding-top: 1.25rem; border-top: 1px solid #111; }
+        .pagination a { text-decoration: none; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; color: #111; }
+        .pagination a:hover { color: #e63946; }
+        .pagination span { color: #888; font-size: 0.8rem; }
+
+        /* ===== TRUST CENTER ===== */
         .trust-hub { max-width: 1000px; margin: 0 auto; }
-        .trust-hero { margin-bottom: 2rem; }
-        .trust-hero h1 { font-size: 2rem; font-family: Georgia, serif; font-weight: 700; margin-bottom: 0.5rem; }
+        .trust-hero { margin-bottom: 2.5rem; }
+        .trust-hero h1 { font-size: 2.2rem; font-family: Georgia, serif; font-weight: 700; margin-bottom: 0.5rem; }
         .trust-section { margin-bottom: 2.5rem; }
-        .trust-section h2 { font-size: 1.3rem; font-family: Georgia, serif; margin-bottom: 1rem; border-bottom: 1px solid #eee; padding-bottom: 0.5rem; }
-        .trust-breadcrumb { font-size: 0.8rem; color: #999; margin-bottom: 1.5rem; }
-        .trust-breadcrumb a { color: #c0392b; text-decoration: none; }
-        .trust-breadcrumb a:hover { text-decoration: underline; }
-        .trust-description { color: #555; margin-bottom: 1.5rem; line-height: 1.7; }
+        .trust-section h2 { font-size: 1.3rem; font-family: Georgia, serif; margin-bottom: 1rem; border-bottom: 1px solid #111; padding-bottom: 0.5rem; }
+        .trust-breadcrumb { font-size: 0.72rem; color: #888; margin-bottom: 1.5rem; text-transform: uppercase; letter-spacing: 0.04em; }
+        .trust-breadcrumb a { color: #e63946; text-decoration: none; }
+        .trust-breadcrumb a:hover { color: #c1121f; }
+        .trust-description { color: #555; margin-bottom: 1.5rem; line-height: 1.7; font-family: Georgia, serif; }
         .cert-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.5rem; }
-        .cert-card { border: 1px solid #ddd; padding: 1.25rem; background: #fff; transition: border-color 0.15s; }
-        .cert-card:hover { border-color: #c0392b; }
+        .cert-card { border: 1px solid #111; padding: 1.25rem; background: #fff; transition: all 0.2s ease; }
+        .cert-card:hover { border-color: #e63946; box-shadow: 4px 4px 0 #e63946; }
         .cert-card__header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
-        .cert-card__title { font-weight: 700; font-size: 1rem; color: #1a1a1a; }
+        .cert-card__title { font-weight: 700; font-size: 1rem; color: #111; }
         .cert-card__desc { font-size: 0.9rem; color: #555; margin-bottom: 0.75rem; }
-        .cert-card__link { font-size: 0.85rem; color: #c0392b; text-decoration: none; font-weight: 600; }
-        .cert-card__link:hover { text-decoration: underline; }
-        .cert-status { display: inline-block; font-size: 0.65rem; font-weight: 700; padding: 0.15rem 0.5rem; text-transform: uppercase; letter-spacing: 0.05em; }
-        .cert-status--active { background: #dcfce7; color: #166534; }
-        .cert-status--in_progress { background: #fef9c3; color: #854d0e; }
-        .cert-status--planned { background: #f3f4f6; color: #6b7280; }
-        .cert-detail { margin-bottom: 2rem; padding: 1.25rem; border: 1px solid #ddd; background: #fafafa; }
+        .cert-card__link { font-size: 0.78rem; color: #e63946; text-decoration: none; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; }
+        .cert-card__link:hover { color: #c1121f; }
+        .cert-status { display: inline-block; font-size: 0.6rem; font-weight: 700; padding: 0.15rem 0.5rem; text-transform: uppercase; letter-spacing: 0.06em; border: 1px solid; }
+        .cert-status--active { border-color: #059669; color: #059669; background: #ecfdf5; }
+        .cert-status--in_progress { border-color: #d97706; color: #92400e; background: #fffbeb; }
+        .cert-status--planned { border-color: #6b7280; color: #6b7280; background: #f9fafb; }
+        .cert-detail { margin-bottom: 2rem; padding: 1.25rem; border: 1px solid #111; background: #fff; }
         .cert-meta { font-size: 0.9rem; color: #555; margin-bottom: 0.35rem; }
-        .cert-meta strong { color: #1a1a1a; }
+        .cert-meta strong { color: #111; }
         .trust-item { padding: 0.75rem 0; border-bottom: 1px solid #eee; }
         .trust-item:last-child { border-bottom: none; }
         .subprocessor-table-wrap { overflow-x: auto; margin: 1.5rem 0; }
         .subprocessor-table { border-collapse: collapse; width: 100%; }
-        .subprocessor-table th, .subprocessor-table td { border: 1px solid #ddd; padding: 0.5rem 0.75rem; text-align: left; font-size: 0.85rem; }
-        .subprocessor-table th { background: #f6f6f6; font-weight: 600; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.04em; }
+        .subprocessor-table th, .subprocessor-table td { border: 1px solid #111; padding: 0.55rem 0.85rem; text-align: left; font-size: 0.85rem; }
+        .subprocessor-table th { background: #f5f5f5; font-weight: 700; text-transform: uppercase; font-size: 0.68rem; letter-spacing: 0.06em; }
         .faq-section { margin-top: 2rem; }
-        .faq-item { border-bottom: 1px solid #eee; }
-        .faq-item summary { padding: 0.75rem 0; cursor: pointer; font-weight: 600; color: #1a1a1a; }
-        .faq-item summary:hover { color: #c0392b; }
-        .faq-answer { padding: 0 0 1rem; color: #555; line-height: 1.7; }
+        .faq-item { border-bottom: 1px solid #ddd; }
+        .faq-item summary { padding: 0.85rem 0; cursor: pointer; font-weight: 700; color: #111; font-size: 0.95rem; }
+        .faq-item summary:hover { color: #e63946; }
+        .faq-item summary::marker { color: #e63946; }
+        .faq-answer { padding: 0 0 1rem; color: #555; line-height: 1.7; font-family: Georgia, serif; }
         .trust-page { margin-bottom: 2rem; }
 
-        /* Changelog */
+        /* ===== CHANGELOG ===== */
         .changelog-entry-header { margin-bottom: 1.5rem; }
-        .changelog-meta { display: flex; align-items: center; gap: 1rem; margin-top: 0.5rem; color: #999; font-size: 0.85rem; }
-        .changelog-summary { color: #555; font-size: 1.05rem; margin-bottom: 1.5rem; }
+        .changelog-meta { display: flex; align-items: center; gap: 1rem; margin-top: 0.5rem; color: #888; font-size: 0.85rem; }
+        .changelog-summary { color: #555; font-size: 1.05rem; margin-bottom: 1.5rem; font-family: Georgia, serif; }
         .changelog-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
-        .changelog-tag { display: inline-block; padding: 0.15rem 0.5rem; font-size: 0.65rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; }
-        .changelog-tag--new { background: #dcfce7; color: #166534; }
-        .changelog-tag--fix { background: #dbeafe; color: #1e40af; }
-        .changelog-tag--breaking { background: #fee2e2; color: #991b1b; }
-        .changelog-tag--improvement { background: #f3e8ff; color: #6b21a8; }
-        .changelog-tag--deprecated { background: #f3f4f6; color: #4b5563; }
+        .changelog-tag { display: inline-block; padding: 0.15rem 0.55rem; font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; border: 1px solid; }
+        .changelog-tag--new { border-color: #059669; color: #059669; background: #ecfdf5; }
+        .changelog-tag--fix { border-color: #2563eb; color: #2563eb; background: #eff6ff; }
+        .changelog-tag--breaking { border-color: #dc2626; color: #dc2626; background: #fef2f2; }
+        .changelog-tag--improvement { border-color: #7c3aed; color: #7c3aed; background: #f5f3ff; }
+        .changelog-tag--deprecated { border-color: #6b7280; color: #6b7280; background: #f9fafb; }
         .changelog-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 1rem; margin-bottom: 2rem; }
         .changelog-header h1 { margin-bottom: 0; font-family: Georgia, serif; }
-        .changelog-rss { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.75rem; color: #999; text-decoration: none; padding: 0.25rem 0.6rem; border: 1px solid #ddd; }
-        .changelog-rss:hover { color: #c0392b; border-color: #c0392b; }
+        .changelog-rss { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.7rem; color: #888; text-decoration: none; padding: 0.25rem 0.65rem; border: 1px solid #111; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; }
+        .changelog-rss:hover { color: #e63946; border-color: #e63946; }
         .changelog-back { margin-bottom: 1.5rem; }
-        .changelog-back a { color: #999; text-decoration: none; font-size: 0.85rem; }
-        .changelog-back a:hover { color: #c0392b; }
+        .changelog-back a { color: #888; text-decoration: none; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; }
+        .changelog-back a:hover { color: #e63946; }
         .changelog-timeline { position: relative; padding-left: 2rem; }
-        .changelog-timeline::before { content: ''; position: absolute; left: 0; top: 0.5rem; bottom: 0; width: 2px; background: #eee; }
+        .changelog-timeline::before { content: ''; position: absolute; left: 0; top: 0.5rem; bottom: 0; width: 2px; background: #e63946; }
         .changelog-item { position: relative; padding-bottom: 1.5rem; border-bottom: 1px solid #eee; margin-bottom: 0; }
-        .changelog-item::before { content: ''; position: absolute; left: -2rem; top: 0.5rem; width: 10px; height: 10px; border-radius: 50%; background: #c0392b; transform: translateX(-4px); }
+        .changelog-item::before { content: ''; position: absolute; left: -2rem; top: 0.55rem; width: 10px; height: 10px; border-radius: 50%; background: #e63946; border: 2px solid #fff; transform: translateX(-4px); box-shadow: 0 0 0 1px #e63946; }
         .changelog-item:last-child { border-bottom: none; }
         .changelog-item-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 0.5rem; }
         .changelog-item-header h2 { margin: 0; font-size: 1.15rem; font-family: Georgia, serif; }
-        .changelog-item-header time { color: #999; font-size: 0.8rem; white-space: nowrap; }
+        .changelog-item-header time { color: #888; font-size: 0.72rem; white-space: nowrap; text-transform: uppercase; letter-spacing: 0.06em; }
         .changelog-item .changelog-tags { margin-top: 0.5rem; }
         .changelog-item p, .changelog-item .excerpt { margin-top: 0.5rem; color: #555; }
         .changelog-feed .changelog-item::before { display: none; }
         .changelog-feed { display: flex; flex-direction: column; gap: 0; }
 
-        /* Roadmap */
+        /* ===== ROADMAP ===== */
         .roadmap-back { margin-bottom: 1.5rem; }
-        .roadmap-back a { color: #999; text-decoration: none; font-size: 0.85rem; }
-        .roadmap-back a:hover { color: #c0392b; }
+        .roadmap-back a { color: #888; text-decoration: none; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; }
+        .roadmap-back a:hover { color: #e63946; }
         .roadmap-entry-header { margin-bottom: 1.5rem; }
-        .roadmap-summary { color: #555; font-size: 1.05rem; margin-bottom: 1.5rem; }
+        .roadmap-summary { color: #555; font-size: 1.05rem; margin-bottom: 1.5rem; font-family: Georgia, serif; }
         .roadmap-status-badges { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
-        .roadmap-status { display: inline-block; padding: 0.15rem 0.6rem; font-size: 0.65rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; }
-        .roadmap-status--planned { background: #dbeafe; color: #1e40af; }
-        .roadmap-status--in-progress { background: #fef3c7; color: #92400e; }
-        .roadmap-status--done { background: #dcfce7; color: #166534; }
-        .roadmap-status--cancelled { background: #f3f4f6; color: #4b5563; text-decoration: line-through; }
-        .roadmap-grouped { display: flex; flex-direction: column; gap: 2rem; }
-        .roadmap-section-header { display: flex; align-items: center; gap: 0.75rem; font-size: 1rem; margin-bottom: 1rem; font-family: Georgia, serif; }
-        .roadmap-items { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1rem; }
-        .roadmap-card { padding: 1rem 1.25rem; border: 1px solid #eee; transition: border-color 0.15s; }
-        .roadmap-card:hover { border-color: #c0392b; }
+        .roadmap-status { display: inline-block; padding: 0.15rem 0.6rem; font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; border: 1px solid; }
+        .roadmap-status--planned { border-color: #2563eb; color: #2563eb; background: #eff6ff; }
+        .roadmap-status--in-progress { border-color: #d97706; color: #92400e; background: #fffbeb; }
+        .roadmap-status--done { border-color: #059669; color: #059669; background: #ecfdf5; }
+        .roadmap-status--cancelled { border-color: #6b7280; color: #6b7280; background: #f9fafb; text-decoration: line-through; }
+        .roadmap-grouped { display: flex; flex-direction: column; gap: 2.5rem; }
+        .roadmap-section-header { display: flex; align-items: center; gap: 0.75rem; font-size: 1rem; margin-bottom: 1rem; font-family: Georgia, serif; border-bottom: 1px solid #111; padding-bottom: 0.5rem; }
+        .roadmap-items { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1.25rem; }
+        .roadmap-card { padding: 1rem 1.25rem; border: 1px solid #111; transition: all 0.2s ease; background: #fff; }
+        .roadmap-card:hover { border-color: #e63946; box-shadow: 4px 4px 0 #e63946; }
         .roadmap-card h3 { margin: 0 0 0.25rem; font-size: 0.95rem; font-family: Georgia, serif; }
         .roadmap-card p, .roadmap-card .excerpt { margin: 0; color: #555; font-size: 0.85rem; }
         .roadmap-kanban { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; }
-        .roadmap-column-header { font-size: 0.95rem; margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem; }
-        .roadmap-count { font-size: 0.75rem; color: #999; font-weight: 400; }
+        .roadmap-column-header { font-size: 0.95rem; margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem; font-family: Georgia, serif; border-bottom: 1px solid #111; padding-bottom: 0.5rem; }
+        .roadmap-count { font-size: 0.7rem; color: #888; font-weight: 400; text-transform: uppercase; letter-spacing: 0.04em; }
         .roadmap-timeline { position: relative; padding-left: 2rem; }
-        .roadmap-timeline::before { content: ''; position: absolute; left: 0.5rem; top: 0; bottom: 0; width: 2px; background: #eee; }
+        .roadmap-timeline::before { content: ''; position: absolute; left: 0.5rem; top: 0; bottom: 0; width: 2px; background: #e63946; }
         .roadmap-milestone { position: relative; margin-bottom: 2rem; }
-        .roadmap-milestone-dot { position: absolute; left: -1.75rem; top: 0.3rem; width: 12px; height: 12px; border-radius: 50%; border: 2px solid #c0392b; background: #fff; }
+        .roadmap-milestone-dot { position: absolute; left: -1.75rem; top: 0.3rem; width: 12px; height: 12px; border-radius: 50%; border: 2px solid #e63946; background: #fff; }
         .roadmap-milestone-dot .roadmap-status { display: none; }
         .roadmap-milestone-content h3 { margin: 0 0 0.25rem; font-family: Georgia, serif; }
         .roadmap-milestone-content p { margin: 0.25rem 0 0; color: #555; font-size: 0.85rem; }
-        @media (max-width: 768px) { .roadmap-kanban { grid-template-columns: 1fr; } }
 
-        /* Tables */
-        table { border-collapse: collapse; width: 100%; margin: 1.5rem 0; }
-        th, td { border: 1px solid #ddd; padding: 0.5rem 0.75rem; text-align: left; font-size: 0.9rem; }
-        th { background: #f6f6f6; font-weight: 600; }
-        ul.contains-task-list, ol.contains-task-list { list-style: none; padding-left: 0; }
-        li.task-list-item { display: flex; align-items: baseline; gap: 0.5rem; }
-        li.task-list-item input[type="checkbox"] { margin: 0; pointer-events: none; }
-        .footnote-definition { font-size: 0.85rem; color: #555; border-top: 1px solid #eee; margin-top: 2rem; padding-top: 0.75rem; }
-        .footnote-definition p { display: inline; }
-        sup.footnote-reference a { text-decoration: none; color: #c0392b; font-weight: 600; }
+        /* ===== FOOTER — Editorial Small Caps ===== */
+        footer { max-width: 1000px; margin: 4rem auto 0; padding: 1.5rem; text-align: center; }
+        footer .footer-rule { border: none; border-top: 1px solid #111; margin: 0 0 1.5rem; }
+        footer nav { margin-bottom: 0.75rem; }
+        footer nav a { color: #555; text-decoration: none; text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.68rem; font-weight: 500; }
+        footer nav a:hover { color: #e63946; }
+        footer p { color: #888; font-size: 0.75rem; letter-spacing: 0.02em; margin: 0; }
 
-        /* TOC & Pagination */
-        .toc { margin: 1.5rem 0; padding: 1rem 1.25rem; border: 1px solid #eee; background: #fafafa; }
-        .toc > ul { margin: 0; padding-left: 1.25rem; }
-        .toc ul ul { padding-left: 1rem; }
-        .toc li { margin: 0.25rem 0; }
-        .toc a { text-decoration: none; }
-        .toc a:hover { text-decoration: underline; }
-        .pagination { display: flex; justify-content: space-between; align-items: center; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #eee; }
-        .pagination a { text-decoration: none; }
-        .pagination a:hover { text-decoration: underline; }
-        .pagination span { color: #999; font-size: 0.85rem; }
-
-        /* Footer */
-        footer { max-width: 1000px; margin: 3rem auto 0; padding: 1.5rem; border-top: 3px double #1a1a1a; color: #999; font-size: 0.8rem; text-align: center; }
-        footer nav { margin-bottom: 0.5rem; }
-        footer nav a { color: #555; text-decoration: none; text-transform: uppercase; letter-spacing: 0.04em; font-size: 0.75rem; }
-        footer nav a:hover { color: #c0392b; }
-
-        /* Accessibility */
-        .skip-link { position: absolute; top: -100%; left: 0; padding: 0.5rem 1rem; background: #c0392b; color: #fff; z-index: 100; text-decoration: none; }
+        /* ===== ACCESSIBILITY ===== */
+        .skip-link { position: absolute; top: -100%; left: 0; padding: 0.5rem 1rem; background: #e63946; color: #fff; z-index: 1000; text-decoration: none; font-size: 0.85rem; font-weight: 600; }
         .skip-link:focus { top: 0; }
-        :focus-visible { outline: 2px solid #c0392b; outline-offset: 2px; }
+        :focus-visible { outline: 2px solid #e63946; outline-offset: 2px; }
         @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } }
-        @media (max-width: 700px) {
-            .article-columns { column-count: 1; }
-            article:first-child h3 { font-size: 1.3rem; }
-            .masthead h1 { font-size: 1.8rem; }
+
+        /* ===== RESPONSIVE ===== */
+        @media (max-width: 768px) {
+            .masthead h1 { font-size: 2rem; }
+            .article-grid { grid-template-columns: 1fr; }
+            .article-grid article { border-right: none; padding: 0; border-bottom: 1px solid #111; padding-bottom: 1.25rem; margin-bottom: 1.25rem; }
+            .article-grid article:nth-child(n+4) { border-top: none; padding-top: 0; }
+            .article-grid article:first-child h3 { font-size: 1.5rem; }
+            main > article h1 { font-size: 1.8rem; }
+            .roadmap-kanban { grid-template-columns: 1fr; }
+            .content-area { padding: 1.5rem 1rem; }
+            .masthead { padding: 1.5rem 1rem 0; }
+            footer { padding: 1.5rem 1rem; }
+            nav.site-nav { flex-wrap: wrap; justify-content: center; }
+        }
+        @media (max-width: 480px) {
+            .masthead h1 { font-size: 1.6rem; }
+            main > article h1 { font-size: 1.5rem; }
+            main > article > p:first-of-type::first-letter { font-size: 3rem; }
+            .search-form input { width: 160px; }
         }
     </style>
     {% block extra_css %}{% endblock %}
@@ -284,11 +356,13 @@
     <header>
     {% block header %}
         <div class="masthead">
+            <hr class="masthead-rule-top">
             <h1><a href="{{ lang_prefix }}/">{{ site.title }}</a></h1>
-            {% if site.description %}<p>{{ site.description }}</p>{% endif %}
+            {% if site.description %}<p class="masthead-desc">{{ site.description }}</p>{% endif %}
+            <hr class="masthead-rule-bottom">
             {% if data.nav %}
             <nav class="site-nav" aria-label="Main navigation">
-                {% for item in data.nav %}{% if item.external %}<a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.title }}</a>{% else %}<a href="{{ lang_prefix }}{{ item.url }}">{{ item.title }}</a>{% endif %}{% endfor %}
+                {% for item in data.nav %}{% if not loop.first %}<span class="nav-sep">&middot;</span>{% endif %}{% if item.external %}<a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.title }}</a>{% else %}<a href="{{ lang_prefix }}{{ item.url }}">{{ item.title }}</a>{% endif %}{% endfor %}
             </nav>
             {% endif %}
             {% if translations | length > 1 %}
@@ -307,6 +381,7 @@
         {% block content %}{% endblock %}
     </main>
     <footer>
+        <hr class="footer-rule">
         {% if data.footer %}{% if data.footer.links %}
         <nav aria-label="Footer navigation">
             {% for link in data.footer.links %}{% if link.external %}<a href="{{ link.url }}" target="_blank" rel="noopener">{{ link.title }}</a>{% else %}<a href="{{ lang_prefix }}{{ link.url }}">{{ link.title }}</a>{% endif %}{% if not loop.last %} &middot; {% endif %}{% endfor %}

--- a/src/themes/magazine.tera
+++ b/src/themes/magazine.tera
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html lang="{{ lang }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="/favicon.ico">
+    <title>{% block title %}{{ site.title }}{% endblock %}</title>
+    <meta name="description" content="{{ page.description | default(value=site.description) }}">
+    <link rel="canonical" href="{{ site.base_url }}{{ page.url | default(value='/') }}">
+    <meta property="og:type" content="{% if page.collection %}article{% else %}website{% endif %}">
+    <meta property="og:url" content="{{ site.base_url }}{{ page.url | default(value='/') }}">
+    <meta property="og:title" content="{{ page.title | default(value=site.title) }}">
+    <meta property="og:description" content="{{ page.description | default(value=site.description) }}">
+    {% if page.image %}<meta property="og:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    <meta property="og:site_name" content="{{ site.title }}">
+    <meta property="og:locale" content="{{ lang }}">
+    <meta name="twitter:card" content="{% if page.image %}summary_large_image{% else %}summary{% endif %}">
+    <meta name="twitter:title" content="{{ page.title | default(value=site.title) }}">
+    <meta name="twitter:description" content="{{ page.description | default(value=site.description) }}">
+    {% if page.image %}<meta name="twitter:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    {% if page.robots %}<meta name="robots" content="{{ page.robots }}">{% endif %}
+    <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ lang_prefix }}/feed.xml">
+    <link rel="alternate" type="text/plain" title="LLM Summary" href="{{ lang_prefix }}/llms.txt">
+    {% if page.url %}<link rel="alternate" type="text/markdown" title="Markdown" href="{{ site.base_url }}{{ page.url }}.md">{% endif %}
+    {% if translations %}{% for t in translations %}<link rel="alternate" hreflang="{{ t.lang }}" href="{{ site.base_url }}{{ t.url }}">
+    {% endfor %}<link rel="alternate" hreflang="x-default" href="{{ site.base_url }}{{ page.url | default(value='/') }}">
+    {% endif %}
+    <script type="application/ld+json">
+    {% set _ld_url = page.url | default(value='/') %}{% set _ld_href = site.base_url ~ _ld_url %}{% set _ld_title = page.title | default(value=site.title) %}{% set _ld_desc = page.description | default(value=site.description) %}
+    {% if page.collection == 'posts' %}{"@context":"https://schema.org","@type":"BlogPosting","headline":{{ _ld_title | json_encode() }},"description":{{ _ld_desc | json_encode() }},"datePublished":{{ page.date | default(value='') | json_encode() }}{% if page.updated %},"dateModified":{{ page.updated | json_encode() }}{% endif %},"author":{"@type":"Person","name":{{ site.author | json_encode() }}},"publisher":{"@type":"Organization","name":{{ site.title | json_encode() }}},"url":{{ _ld_href | json_encode() }}}
+    {% elif page.collection %}{"@context":"https://schema.org","@type":"Article","headline":{{ _ld_title | json_encode() }},"description":{{ _ld_desc | json_encode() }}{% if page.updated %},"dateModified":{{ page.updated | json_encode() }}{% endif %},"author":{"@type":"Person","name":{{ site.author | json_encode() }}},"publisher":{"@type":"Organization","name":{{ site.title | json_encode() }}},"url":{{ _ld_href | json_encode() }}}
+    {% else %}{"@context":"https://schema.org","@type":"WebSite","name":{{ site.title | json_encode() }},"description":{{ site.description | json_encode() }},"url":{{ site.base_url | json_encode() }}}
+    {% endif %}
+    </script>
+    <style>
+        *, *::before, *::after { box-sizing: border-box; }
+        body { margin: 0; padding: 0; font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; color: #1a1a1a; background: #fff; }
+        a { color: #c0392b; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+
+        /* Masthead — magazine nameplate */
+        .masthead { max-width: 1000px; margin: 0 auto; padding: 1.5rem 1.5rem 0; text-align: center; border-bottom: 3px double #1a1a1a; }
+        .masthead h1 { margin: 0; font-size: 2.5rem; font-weight: 900; letter-spacing: 0.04em; text-transform: uppercase; line-height: 1.1; }
+        .masthead h1 a { color: #1a1a1a; text-decoration: none; }
+        .masthead p { margin: 0.25rem 0 0.75rem; color: #888; font-size: 0.85rem; font-style: italic; }
+        nav.site-nav { display: flex; justify-content: center; gap: 0.25rem; padding: 0.75rem 0; border-top: 1px solid #ddd; margin-top: 0.75rem; }
+        nav.site-nav a { font-size: 0.8rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: #1a1a1a; padding: 0.25rem 0.75rem; }
+        nav.site-nav a:hover { color: #c0392b; text-decoration: none; }
+        .lang-switcher { display: inline-flex; gap: 0.4rem; font-size: 0.75rem; margin-top: 0.5rem; }
+        .lang-switcher a { color: #999; padding: 0.1rem 0.35rem; border: 1px solid #ddd; text-decoration: none; }
+        .lang-switcher a:hover { border-color: #c0392b; color: #c0392b; }
+        .lang-switcher strong { padding: 0.1rem 0.35rem; background: #1a1a1a; color: #fff; }
+        .search-form { display: inline-block; margin-top: 0.5rem; }
+        .search-form input { width: 180px; padding: 0.3rem 0.6rem; border: 1px solid #ddd; font-size: 0.8rem; font-family: inherit; }
+        .search-form input:focus { outline: none; border-color: #c0392b; }
+        #search-results { max-width: 360px; margin: 0.25rem auto; border: 1px solid #ddd; background: #fff; box-shadow: 0 4px 16px rgba(0,0,0,0.08); }
+        #search-results a { display: block; padding: 0.5rem 0.75rem; text-decoration: none; border-bottom: 1px solid #f0f0f0; font-size: 0.85rem; color: #c0392b; }
+        #search-results a:last-child { border-bottom: none; }
+        #search-results a:hover { background: #fef6f5; }
+        #search-results strong { color: #1a1a1a; }
+        #search-results .result-meta { font-size: 0.7rem; color: #999; margin-top: 0.1rem; }
+        #search-results .no-results { padding: 0.5rem 0.75rem; color: #999; font-size: 0.85rem; }
+
+        /* Content area */
+        .content-area { max-width: 1000px; margin: 0 auto; padding: 1.5rem; }
+
+        /* Article grid — magazine multi-column */
+        main section { margin-bottom: 2rem; }
+        main section > h2 { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.1em; color: #c0392b; font-weight: 700; margin: 0 0 1rem; padding-bottom: 0.5rem; border-bottom: 1px solid #eee; }
+        .article-columns { column-count: 2; column-gap: 2rem; column-rule: 1px solid #eee; }
+        article { break-inside: avoid; margin-bottom: 1.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid #eee; }
+        article:last-child { border-bottom: none; }
+        /* Featured first article spans full width */
+        article:first-child { column-span: all; margin-bottom: 2rem; padding-bottom: 2rem; border-bottom: 2px solid #1a1a1a; }
+        article:first-child h3 { font-size: 1.6rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; line-height: 1.25; }
+        article:first-child p { font-size: 1rem; color: #555; }
+        article h3 { margin: 0 0 0.3rem; font-size: 1.05rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; line-height: 1.3; }
+        article h3 a { color: #1a1a1a; text-decoration: none; }
+        article h3 a:hover { color: #c0392b; }
+        article p { color: #555; font-size: 0.9rem; margin: 0.3rem 0 0; }
+        time { font-size: 0.75rem; color: #999; text-transform: uppercase; letter-spacing: 0.04em; }
+        .reading-time { color: #999; font-size: 0.8rem; }
+        .tags a, .tags span { color: #c0392b; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; margin-right: 0.5rem; }
+        .tags a:hover { text-decoration: underline; }
+
+        /* Single article pages — elegant reading column */
+        main > article { max-width: 680px; margin: 0 auto; border-bottom: none; padding-bottom: 0; }
+        main > article:first-child { column-span: none; border-bottom: none; }
+        main > article h1 { font-size: 2.2rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; line-height: 1.2; margin: 0 0 0.5rem; }
+        main > article h2 { font-size: 1.3rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; margin-top: 2.5rem; padding-bottom: 0.3rem; border-bottom: 1px solid #eee; }
+        main > article h3 { font-size: 1.05rem; font-weight: 600; margin-top: 1.5rem; }
+        main > article p { font-size: 1.05rem; line-height: 1.8; color: #333; }
+        main > article > p:first-of-type::first-letter { font-size: 3.2rem; font-family: Georgia, serif; float: left; line-height: 1; margin: 0.1rem 0.15rem 0 0; font-weight: 700; color: #c0392b; }
+
+        /* Typography */
+        pre { background: #1e1e2e; color: #cdd6f4; padding: 1rem; overflow-x: auto; font-size: 0.85rem; }
+        pre code { background: none; color: inherit; padding: 0; }
+        code { font-size: 0.85em; background: #f5f5f5; padding: 0.15em 0.35em; color: #c0392b; }
+        blockquote { border-left: 3px solid #c0392b; margin: 1.5rem 0; padding: 0.5rem 1.5rem; font-family: Georgia, serif; font-style: italic; font-size: 1.1rem; color: #555; }
+        img { max-width: 100%; height: auto; }
+        figure { margin: 1.5rem 0; }
+        figure img { display: block; }
+        figcaption { font-size: 0.8rem; color: #888; margin-top: 0.3rem; font-style: italic; }
+        hr { border: none; height: 1px; background: #ddd; margin: 2rem 0; }
+
+        /* Embeds */
+        .video-embed { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin: 1.5rem 0; }
+        .video-embed iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
+        .gist-embed { margin: 1.5rem 0; }
+
+        /* Callouts */
+        .callout { padding: 1rem 1.25rem; margin: 1.5rem 0; border-left: 3px solid #c0392b; background: #fef6f5; }
+        .callout-title { font-weight: 700; margin-bottom: 0.4rem; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.04em; }
+        .callout-info { border-left-color: #2980b9; background: #eef6fc; }
+        .callout-warning { border-left-color: #d97706; background: #fffbeb; }
+        .callout-danger { border-left-color: #c0392b; background: #fef6f5; }
+        .callout-tip { border-left-color: #27ae60; background: #f0fdf4; }
+        .callout-note { border-left-color: #7f8c8d; background: #f9fafb; }
+        .callout p:last-child { margin-bottom: 0; }
+
+        /* Contact form */
+        .contact-form { max-width: 480px; }
+        .contact-form-field { margin-bottom: 1rem; }
+        .contact-form-field label { display: block; font-weight: 600; margin-bottom: 0.25rem; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.04em; color: #555; }
+        .contact-form-field input, .contact-form-field textarea { width: 100%; padding: 0.5rem 0.75rem; border: 1px solid #ddd; font: inherit; box-sizing: border-box; }
+        .contact-form-field input:focus, .contact-form-field textarea:focus { outline: none; border-color: #c0392b; }
+        .contact-form-submit { background: #c0392b; color: #fff; border: none; padding: 0.5rem 1.5rem; font: inherit; font-weight: 600; cursor: pointer; text-transform: uppercase; letter-spacing: 0.04em; font-size: 0.85rem; }
+        .contact-form-submit:hover { background: #a93226; }
+        .contact-form-honeypot { display: none; }
+        .contact-form-embed { min-height: 400px; }
+        .contact-form-error { color: #c0392b; background: #fef6f5; padding: 1rem; border-left: 3px solid #c0392b; }
+
+        /* Trust center */
+        .trust-hub { max-width: 1000px; margin: 0 auto; }
+        .trust-hero { margin-bottom: 2rem; }
+        .trust-hero h1 { font-size: 2rem; font-family: Georgia, serif; font-weight: 700; margin-bottom: 0.5rem; }
+        .trust-section { margin-bottom: 2.5rem; }
+        .trust-section h2 { font-size: 1.3rem; font-family: Georgia, serif; margin-bottom: 1rem; border-bottom: 1px solid #eee; padding-bottom: 0.5rem; }
+        .trust-breadcrumb { font-size: 0.8rem; color: #999; margin-bottom: 1.5rem; }
+        .trust-breadcrumb a { color: #c0392b; text-decoration: none; }
+        .trust-breadcrumb a:hover { text-decoration: underline; }
+        .trust-description { color: #555; margin-bottom: 1.5rem; line-height: 1.7; }
+        .cert-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.5rem; }
+        .cert-card { border: 1px solid #ddd; padding: 1.25rem; background: #fff; transition: border-color 0.15s; }
+        .cert-card:hover { border-color: #c0392b; }
+        .cert-card__header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+        .cert-card__title { font-weight: 700; font-size: 1rem; color: #1a1a1a; }
+        .cert-card__desc { font-size: 0.9rem; color: #555; margin-bottom: 0.75rem; }
+        .cert-card__link { font-size: 0.85rem; color: #c0392b; text-decoration: none; font-weight: 600; }
+        .cert-card__link:hover { text-decoration: underline; }
+        .cert-status { display: inline-block; font-size: 0.65rem; font-weight: 700; padding: 0.15rem 0.5rem; text-transform: uppercase; letter-spacing: 0.05em; }
+        .cert-status--active { background: #dcfce7; color: #166534; }
+        .cert-status--in_progress { background: #fef9c3; color: #854d0e; }
+        .cert-status--planned { background: #f3f4f6; color: #6b7280; }
+        .cert-detail { margin-bottom: 2rem; padding: 1.25rem; border: 1px solid #ddd; background: #fafafa; }
+        .cert-meta { font-size: 0.9rem; color: #555; margin-bottom: 0.35rem; }
+        .cert-meta strong { color: #1a1a1a; }
+        .trust-item { padding: 0.75rem 0; border-bottom: 1px solid #eee; }
+        .trust-item:last-child { border-bottom: none; }
+        .subprocessor-table-wrap { overflow-x: auto; margin: 1.5rem 0; }
+        .subprocessor-table { border-collapse: collapse; width: 100%; }
+        .subprocessor-table th, .subprocessor-table td { border: 1px solid #ddd; padding: 0.5rem 0.75rem; text-align: left; font-size: 0.85rem; }
+        .subprocessor-table th { background: #f6f6f6; font-weight: 600; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.04em; }
+        .faq-section { margin-top: 2rem; }
+        .faq-item { border-bottom: 1px solid #eee; }
+        .faq-item summary { padding: 0.75rem 0; cursor: pointer; font-weight: 600; color: #1a1a1a; }
+        .faq-item summary:hover { color: #c0392b; }
+        .faq-answer { padding: 0 0 1rem; color: #555; line-height: 1.7; }
+        .trust-page { margin-bottom: 2rem; }
+
+        /* Changelog */
+        .changelog-entry-header { margin-bottom: 1.5rem; }
+        .changelog-meta { display: flex; align-items: center; gap: 1rem; margin-top: 0.5rem; color: #999; font-size: 0.85rem; }
+        .changelog-summary { color: #555; font-size: 1.05rem; margin-bottom: 1.5rem; }
+        .changelog-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+        .changelog-tag { display: inline-block; padding: 0.15rem 0.5rem; font-size: 0.65rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; }
+        .changelog-tag--new { background: #dcfce7; color: #166534; }
+        .changelog-tag--fix { background: #dbeafe; color: #1e40af; }
+        .changelog-tag--breaking { background: #fee2e2; color: #991b1b; }
+        .changelog-tag--improvement { background: #f3e8ff; color: #6b21a8; }
+        .changelog-tag--deprecated { background: #f3f4f6; color: #4b5563; }
+        .changelog-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 1rem; margin-bottom: 2rem; }
+        .changelog-header h1 { margin-bottom: 0; font-family: Georgia, serif; }
+        .changelog-rss { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.75rem; color: #999; text-decoration: none; padding: 0.25rem 0.6rem; border: 1px solid #ddd; }
+        .changelog-rss:hover { color: #c0392b; border-color: #c0392b; }
+        .changelog-back { margin-bottom: 1.5rem; }
+        .changelog-back a { color: #999; text-decoration: none; font-size: 0.85rem; }
+        .changelog-back a:hover { color: #c0392b; }
+        .changelog-timeline { position: relative; padding-left: 2rem; }
+        .changelog-timeline::before { content: ''; position: absolute; left: 0; top: 0.5rem; bottom: 0; width: 2px; background: #eee; }
+        .changelog-item { position: relative; padding-bottom: 1.5rem; border-bottom: 1px solid #eee; margin-bottom: 0; }
+        .changelog-item::before { content: ''; position: absolute; left: -2rem; top: 0.5rem; width: 10px; height: 10px; border-radius: 50%; background: #c0392b; transform: translateX(-4px); }
+        .changelog-item:last-child { border-bottom: none; }
+        .changelog-item-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 0.5rem; }
+        .changelog-item-header h2 { margin: 0; font-size: 1.15rem; font-family: Georgia, serif; }
+        .changelog-item-header time { color: #999; font-size: 0.8rem; white-space: nowrap; }
+        .changelog-item .changelog-tags { margin-top: 0.5rem; }
+        .changelog-item p, .changelog-item .excerpt { margin-top: 0.5rem; color: #555; }
+        .changelog-feed .changelog-item::before { display: none; }
+        .changelog-feed { display: flex; flex-direction: column; gap: 0; }
+
+        /* Roadmap */
+        .roadmap-back { margin-bottom: 1.5rem; }
+        .roadmap-back a { color: #999; text-decoration: none; font-size: 0.85rem; }
+        .roadmap-back a:hover { color: #c0392b; }
+        .roadmap-entry-header { margin-bottom: 1.5rem; }
+        .roadmap-summary { color: #555; font-size: 1.05rem; margin-bottom: 1.5rem; }
+        .roadmap-status-badges { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
+        .roadmap-status { display: inline-block; padding: 0.15rem 0.6rem; font-size: 0.65rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; }
+        .roadmap-status--planned { background: #dbeafe; color: #1e40af; }
+        .roadmap-status--in-progress { background: #fef3c7; color: #92400e; }
+        .roadmap-status--done { background: #dcfce7; color: #166534; }
+        .roadmap-status--cancelled { background: #f3f4f6; color: #4b5563; text-decoration: line-through; }
+        .roadmap-grouped { display: flex; flex-direction: column; gap: 2rem; }
+        .roadmap-section-header { display: flex; align-items: center; gap: 0.75rem; font-size: 1rem; margin-bottom: 1rem; font-family: Georgia, serif; }
+        .roadmap-items { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1rem; }
+        .roadmap-card { padding: 1rem 1.25rem; border: 1px solid #eee; transition: border-color 0.15s; }
+        .roadmap-card:hover { border-color: #c0392b; }
+        .roadmap-card h3 { margin: 0 0 0.25rem; font-size: 0.95rem; font-family: Georgia, serif; }
+        .roadmap-card p, .roadmap-card .excerpt { margin: 0; color: #555; font-size: 0.85rem; }
+        .roadmap-kanban { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; }
+        .roadmap-column-header { font-size: 0.95rem; margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem; }
+        .roadmap-count { font-size: 0.75rem; color: #999; font-weight: 400; }
+        .roadmap-timeline { position: relative; padding-left: 2rem; }
+        .roadmap-timeline::before { content: ''; position: absolute; left: 0.5rem; top: 0; bottom: 0; width: 2px; background: #eee; }
+        .roadmap-milestone { position: relative; margin-bottom: 2rem; }
+        .roadmap-milestone-dot { position: absolute; left: -1.75rem; top: 0.3rem; width: 12px; height: 12px; border-radius: 50%; border: 2px solid #c0392b; background: #fff; }
+        .roadmap-milestone-dot .roadmap-status { display: none; }
+        .roadmap-milestone-content h3 { margin: 0 0 0.25rem; font-family: Georgia, serif; }
+        .roadmap-milestone-content p { margin: 0.25rem 0 0; color: #555; font-size: 0.85rem; }
+        @media (max-width: 768px) { .roadmap-kanban { grid-template-columns: 1fr; } }
+
+        /* Tables */
+        table { border-collapse: collapse; width: 100%; margin: 1.5rem 0; }
+        th, td { border: 1px solid #ddd; padding: 0.5rem 0.75rem; text-align: left; font-size: 0.9rem; }
+        th { background: #f6f6f6; font-weight: 600; }
+        ul.contains-task-list, ol.contains-task-list { list-style: none; padding-left: 0; }
+        li.task-list-item { display: flex; align-items: baseline; gap: 0.5rem; }
+        li.task-list-item input[type="checkbox"] { margin: 0; pointer-events: none; }
+        .footnote-definition { font-size: 0.85rem; color: #555; border-top: 1px solid #eee; margin-top: 2rem; padding-top: 0.75rem; }
+        .footnote-definition p { display: inline; }
+        sup.footnote-reference a { text-decoration: none; color: #c0392b; font-weight: 600; }
+
+        /* TOC & Pagination */
+        .toc { margin: 1.5rem 0; padding: 1rem 1.25rem; border: 1px solid #eee; background: #fafafa; }
+        .toc > ul { margin: 0; padding-left: 1.25rem; }
+        .toc ul ul { padding-left: 1rem; }
+        .toc li { margin: 0.25rem 0; }
+        .toc a { text-decoration: none; }
+        .toc a:hover { text-decoration: underline; }
+        .pagination { display: flex; justify-content: space-between; align-items: center; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #eee; }
+        .pagination a { text-decoration: none; }
+        .pagination a:hover { text-decoration: underline; }
+        .pagination span { color: #999; font-size: 0.85rem; }
+
+        /* Footer */
+        footer { max-width: 1000px; margin: 3rem auto 0; padding: 1.5rem; border-top: 3px double #1a1a1a; color: #999; font-size: 0.8rem; text-align: center; }
+        footer nav { margin-bottom: 0.5rem; }
+        footer nav a { color: #555; text-decoration: none; text-transform: uppercase; letter-spacing: 0.04em; font-size: 0.75rem; }
+        footer nav a:hover { color: #c0392b; }
+
+        /* Accessibility */
+        .skip-link { position: absolute; top: -100%; left: 0; padding: 0.5rem 1rem; background: #c0392b; color: #fff; z-index: 100; text-decoration: none; }
+        .skip-link:focus { top: 0; }
+        :focus-visible { outline: 2px solid #c0392b; outline-offset: 2px; }
+        @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } }
+        @media (max-width: 700px) {
+            .article-columns { column-count: 1; }
+            article:first-child h3 { font-size: 1.3rem; }
+            .masthead h1 { font-size: 1.8rem; }
+        }
+    </style>
+    {% block extra_css %}{% endblock %}
+    {% block head %}{% endblock %}
+</head>
+<body>
+    <a href="#main" class="skip-link">{{ t.skip_to_content }}</a>
+    <header>
+    {% block header %}
+        <div class="masthead">
+            <h1><a href="{{ lang_prefix }}/">{{ site.title }}</a></h1>
+            {% if site.description %}<p>{{ site.description }}</p>{% endif %}
+            {% if data.nav %}
+            <nav class="site-nav" aria-label="Main navigation">
+                {% for item in data.nav %}{% if item.external %}<a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.title }}</a>{% else %}<a href="{{ lang_prefix }}{{ item.url }}">{{ item.title }}</a>{% endif %}{% endfor %}
+            </nav>
+            {% endif %}
+            {% if translations | length > 1 %}
+            <nav class="lang-switcher">
+                {% for t in translations %}{% if t.lang == lang %}<strong>{{ t.lang | upper }}</strong>{% else %}<a href="{{ t.url }}">{{ t.lang | upper }}</a>{% endif %}{% endfor %}
+            </nav>
+            {% endif %}
+            <form class="search-form" role="search" aria-label="{{ t.search_label }}" onsubmit="return false">
+                <input type="search" id="search-input" placeholder="{{ t.search_placeholder }}" autocomplete="off" aria-label="{{ t.search_label }}">
+            </form>
+            <div id="search-results" aria-live="polite"></div>
+        </div>
+    {% endblock %}
+    </header>
+    <main id="main" class="content-area">
+        {% block content %}{% endblock %}
+    </main>
+    <footer>
+        {% if data.footer %}{% if data.footer.links %}
+        <nav aria-label="Footer navigation">
+            {% for link in data.footer.links %}{% if link.external %}<a href="{{ link.url }}" target="_blank" rel="noopener">{{ link.title }}</a>{% else %}<a href="{{ lang_prefix }}{{ link.url }}">{{ link.title }}</a>{% endif %}{% if not loop.last %} &middot; {% endif %}{% endfor %}
+        </nav>
+        {% endif %}{% endif %}
+        <p>&copy; {% if data.footer %}{% if data.footer.copyright %}{{ data.footer.copyright }}{% else %}{{ site.author }}{% endif %}{% else %}{{ site.author }}{% endif %}</p>
+    </footer>
+    <script>
+    (function(){
+        var index = null;
+        var input = document.getElementById('search-input');
+        var results = document.getElementById('search-results');
+        var basePath = {{ site.base_path | json_encode() }};
+        var indexUrl = basePath + {% if lang != default_language %}('/' + {{ lang | json_encode() }} + '/search-index.json'){% else %}'/search-index.json'{% endif %};
+        function load(cb) { if (index) { cb(); return; } fetch(indexUrl).then(function(r){return r.json();}).then(function(d){index=d;cb();}).catch(function(){index=[];}); }
+        function search(q) {
+            q = q.toLowerCase().trim();
+            if (!q) { results.innerHTML = ''; return; }
+            var hits = index.filter(function(e){
+                return (e.title||'').toLowerCase().includes(q) || (e.description||'').toLowerCase().includes(q) || (e.tags||[]).some(function(t){return t.toLowerCase().includes(q);});
+            }).slice(0, 8);
+            if (!hits.length) { results.innerHTML = '<div class="no-results">{{ t.no_results }}</div>'; return; }
+            results.innerHTML = hits.map(function(e){
+                var meta = [e.collection, e.date].filter(Boolean).join(' · ');
+                return '<a href="' + basePath + e.url + '"><strong>' + e.title + '</strong>' + (meta ? '<div class="result-meta">' + meta + '</div>' : '') + '</a>';
+            }).join('');
+        }
+        input.addEventListener('input', function(){ load(function(){ search(input.value); }); });
+    })();
+    </script>
+    {% block footer %}{% endblock %}
+    {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/src/themes/magazine.tera
+++ b/src/themes/magazine.tera
@@ -38,10 +38,13 @@
     {% if page.collection %}{% set _bc_col_url = site.base_url ~ lang_prefix ~ "/" ~ page.collection %}<script type="application/ld+json">
     {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
     </script>{% endif %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
     <style>
         /* ===== RESET & FOUNDATION ===== */
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-        body { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; line-height: 1.6; color: #111; background: #fff; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { font-family: 'DM Sans', system-ui, -apple-system, 'Segoe UI', sans-serif; line-height: 1.6; color: #111; background: #fff; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
         a { color: #e63946; text-decoration: none; transition: color 0.15s ease; }
         a:hover { color: #c1121f; }
         img { max-width: 100%; height: auto; display: block; }
@@ -49,10 +52,10 @@
         /* ===== MASTHEAD — Editorial Nameplate ===== */
         .masthead { max-width: 1000px; margin: 0 auto; padding: 2rem 1.5rem 0; text-align: center; }
         .masthead-rule-top { border: none; border-top: 1px solid #111; margin: 0 0 1rem; }
-        .masthead h1 { font-size: 3rem; font-weight: 900; letter-spacing: -0.03em; text-transform: uppercase; line-height: 1; margin: 0; }
+        .masthead h1 { font-family: 'Playfair Display', Georgia, serif; font-size: 3rem; font-weight: 900; letter-spacing: -0.03em; text-transform: uppercase; line-height: 1; margin: 0; }
         .masthead h1 a { color: #111; text-decoration: none; }
         .masthead h1 a:hover { color: #e63946; }
-        .masthead-desc { font-family: Georgia, 'Times New Roman', serif; font-style: italic; color: #555; font-size: 0.95rem; margin: 0.4rem 0 0; }
+        .masthead-desc { font-family: 'Source Serif 4', Georgia, serif; font-style: italic; color: #555; font-size: 0.95rem; margin: 0.4rem 0 0; }
         .masthead-rule-bottom { border: none; border-top: 1px solid #111; margin: 1rem 0 0; }
 
         /* Navigation — uppercase, small, middot separated */
@@ -84,24 +87,46 @@
         /* ===== CONTENT AREA ===== */
         .content-area { max-width: 1000px; margin: 0 auto; padding: 2rem 1.5rem; }
 
+        /* ===== HOMEPAGE CONTENT — Editorial Feature ===== */
+        .homepage-content { margin-bottom: 2.5rem; padding-bottom: 2rem; border-bottom: 2px solid #111; }
+        .homepage-content > h1:first-child { font-family: 'Playfair Display', Georgia, serif; font-size: 2.8rem; font-weight: 900; line-height: 1.1; letter-spacing: -0.02em; margin-bottom: 0.75rem; }
+        .homepage-content > p { font-family: 'Source Serif 4', Georgia, serif; font-size: 1.1rem; line-height: 1.8; color: #333; margin-bottom: 1rem; }
+        .homepage-content > p strong { color: #111; }
+        .homepage-content > p a { color: #e63946; font-weight: 600; }
+        .homepage-content > p a:hover { color: #c1121f; text-decoration: underline; }
+        .homepage-content > h2 { font-family: 'Playfair Display', Georgia, serif; font-size: 1.4rem; font-weight: 700; margin-top: 2rem; margin-bottom: 0.6rem; border-bottom: 1px solid #ddd; padding-bottom: 0.35rem; }
+        .homepage-content > h3 { font-family: 'Playfair Display', Georgia, serif; font-size: 1.1rem; font-weight: 700; margin-top: 1.5rem; margin-bottom: 0.4rem; color: #111; }
+        .homepage-content > ul { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.5rem; list-style: none; padding: 0; margin: 2rem 0; }
+        .homepage-content > ul > li { text-align: center; padding: 1.25rem 1rem; border: 1px solid #111; transition: box-shadow 0.2s ease; }
+        .homepage-content > ul > li:hover { box-shadow: 4px 4px 0 #e63946; }
+        .homepage-content > ul > li strong { display: block; font-family: 'Playfair Display', Georgia, serif; font-size: 2rem; color: #e63946; line-height: 1; margin-bottom: 0.25rem; }
+        .homepage-content blockquote { font-family: 'Source Serif 4', Georgia, serif; font-size: 1.15rem; border-left: 3px solid #e63946; margin: 2rem 0; padding: 0.75rem 0 0.75rem 1.5rem; font-style: italic; color: #333; }
+        .homepage-content blockquote p { font-size: inherit; line-height: 1.6; color: inherit; margin-bottom: 0.5rem; }
+        .homepage-content blockquote p:last-child { margin-bottom: 0; }
+        .homepage-content > hr { border: none; text-align: center; margin: 2.5rem 0; }
+        .homepage-content > hr::before { content: '\25C6\2002\25C6\2002\25C6'; letter-spacing: 0.5em; color: #e63946; font-size: 0.6rem; }
+        .homepage-content pre { background: #111; color: #e8e8e8; padding: 1.25rem 1.5rem; overflow-x: auto; font-size: 0.85rem; line-height: 1.65; border-left: 3px solid #e63946; margin: 1.5rem 0; }
+        .homepage-content pre code { background: none; color: inherit; padding: 0; font-size: inherit; border: none; }
+
         /* Section labels — editorial red uppercase */
-        main section { margin-bottom: 3rem; }
-        main section > h2 { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.12em; color: #e63946; font-weight: 700; margin: 0 0 1.25rem; padding-bottom: 0.6rem; border-bottom: 1px solid #111; display: flex; align-items: center; gap: 0.5rem; }
+        main > section { margin-bottom: 3rem; }
+        main > section > h2 { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.12em; color: #e63946; font-weight: 700; margin: 0 0 1.25rem; padding-bottom: 0.6rem; border-bottom: 1px solid #111; display: flex; align-items: center; gap: 0.5rem; }
 
         /* ===== ARTICLE GRID — 3 Column Magazine Layout ===== */
-        .article-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0; }
-        .article-grid article { padding: 0 1.25rem; border-right: 1px solid #111; }
-        .article-grid article:nth-child(3n) { border-right: none; }
-        .article-grid article:nth-child(n+4) { border-top: 1px solid #111; padding-top: 1.5rem; margin-top: 0; }
+        main > section { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0; }
+        main > section > h2 { grid-column: 1 / -1; }
+        section > article { padding: 0 1.25rem; border-right: 1px solid #111; }
+        section > article:nth-of-type(3n) { border-right: none; }
+        section > article:nth-of-type(n+4) { border-top: 1px solid #111; padding-top: 1.5rem; margin-top: 0; }
 
         /* Feature article — full span */
-        .article-grid article:first-child { grid-column: 1 / -1; border-right: none; padding: 0 0 1.5rem; margin-bottom: 0.5rem; border-bottom: 2px solid #111; }
-        .article-grid article:first-child h3 { font-size: 2rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; line-height: 1.2; margin: 0 0 0.4rem; }
-        .article-grid article:first-child p { font-size: 1.05rem; color: #555; line-height: 1.6; }
+        section > article:first-of-type { grid-column: 1 / -1; border-right: none; padding: 0 0 1.5rem; margin-bottom: 0.5rem; border-bottom: 2px solid #111; }
+        section > article:first-of-type h3 { font-size: 2rem; font-family: 'Playfair Display', Georgia, serif; font-weight: 700; line-height: 1.2; margin: 0 0 0.4rem; }
+        section > article:first-of-type p { font-size: 1.05rem; color: #555; line-height: 1.6; }
 
         /* Standard article cards */
         article { margin-bottom: 1.5rem; padding-bottom: 1.5rem; }
-        article h3 { margin: 0 0 0.3rem; font-size: 1rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; line-height: 1.3; }
+        article h3 { margin: 0 0 0.3rem; font-size: 1rem; font-family: 'Playfair Display', Georgia, serif; font-weight: 700; line-height: 1.3; }
         article h3 a { color: #111; text-decoration: none; }
         article h3 a:hover { color: #e63946; }
         article p { color: #555; font-size: 0.88rem; margin: 0.3rem 0 0; line-height: 1.5; }
@@ -113,12 +138,12 @@
         /* ===== SINGLE ARTICLE PAGES — Editorial Reading Column ===== */
         main > article { max-width: 680px; margin: 0 auto; border-right: none; padding: 0; }
         main > article:first-child { grid-column: unset; border-bottom: none; margin-bottom: 0; }
-        main > article h1 { font-size: 2.4rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; line-height: 1.15; margin: 0 0 0.6rem; letter-spacing: -0.01em; }
-        main > article h2 { font-size: 1.35rem; font-family: Georgia, 'Times New Roman', serif; font-weight: 700; margin-top: 2.5rem; margin-bottom: 0.5rem; padding-bottom: 0.35rem; border-bottom: 1px solid #eee; }
-        main > article h3 { font-size: 1.1rem; font-weight: 700; margin-top: 2rem; margin-bottom: 0.4rem; font-family: Georgia, 'Times New Roman', serif; }
+        main > article h1 { font-size: 2.4rem; font-family: 'Playfair Display', Georgia, serif; font-weight: 700; line-height: 1.15; margin: 0 0 0.6rem; letter-spacing: -0.01em; }
+        main > article h2 { font-size: 1.35rem; font-family: 'Playfair Display', Georgia, serif; font-weight: 700; margin-top: 2.5rem; margin-bottom: 0.5rem; padding-bottom: 0.35rem; border-bottom: 1px solid #eee; }
+        main > article h3 { font-size: 1.1rem; font-weight: 700; margin-top: 2rem; margin-bottom: 0.4rem; font-family: 'Playfair Display', Georgia, serif; }
         main > article h4 { font-size: 0.95rem; font-weight: 700; margin-top: 1.5rem; text-transform: uppercase; letter-spacing: 0.04em; }
-        main > article p { font-family: Georgia, 'Times New Roman', serif; font-size: 1.1rem; line-height: 1.8; color: #111; margin-bottom: 1.2rem; }
-        main > article ul, main > article ol { font-family: Georgia, 'Times New Roman', serif; font-size: 1.1rem; line-height: 1.8; color: #111; margin: 0 0 1.2rem 1.5rem; }
+        main > article p { font-family: 'Source Serif 4', Georgia, serif; font-size: 1.1rem; line-height: 1.8; color: #111; margin-bottom: 1.2rem; }
+        main > article ul, main > article ol { font-family: 'Source Serif 4', Georgia, serif; font-size: 1.1rem; line-height: 1.8; color: #111; margin: 0 0 1.2rem 1.5rem; }
         main > article li { margin-bottom: 0.3rem; }
 
         /* Drop cap — editorial signature */
@@ -126,7 +151,7 @@
             float: left;
             font-size: 4rem;
             line-height: 0.8;
-            font-family: Georgia, serif;
+            font-family: 'Playfair Display', Georgia, serif;
             font-weight: 700;
             color: #e63946;
             margin: 0.05em 0.1em 0 0;
@@ -137,19 +162,24 @@
         hr::before { content: '\25C6\2002\25C6\2002\25C6'; letter-spacing: 0.5em; color: #e63946; font-size: 0.6rem; }
 
         /* ===== BLOCKQUOTES — Pull-quote Style ===== */
-        blockquote { border-left: 3px solid #e63946; margin: 2rem 0; padding: 0.75rem 0 0.75rem 1.5rem; font-family: Georgia, serif; font-style: italic; font-size: 1.3rem; line-height: 1.5; color: #333; }
+        blockquote { border-left: 3px solid #e63946; margin: 2rem 0; padding: 0.75rem 0 0.75rem 1.5rem; font-family: 'Source Serif 4', Georgia, serif; font-style: italic; font-size: 1.3rem; line-height: 1.5; color: #333; }
         blockquote p { font-size: inherit; line-height: inherit; color: inherit; margin-bottom: 0.5rem; }
         blockquote p:last-child { margin-bottom: 0; }
 
         /* ===== CODE BLOCKS ===== */
-        pre { background: #111; color: #e8e8e8; padding: 1.25rem 1.5rem; overflow-x: auto; font-size: 0.85rem; line-height: 1.65; margin: 1.5rem 0; border-left: 3px solid #e63946; }
+        pre { background: #111; color: #e8e8e8; padding: 1.25rem 1.5rem; overflow-x: auto; font-size: 0.85rem; line-height: 1.65; margin: 1.5rem 0; border-left: 3px solid #e63946; position: relative; }
         pre code { background: none; color: inherit; padding: 0; font-size: inherit; border: none; }
         code { font-size: 0.85em; background: #f5f5f5; padding: 0.15em 0.4em; color: #e63946; border: 1px solid #eee; font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace; }
+
+        /* Copy button */
+        .code-copy-btn { position: absolute; top: 0.5rem; right: 0.5rem; background: rgba(255,255,255,0.1); border: none; padding: 0.2rem 0.5rem; font-size: 0.65rem; cursor: pointer; color: #999; font-family: inherit; opacity: 0; transition: opacity 0.15s; }
+        pre:hover .code-copy-btn { opacity: 1; }
+        .code-copy-btn:hover { background: rgba(255,255,255,0.2); color: #fff; }
 
         /* ===== FIGURES ===== */
         figure { margin: 2rem 0; }
         figure img { display: block; }
-        figcaption { font-size: 0.78rem; color: #888; margin-top: 0.5rem; font-style: italic; font-family: Georgia, serif; text-align: center; }
+        figcaption { font-size: 0.78rem; color: #888; margin-top: 0.5rem; font-style: italic; font-family: 'Source Serif 4', Georgia, serif; text-align: center; }
 
         /* ===== EMBEDS ===== */
         .video-embed { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin: 2rem 0; background: #f5f5f5; }
@@ -175,7 +205,7 @@
         .contact-form { max-width: 480px; }
         .contact-form-field { margin-bottom: 1.25rem; }
         .contact-form-field label { display: block; font-weight: 600; margin-bottom: 0.3rem; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: #555; }
-        .contact-form-field input, .contact-form-field textarea { width: 100%; padding: 0.6rem 0.8rem; border: 1px solid #111; font-family: Georgia, serif; font-size: 0.95rem; background: #fff; transition: border-color 0.15s ease; }
+        .contact-form-field input, .contact-form-field textarea { width: 100%; padding: 0.6rem 0.8rem; border: 1px solid #111; font-family: 'Source Serif 4', Georgia, serif; font-size: 0.95rem; background: #fff; transition: border-color 0.15s ease; }
         .contact-form-field input:focus, .contact-form-field textarea:focus { outline: none; border-color: #e63946; box-shadow: 0 0 0 1px #e63946; }
         .contact-form-submit { background: #e63946; color: #fff; border: none; padding: 0.6rem 2rem; font-family: system-ui, sans-serif; font-weight: 700; cursor: pointer; text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.78rem; transition: background 0.15s ease; }
         .contact-form-submit:hover { background: #c1121f; }
@@ -216,13 +246,13 @@
         /* ===== TRUST CENTER ===== */
         .trust-hub { max-width: 1000px; margin: 0 auto; }
         .trust-hero { margin-bottom: 2.5rem; }
-        .trust-hero h1 { font-size: 2.2rem; font-family: Georgia, serif; font-weight: 700; margin-bottom: 0.5rem; }
+        .trust-hero h1 { font-size: 2.2rem; font-family: 'Playfair Display', Georgia, serif; font-weight: 700; margin-bottom: 0.5rem; }
         .trust-section { margin-bottom: 2.5rem; }
-        .trust-section h2 { font-size: 1.3rem; font-family: Georgia, serif; margin-bottom: 1rem; border-bottom: 1px solid #111; padding-bottom: 0.5rem; }
+        .trust-section h2 { font-size: 1.3rem; font-family: 'Playfair Display', Georgia, serif; margin-bottom: 1rem; border-bottom: 1px solid #111; padding-bottom: 0.5rem; }
         .trust-breadcrumb { font-size: 0.72rem; color: #888; margin-bottom: 1.5rem; text-transform: uppercase; letter-spacing: 0.04em; }
         .trust-breadcrumb a { color: #e63946; text-decoration: none; }
         .trust-breadcrumb a:hover { color: #c1121f; }
-        .trust-description { color: #555; margin-bottom: 1.5rem; line-height: 1.7; font-family: Georgia, serif; }
+        .trust-description { color: #555; margin-bottom: 1.5rem; line-height: 1.7; font-family: 'Source Serif 4', Georgia, serif; }
         .cert-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.5rem; }
         .cert-card { border: 1px solid #111; padding: 1.25rem; background: #fff; transition: all 0.2s ease; }
         .cert-card:hover { border-color: #e63946; box-shadow: 4px 4px 0 #e63946; }
@@ -249,13 +279,13 @@
         .faq-item summary { padding: 0.85rem 0; cursor: pointer; font-weight: 700; color: #111; font-size: 0.95rem; }
         .faq-item summary:hover { color: #e63946; }
         .faq-item summary::marker { color: #e63946; }
-        .faq-answer { padding: 0 0 1rem; color: #555; line-height: 1.7; font-family: Georgia, serif; }
+        .faq-answer { padding: 0 0 1rem; color: #555; line-height: 1.7; font-family: 'Source Serif 4', Georgia, serif; }
         .trust-page { margin-bottom: 2rem; }
 
         /* ===== CHANGELOG ===== */
         .changelog-entry-header { margin-bottom: 1.5rem; }
         .changelog-meta { display: flex; align-items: center; gap: 1rem; margin-top: 0.5rem; color: #888; font-size: 0.85rem; }
-        .changelog-summary { color: #555; font-size: 1.05rem; margin-bottom: 1.5rem; font-family: Georgia, serif; }
+        .changelog-summary { color: #555; font-size: 1.05rem; margin-bottom: 1.5rem; font-family: 'Source Serif 4', Georgia, serif; }
         .changelog-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
         .changelog-tag { display: inline-block; padding: 0.15rem 0.55rem; font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; border: 1px solid; }
         .changelog-tag--new { border-color: #059669; color: #059669; background: #ecfdf5; }
@@ -264,7 +294,7 @@
         .changelog-tag--improvement { border-color: #7c3aed; color: #7c3aed; background: #f5f3ff; }
         .changelog-tag--deprecated { border-color: #6b7280; color: #6b7280; background: #f9fafb; }
         .changelog-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 1rem; margin-bottom: 2rem; }
-        .changelog-header h1 { margin-bottom: 0; font-family: Georgia, serif; }
+        .changelog-header h1 { margin-bottom: 0; font-family: 'Playfair Display', Georgia, serif; }
         .changelog-rss { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.7rem; color: #888; text-decoration: none; padding: 0.25rem 0.65rem; border: 1px solid #111; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; }
         .changelog-rss:hover { color: #e63946; border-color: #e63946; }
         .changelog-back { margin-bottom: 1.5rem; }
@@ -276,7 +306,7 @@
         .changelog-item::before { content: ''; position: absolute; left: -2rem; top: 0.55rem; width: 10px; height: 10px; border-radius: 50%; background: #e63946; border: 2px solid #fff; transform: translateX(-4px); box-shadow: 0 0 0 1px #e63946; }
         .changelog-item:last-child { border-bottom: none; }
         .changelog-item-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 0.5rem; }
-        .changelog-item-header h2 { margin: 0; font-size: 1.15rem; font-family: Georgia, serif; }
+        .changelog-item-header h2 { margin: 0; font-size: 1.15rem; font-family: 'Playfair Display', Georgia, serif; }
         .changelog-item-header time { color: #888; font-size: 0.72rem; white-space: nowrap; text-transform: uppercase; letter-spacing: 0.06em; }
         .changelog-item .changelog-tags { margin-top: 0.5rem; }
         .changelog-item p, .changelog-item .excerpt { margin-top: 0.5rem; color: #555; }
@@ -288,7 +318,7 @@
         .roadmap-back a { color: #888; text-decoration: none; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; }
         .roadmap-back a:hover { color: #e63946; }
         .roadmap-entry-header { margin-bottom: 1.5rem; }
-        .roadmap-summary { color: #555; font-size: 1.05rem; margin-bottom: 1.5rem; font-family: Georgia, serif; }
+        .roadmap-summary { color: #555; font-size: 1.05rem; margin-bottom: 1.5rem; font-family: 'Source Serif 4', Georgia, serif; }
         .roadmap-status-badges { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
         .roadmap-status { display: inline-block; padding: 0.15rem 0.6rem; font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; border: 1px solid; }
         .roadmap-status--planned { border-color: #2563eb; color: #2563eb; background: #eff6ff; }
@@ -296,21 +326,21 @@
         .roadmap-status--done { border-color: #059669; color: #059669; background: #ecfdf5; }
         .roadmap-status--cancelled { border-color: #6b7280; color: #6b7280; background: #f9fafb; text-decoration: line-through; }
         .roadmap-grouped { display: flex; flex-direction: column; gap: 2.5rem; }
-        .roadmap-section-header { display: flex; align-items: center; gap: 0.75rem; font-size: 1rem; margin-bottom: 1rem; font-family: Georgia, serif; border-bottom: 1px solid #111; padding-bottom: 0.5rem; }
+        .roadmap-section-header { display: flex; align-items: center; gap: 0.75rem; font-size: 1rem; margin-bottom: 1rem; font-family: 'Playfair Display', Georgia, serif; border-bottom: 1px solid #111; padding-bottom: 0.5rem; }
         .roadmap-items { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1.25rem; }
         .roadmap-card { padding: 1rem 1.25rem; border: 1px solid #111; transition: all 0.2s ease; background: #fff; }
         .roadmap-card:hover { border-color: #e63946; box-shadow: 4px 4px 0 #e63946; }
-        .roadmap-card h3 { margin: 0 0 0.25rem; font-size: 0.95rem; font-family: Georgia, serif; }
+        .roadmap-card h3 { margin: 0 0 0.25rem; font-size: 0.95rem; font-family: 'Playfair Display', Georgia, serif; }
         .roadmap-card p, .roadmap-card .excerpt { margin: 0; color: #555; font-size: 0.85rem; }
         .roadmap-kanban { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; }
-        .roadmap-column-header { font-size: 0.95rem; margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem; font-family: Georgia, serif; border-bottom: 1px solid #111; padding-bottom: 0.5rem; }
+        .roadmap-column-header { font-size: 0.95rem; margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem; font-family: 'Playfair Display', Georgia, serif; border-bottom: 1px solid #111; padding-bottom: 0.5rem; }
         .roadmap-count { font-size: 0.7rem; color: #888; font-weight: 400; text-transform: uppercase; letter-spacing: 0.04em; }
         .roadmap-timeline { position: relative; padding-left: 2rem; }
         .roadmap-timeline::before { content: ''; position: absolute; left: 0.5rem; top: 0; bottom: 0; width: 2px; background: #e63946; }
         .roadmap-milestone { position: relative; margin-bottom: 2rem; }
         .roadmap-milestone-dot { position: absolute; left: -1.75rem; top: 0.3rem; width: 12px; height: 12px; border-radius: 50%; border: 2px solid #e63946; background: #fff; }
         .roadmap-milestone-dot .roadmap-status { display: none; }
-        .roadmap-milestone-content h3 { margin: 0 0 0.25rem; font-family: Georgia, serif; }
+        .roadmap-milestone-content h3 { margin: 0 0 0.25rem; font-family: 'Playfair Display', Georgia, serif; }
         .roadmap-milestone-content p { margin: 0.25rem 0 0; color: #555; font-size: 0.85rem; }
 
         /* ===== FOOTER — Editorial Small Caps ===== */
@@ -330,22 +360,25 @@
         /* ===== RESPONSIVE ===== */
         @media (max-width: 768px) {
             .masthead h1 { font-size: 2rem; }
-            .article-grid { grid-template-columns: 1fr; }
-            .article-grid article { border-right: none; padding: 0; border-bottom: 1px solid #111; padding-bottom: 1.25rem; margin-bottom: 1.25rem; }
-            .article-grid article:nth-child(n+4) { border-top: none; padding-top: 0; }
-            .article-grid article:first-child h3 { font-size: 1.5rem; }
+            main > section { grid-template-columns: 1fr; }
+            section > article { border-right: none; padding: 0; border-bottom: 1px solid #111; padding-bottom: 1.25rem; margin-bottom: 1.25rem; }
+            section > article:nth-of-type(n+4) { border-top: none; padding-top: 0; }
+            section > article:first-of-type h3 { font-size: 1.5rem; }
             main > article h1 { font-size: 1.8rem; }
             .roadmap-kanban { grid-template-columns: 1fr; }
             .content-area { padding: 1.5rem 1rem; }
             .masthead { padding: 1.5rem 1rem 0; }
             footer { padding: 1.5rem 1rem; }
             nav.site-nav { flex-wrap: wrap; justify-content: center; }
+            .homepage-content > ul { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
         }
         @media (max-width: 480px) {
             .masthead h1 { font-size: 1.6rem; }
             main > article h1 { font-size: 1.5rem; }
             main > article > p:first-of-type::first-letter { font-size: 3rem; }
             .search-form input { width: 160px; }
+            .homepage-content > ul { grid-template-columns: 1fr; }
+            .homepage-content > h1:first-child { font-size: 2rem; }
         }
     </style>
     {% block extra_css %}{% endblock %}
@@ -397,19 +430,38 @@
         var basePath = {{ site.base_path | json_encode() }};
         var indexUrl = basePath + {% if lang != default_language %}('/' + {{ lang | json_encode() }} + '/search-index.json'){% else %}'/search-index.json'{% endif %};
         function load(cb) { if (index) { cb(); return; } fetch(indexUrl).then(function(r){return r.json();}).then(function(d){index=d;cb();}).catch(function(){index=[];}); }
-        function search(q) {
+        function doSearch(q) {
             q = q.toLowerCase().trim();
-            if (!q) { results.innerHTML = ''; return; }
+            if (!q) { results.textContent = ''; return; }
             var hits = index.filter(function(e){
                 return (e.title||'').toLowerCase().includes(q) || (e.description||'').toLowerCase().includes(q) || (e.tags||[]).some(function(t){return t.toLowerCase().includes(q);});
             }).slice(0, 8);
-            if (!hits.length) { results.innerHTML = '<div class="no-results">{{ t.no_results }}</div>'; return; }
-            results.innerHTML = hits.map(function(e){
-                var meta = [e.collection, e.date].filter(Boolean).join(' · ');
-                return '<a href="' + basePath + e.url + '"><strong>' + e.title + '</strong>' + (meta ? '<div class="result-meta">' + meta + '</div>' : '') + '</a>';
-            }).join('');
+            if (!hits.length) {
+                var noRes = document.createElement('div');
+                noRes.className = 'no-results';
+                noRes.textContent = '{{ t.no_results }}';
+                results.textContent = '';
+                results.appendChild(noRes);
+                return;
+            }
+            results.textContent = '';
+            hits.forEach(function(e){
+                var a = document.createElement('a');
+                a.href = basePath + e.url;
+                var strong = document.createElement('strong');
+                strong.textContent = e.title;
+                a.appendChild(strong);
+                var meta = [e.collection, e.date].filter(Boolean).join(' \u00b7 ');
+                if (meta) {
+                    var div = document.createElement('div');
+                    div.className = 'result-meta';
+                    div.textContent = meta;
+                    a.appendChild(div);
+                }
+                results.appendChild(a);
+            });
         }
-        input.addEventListener('input', function(){ load(function(){ search(input.value); }); });
+        input.addEventListener('input', function(){ load(function(){ doSearch(input.value); }); });
     })();
     </script>
     {% block footer %}{% endblock %}

--- a/src/themes/magazine.tera
+++ b/src/themes/magazine.tera
@@ -11,13 +11,16 @@
     <meta property="og:url" content="{{ site.base_url }}{{ page.url | default(value='/') }}">
     <meta property="og:title" content="{{ page.title | default(value=site.title) }}">
     <meta property="og:description" content="{{ page.description | default(value=site.description) }}">
-    {% if page.image %}<meta property="og:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    {% if page.image %}{% set _abs_image = page.image %}{% if not page.image is starting_with("http") %}{% set _abs_image = site.base_url ~ page.image %}{% endif %}<meta property="og:image" content="{{ _abs_image }}">
+    <meta property="og:image:width" content="1200"><meta property="og:image:height" content="630">{% endif %}
     <meta property="og:site_name" content="{{ site.title }}">
     <meta property="og:locale" content="{{ lang }}">
+    {% if page.collection and page.date %}<meta property="article:published_time" content="{{ page.date }}">{% endif %}
+    {% if page.collection and page.updated %}<meta property="article:modified_time" content="{{ page.updated }}">{% endif %}
     <meta name="twitter:card" content="{% if page.image %}summary_large_image{% else %}summary{% endif %}">
     <meta name="twitter:title" content="{{ page.title | default(value=site.title) }}">
     <meta name="twitter:description" content="{{ page.description | default(value=site.description) }}">
-    {% if page.image %}<meta name="twitter:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    {% if page.image %}<meta name="twitter:image" content="{{ _abs_image }}">{% endif %}
     {% if page.robots %}<meta name="robots" content="{{ page.robots }}">{% endif %}
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ lang_prefix }}/feed.xml">
     <link rel="alternate" type="text/plain" title="LLM Summary" href="{{ lang_prefix }}/llms.txt">
@@ -32,6 +35,9 @@
     {% else %}{"@context":"https://schema.org","@type":"WebSite","name":{{ site.title | json_encode() }},"description":{{ site.description | json_encode() }},"url":{{ site.base_url | json_encode() }}}
     {% endif %}
     </script>
+    {% if page.collection %}{% set _bc_col_url = site.base_url ~ lang_prefix ~ "/" ~ page.collection %}<script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
+    </script>{% endif %}
     <style>
         *, *::before, *::after { box-sizing: border-box; }
         body { margin: 0; padding: 0; font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; color: #1a1a1a; background: #fff; }

--- a/src/themes/minimal.tera
+++ b/src/themes/minimal.tera
@@ -38,9 +38,12 @@
     {% if page.collection %}{% set _bc_col_url = site.base_url ~ lang_prefix ~ "/" ~ page.collection %}<script type="application/ld+json">
     {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
     </script>{% endif %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
     <style>
         *, *::before, *::after { box-sizing: border-box; }
-        body { max-width: 600px; margin: 4rem auto; padding: 0 1.5rem; font-family: Georgia, 'Times New Roman', serif; line-height: 1.7; color: #333; font-size: 1.05rem; }
+        body { max-width: 600px; margin: 4rem auto; padding: 0 1.5rem; font-family: 'Lora', Georgia, 'Times New Roman', serif; line-height: 1.7; color: #333; font-size: 1.05rem; }
         a { color: #333; }
         header { margin-bottom: 3rem; }
         header h1 { font-size: 1.2rem; font-weight: normal; letter-spacing: 0.05em; text-transform: uppercase; }
@@ -64,6 +67,16 @@
         #search-results a:hover { color: #000; }
         #search-results .result-meta { font-size: 0.78rem; color: #aaa; font-style: normal; margin-top: 0.1rem; }
         #search-results .no-results { padding: 0.4rem 0; color: #aaa; font-size: 0.85rem; font-family: system-ui, sans-serif; }
+        .homepage-content { margin-bottom: 3rem; padding-bottom: 2.5rem; border-bottom: 1px solid #ddd; }
+        .homepage-content > h1:first-child { font-size: 2rem; font-weight: 400; letter-spacing: -0.01em; line-height: 1.3; margin-bottom: 0.75rem; }
+        .homepage-content > p { font-size: 1.05rem; line-height: 1.8; color: #444; margin-bottom: 1rem; }
+        .homepage-content > h2 { font-size: 1.2rem; margin-top: 2rem; margin-bottom: 0.5rem; }
+        .homepage-content > h3 { font-size: 1.05rem; font-weight: 700; margin-top: 1.5rem; margin-bottom: 0.4rem; }
+        .homepage-content > ul { list-style: none; padding: 0; margin: 1.5rem 0; }
+        .homepage-content > ul > li { padding: 0.75rem 0; border-bottom: 1px solid #eee; }
+        .homepage-content > ul > li:last-child { border-bottom: none; }
+        .homepage-content > ul > li strong { color: #333; }
+        .homepage-content blockquote { border-left: 2px solid #ccc; padding-left: 1.5rem; margin: 1.5rem 0; font-style: italic; color: #666; }
         article { margin-bottom: 2.5rem; }
         article h1 { font-size: 1.8rem; }
         article h3 a { text-decoration: none; color: inherit; }
@@ -262,19 +275,38 @@
         var basePath = {{ site.base_path | json_encode() }};
         var indexUrl = basePath + {% if lang != default_language %}('/' + {{ lang | json_encode() }} + '/search-index.json'){% else %}'/search-index.json'{% endif %};
         function load(cb) { if (index) { cb(); return; } fetch(indexUrl).then(function(r){return r.json();}).then(function(d){index=d;cb();}).catch(function(){index=[];}); }
-        function search(q) {
+        function doSearch(q) {
             q = q.toLowerCase().trim();
-            if (!q) { results.innerHTML = ''; return; }
+            if (!q) { results.textContent = ''; return; }
             var hits = index.filter(function(e){
                 return (e.title||'').toLowerCase().includes(q) || (e.description||'').toLowerCase().includes(q) || (e.tags||[]).some(function(t){return t.toLowerCase().includes(q);});
             }).slice(0, 8);
-            if (!hits.length) { results.innerHTML = '<div class="no-results">{{ t.no_results }}</div>'; return; }
-            results.innerHTML = hits.map(function(e){
-                var meta = [e.collection, e.date].filter(Boolean).join(' · ');
-                return '<a href="' + basePath + e.url + '"><strong>' + e.title + '</strong>' + (meta ? '<div class="result-meta">' + meta + '</div>' : '') + '</a>';
-            }).join('');
+            if (!hits.length) {
+                var noRes = document.createElement('div');
+                noRes.className = 'no-results';
+                noRes.textContent = '{{ t.no_results }}';
+                results.textContent = '';
+                results.appendChild(noRes);
+                return;
+            }
+            results.textContent = '';
+            hits.forEach(function(e){
+                var a = document.createElement('a');
+                a.href = basePath + e.url;
+                var strong = document.createElement('strong');
+                strong.textContent = e.title;
+                a.appendChild(strong);
+                var meta = [e.collection, e.date].filter(Boolean).join(' \u00b7 ');
+                if (meta) {
+                    var div = document.createElement('div');
+                    div.className = 'result-meta';
+                    div.textContent = meta;
+                    a.appendChild(div);
+                }
+                results.appendChild(a);
+            });
         }
-        input.addEventListener('input', function(){ load(function(){ search(input.value); }); });
+        input.addEventListener('input', function(){ load(function(){ doSearch(input.value); }); });
     })();
     </script>
     {% block footer %}{% endblock %}

--- a/src/themes/terminal.tera
+++ b/src/themes/terminal.tera
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html lang="{{ lang }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="/favicon.ico">
+    <title>{% block title %}{{ site.title }}{% endblock %}</title>
+    <meta name="description" content="{{ page.description | default(value=site.description) }}">
+    <link rel="canonical" href="{{ site.base_url }}{{ page.url | default(value='/') }}">
+    <meta property="og:type" content="{% if page.collection %}article{% else %}website{% endif %}">
+    <meta property="og:url" content="{{ site.base_url }}{{ page.url | default(value='/') }}">
+    <meta property="og:title" content="{{ page.title | default(value=site.title) }}">
+    <meta property="og:description" content="{{ page.description | default(value=site.description) }}">
+    {% if page.image %}<meta property="og:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    <meta property="og:site_name" content="{{ site.title }}">
+    <meta property="og:locale" content="{{ lang }}">
+    <meta name="twitter:card" content="{% if page.image %}summary_large_image{% else %}summary{% endif %}">
+    <meta name="twitter:title" content="{{ page.title | default(value=site.title) }}">
+    <meta name="twitter:description" content="{{ page.description | default(value=site.description) }}">
+    {% if page.image %}<meta name="twitter:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    {% if page.robots %}<meta name="robots" content="{{ page.robots }}">{% endif %}
+    <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ lang_prefix }}/feed.xml">
+    <link rel="alternate" type="text/plain" title="LLM Summary" href="{{ lang_prefix }}/llms.txt">
+    {% if page.url %}<link rel="alternate" type="text/markdown" title="Markdown" href="{{ site.base_url }}{{ page.url }}.md">{% endif %}
+    {% if translations %}{% for t in translations %}<link rel="alternate" hreflang="{{ t.lang }}" href="{{ site.base_url }}{{ t.url }}">
+    {% endfor %}<link rel="alternate" hreflang="x-default" href="{{ site.base_url }}{{ page.url | default(value='/') }}">
+    {% endif %}
+    <script type="application/ld+json">
+    {% set _ld_url = page.url | default(value='/') %}{% set _ld_href = site.base_url ~ _ld_url %}{% set _ld_title = page.title | default(value=site.title) %}{% set _ld_desc = page.description | default(value=site.description) %}
+    {% if page.collection == 'posts' %}{"@context":"https://schema.org","@type":"BlogPosting","headline":{{ _ld_title | json_encode() }},"description":{{ _ld_desc | json_encode() }},"datePublished":{{ page.date | default(value='') | json_encode() }}{% if page.updated %},"dateModified":{{ page.updated | json_encode() }}{% endif %},"author":{"@type":"Person","name":{{ site.author | json_encode() }}},"publisher":{"@type":"Organization","name":{{ site.title | json_encode() }}},"url":{{ _ld_href | json_encode() }}}
+    {% elif page.collection %}{"@context":"https://schema.org","@type":"Article","headline":{{ _ld_title | json_encode() }},"description":{{ _ld_desc | json_encode() }}{% if page.updated %},"dateModified":{{ page.updated | json_encode() }}{% endif %},"author":{"@type":"Person","name":{{ site.author | json_encode() }}},"publisher":{"@type":"Organization","name":{{ site.title | json_encode() }}},"url":{{ _ld_href | json_encode() }}}
+    {% else %}{"@context":"https://schema.org","@type":"WebSite","name":{{ site.title | json_encode() }},"description":{{ site.description | json_encode() }},"url":{{ site.base_url | json_encode() }}}
+    {% endif %}
+    </script>
+    <style>
+        *, *::before, *::after { box-sizing: border-box; }
+        body { max-width: 760px; margin: 0 auto; padding: 1.5rem 1.25rem; font-family: ui-monospace, 'SFMono-Regular', 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace; font-size: 0.9rem; line-height: 1.7; color: #b0b0b0; background: #0c0c0c; }
+        ::selection { background: #33ff00; color: #0c0c0c; }
+        a { color: #33ff00; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+
+        /* Prompt-style header */
+        header { margin-bottom: 2rem; border: 1px solid #2a2a2a; padding: 1.25rem; background: #111; }
+        header h1 { margin: 0 0 0.25rem; font-size: 1rem; font-weight: 400; }
+        header h1 a { color: #33ff00; text-decoration: none; }
+        header h1::before { content: '~ $ '; color: #555; }
+        header p { margin: 0 0 0.75rem; color: #666; font-size: 0.85rem; }
+        header p::before { content: '# '; color: #444; }
+        nav.site-nav { margin-bottom: 0.75rem; }
+        nav.site-nav a { color: #33ff00; margin-right: 1.5rem; font-size: 0.85rem; }
+        nav.site-nav a::before { content: './'; color: #555; }
+        nav.site-nav a:hover { text-decoration: underline; }
+        .lang-switcher { display: inline-flex; gap: 0.5rem; font-size: 0.8rem; }
+        .lang-switcher a { color: #666; padding: 0.1rem 0.3rem; border: 1px solid #333; }
+        .lang-switcher a:hover { border-color: #33ff00; color: #33ff00; }
+        .lang-switcher strong { color: #33ff00; padding: 0.1rem 0.3rem; border: 1px solid #33ff00; }
+        .search-form { margin-top: 0.75rem; }
+        .search-form input { width: 100%; padding: 0.4rem 0.6rem; border: 1px solid #2a2a2a; background: #0c0c0c; color: #33ff00; font-family: inherit; font-size: 0.85rem; }
+        .search-form input::placeholder { color: #444; }
+        .search-form input:focus { outline: none; border-color: #33ff00; box-shadow: 0 0 0 1px #33ff00; }
+        #search-results { border: 1px solid #2a2a2a; background: #111; }
+        #search-results a { display: block; padding: 0.4rem 0.6rem; color: #33ff00; border-bottom: 1px solid #1a1a1a; font-size: 0.85rem; }
+        #search-results a:last-child { border-bottom: none; }
+        #search-results a:hover { background: #1a1a1a; }
+        #search-results a::before { content: '> '; color: #555; }
+        #search-results strong { color: #e0e0e0; }
+        #search-results .result-meta { font-size: 0.75rem; color: #555; margin-top: 0.1rem; }
+        #search-results .no-results { padding: 0.4rem 0.6rem; color: #555; font-size: 0.85rem; }
+
+        /* Content */
+        article { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px dashed #2a2a2a; }
+        article:last-child { border-bottom: none; }
+        article h1 { font-size: 1.2rem; font-weight: 700; color: #e0e0e0; margin: 0 0 0.25rem; }
+        article h2 { font-size: 1rem; font-weight: 700; color: #e0e0e0; margin-top: 2rem; border-bottom: 1px dashed #2a2a2a; padding-bottom: 0.25rem; }
+        article h3 { font-size: 0.9rem; font-weight: 700; color: #c0c0c0; margin: 0 0 0.25rem; }
+        article h3 a { color: #33ff00; }
+        article h3 a:hover { text-decoration: underline; }
+        article h3::before { content: '## '; color: #555; }
+        article p { color: #b0b0b0; }
+        time { font-size: 0.8rem; color: #555; }
+        time::before { content: '['; }
+        time::after { content: ']'; }
+        .reading-time { color: #555; font-size: 0.8rem; }
+        .tags a, .tags span { color: #0af; font-size: 0.8rem; margin-right: 0.5rem; text-decoration: none; }
+        .tags a::before, .tags span::before { content: '#'; }
+        .tags a:hover { text-decoration: underline; }
+
+        /* Code — already monospace, so just adjust colors */
+        pre { background: #111; color: #cdd6f4; padding: 1rem; border: 1px solid #2a2a2a; overflow-x: auto; }
+        pre code { background: none; color: inherit; font-size: 0.85rem; padding: 0; }
+        code { font-size: 0.85rem; background: #1a1a1a; color: #33ff00; padding: 0.1em 0.3em; border: 1px solid #2a2a2a; }
+        blockquote { border-left: 2px solid #33ff00; margin-left: 0; padding-left: 1rem; color: #888; }
+        blockquote::before { content: ''; }
+        img { max-width: 100%; height: auto; border: 1px solid #2a2a2a; }
+        figure { margin: 1.5rem 0; }
+        figure img { display: block; }
+        figcaption { font-size: 0.8rem; color: #555; margin-top: 0.3rem; }
+        figcaption::before { content: '// '; color: #444; }
+        hr { border: none; border-top: 1px dashed #2a2a2a; margin: 2rem 0; }
+
+        /* Embeds */
+        .video-embed { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin: 1.5rem 0; border: 1px solid #2a2a2a; }
+        .video-embed iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
+        .gist-embed { margin: 1.5rem 0; }
+
+        /* Callouts */
+        .callout { padding: 0.75rem 1rem; margin: 1.5rem 0; border: 1px solid #2a2a2a; border-left: 3px solid #33ff00; background: #111; }
+        .callout-title { font-weight: 700; margin-bottom: 0.4rem; font-size: 0.8rem; color: #33ff00; text-transform: uppercase; }
+        .callout-info { border-left-color: #0af; }
+        .callout-info .callout-title { color: #0af; }
+        .callout-warning { border-left-color: #ffb000; }
+        .callout-warning .callout-title { color: #ffb000; }
+        .callout-danger { border-left-color: #ff3333; }
+        .callout-danger .callout-title { color: #ff3333; }
+        .callout-tip { border-left-color: #33ff00; }
+        .callout-tip .callout-title { color: #33ff00; }
+        .callout-note { border-left-color: #888; }
+        .callout-note .callout-title { color: #888; }
+        .callout p:last-child { margin-bottom: 0; }
+
+        /* Contact form */
+        .contact-form { max-width: 480px; }
+        .contact-form-field { margin-bottom: 1rem; }
+        .contact-form-field label { display: block; font-weight: 400; margin-bottom: 0.25rem; font-size: 0.8rem; color: #33ff00; text-transform: uppercase; }
+        .contact-form-field input, .contact-form-field textarea { width: 100%; padding: 0.5rem 0.6rem; border: 1px solid #2a2a2a; background: #0c0c0c; color: #b0b0b0; font: inherit; box-sizing: border-box; }
+        .contact-form-field input:focus, .contact-form-field textarea:focus { outline: none; border-color: #33ff00; box-shadow: 0 0 0 1px #33ff00; }
+        .contact-form-submit { background: #33ff00; color: #0c0c0c; border: none; padding: 0.5rem 1.5rem; font: inherit; font-weight: 700; cursor: pointer; }
+        .contact-form-submit:hover { background: #2be600; }
+        .contact-form-honeypot { display: none; }
+        .contact-form-embed { min-height: 400px; border: 1px solid #2a2a2a; }
+        .contact-form-error { color: #ff3333; background: #1a0000; padding: 0.75rem; border: 1px solid #ff3333; }
+
+        /* Trust center */
+        .trust-hub { max-width: 760px; margin: 0 auto; }
+        .trust-hero { margin-bottom: 2rem; }
+        .trust-hero h1 { font-size: 1.2rem; font-weight: 700; color: #e0e0e0; margin-bottom: 0.5rem; }
+        .trust-section { margin-bottom: 2rem; }
+        .trust-section h2 { font-size: 1rem; color: #33ff00; margin-bottom: 0.75rem; border-bottom: 1px dashed #2a2a2a; padding-bottom: 0.25rem; }
+        .trust-breadcrumb { font-size: 0.8rem; color: #555; margin-bottom: 1.5rem; }
+        .trust-breadcrumb a { color: #33ff00; text-decoration: none; }
+        .trust-breadcrumb a:hover { text-decoration: underline; }
+        .trust-description { color: #888; margin-bottom: 1.5rem; line-height: 1.7; }
+        .cert-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; }
+        .cert-card { border: 1px solid #2a2a2a; padding: 1rem; background: #111; }
+        .cert-card:hover { border-color: #33ff00; }
+        .cert-card__header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+        .cert-card__title { font-weight: 700; font-size: 0.9rem; color: #e0e0e0; }
+        .cert-card__desc { font-size: 0.85rem; color: #888; margin-bottom: 0.5rem; }
+        .cert-card__link { font-size: 0.8rem; color: #33ff00; text-decoration: none; }
+        .cert-card__link:hover { text-decoration: underline; }
+        .cert-status { display: inline-block; font-size: 0.7rem; font-weight: 700; padding: 0.1rem 0.4rem; text-transform: uppercase; letter-spacing: 0.05em; border: 1px solid; }
+        .cert-status--active { border-color: #33ff00; color: #33ff00; }
+        .cert-status--in_progress { border-color: #ffb000; color: #ffb000; }
+        .cert-status--planned { border-color: #555; color: #555; }
+        .cert-detail { margin-bottom: 2rem; padding: 1rem; border: 1px solid #2a2a2a; background: #111; }
+        .cert-meta { font-size: 0.85rem; color: #888; margin-bottom: 0.25rem; }
+        .cert-meta strong { color: #e0e0e0; }
+        .trust-item { padding: 0.5rem 0; border-bottom: 1px dashed #2a2a2a; }
+        .trust-item:last-child { border-bottom: none; }
+        .subprocessor-table-wrap { overflow-x: auto; margin: 1.5rem 0; }
+        .subprocessor-table { border-collapse: collapse; width: 100%; }
+        .subprocessor-table th, .subprocessor-table td { border: 1px solid #2a2a2a; padding: 0.4rem 0.6rem; text-align: left; font-size: 0.85rem; }
+        .subprocessor-table th { background: #111; color: #33ff00; font-weight: 400; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.05em; }
+        .faq-section { margin-top: 2rem; }
+        .faq-item { border-bottom: 1px dashed #2a2a2a; }
+        .faq-item summary { padding: 0.5rem 0; cursor: pointer; color: #e0e0e0; font-size: 0.85rem; }
+        .faq-item summary:hover { color: #33ff00; }
+        .faq-answer { padding: 0 0 0.75rem; color: #888; line-height: 1.7; }
+        .trust-page { margin-bottom: 2rem; }
+
+        /* Changelog */
+        .changelog-entry-header { margin-bottom: 1.5rem; }
+        .changelog-meta { display: flex; align-items: center; gap: 1rem; margin-top: 0.5rem; color: #555; font-size: 0.85rem; }
+        .changelog-summary { color: #888; font-size: 0.9rem; margin-bottom: 1.5rem; }
+        .changelog-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+        .changelog-tag { display: inline-block; padding: 0.1rem 0.5rem; font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; border: 1px solid; }
+        .changelog-tag--new { border-color: #33ff00; color: #33ff00; }
+        .changelog-tag--fix { border-color: #0af; color: #0af; }
+        .changelog-tag--breaking { border-color: #ff3333; color: #ff3333; }
+        .changelog-tag--improvement { border-color: #c084fc; color: #c084fc; }
+        .changelog-tag--deprecated { border-color: #555; color: #555; }
+        .changelog-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 1rem; margin-bottom: 2rem; }
+        .changelog-header h1 { margin-bottom: 0; }
+        .changelog-rss { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.75rem; color: #555; text-decoration: none; padding: 0.2rem 0.5rem; border: 1px solid #2a2a2a; }
+        .changelog-rss:hover { color: #33ff00; border-color: #33ff00; }
+        .changelog-back { margin-bottom: 1.5rem; }
+        .changelog-back a { color: #555; text-decoration: none; font-size: 0.85rem; }
+        .changelog-back a:hover { color: #33ff00; }
+        .changelog-timeline { position: relative; padding-left: 1.5rem; }
+        .changelog-timeline::before { content: ''; position: absolute; left: 0; top: 0.5rem; bottom: 0; width: 1px; background: #2a2a2a; }
+        .changelog-item { position: relative; padding-bottom: 1.5rem; border-bottom: 1px dashed #2a2a2a; margin-bottom: 0; }
+        .changelog-item::before { content: '*'; position: absolute; left: -1.5rem; top: 0.1rem; color: #33ff00; font-weight: 700; transform: translateX(-2px); }
+        .changelog-item:last-child { border-bottom: none; }
+        .changelog-item-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 0.5rem; }
+        .changelog-item-header h2 { margin: 0; font-size: 1rem; color: #e0e0e0; }
+        .changelog-item-header time { color: #555; font-size: 0.8rem; white-space: nowrap; }
+        .changelog-item .changelog-tags { margin-top: 0.5rem; }
+        .changelog-item p, .changelog-item .excerpt { margin-top: 0.5rem; color: #888; }
+        .changelog-feed .changelog-item::before { display: none; }
+        .changelog-feed { display: flex; flex-direction: column; gap: 0; }
+
+        /* Roadmap */
+        .roadmap-back { margin-bottom: 1.5rem; }
+        .roadmap-back a { color: #555; text-decoration: none; font-size: 0.85rem; }
+        .roadmap-back a:hover { color: #33ff00; }
+        .roadmap-entry-header { margin-bottom: 1.5rem; }
+        .roadmap-summary { color: #888; font-size: 0.9rem; margin-bottom: 1.5rem; }
+        .roadmap-status-badges { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
+        .roadmap-status { display: inline-block; padding: 0.1rem 0.5rem; font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; border: 1px solid; }
+        .roadmap-status--planned { border-color: #0af; color: #0af; }
+        .roadmap-status--in-progress { border-color: #ffb000; color: #ffb000; }
+        .roadmap-status--done { border-color: #33ff00; color: #33ff00; }
+        .roadmap-status--cancelled { border-color: #555; color: #555; text-decoration: line-through; }
+        .roadmap-grouped { display: flex; flex-direction: column; gap: 2rem; }
+        .roadmap-section-header { display: flex; align-items: center; gap: 0.75rem; font-size: 0.9rem; margin-bottom: 0.75rem; color: #e0e0e0; }
+        .roadmap-items { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1rem; }
+        .roadmap-card { padding: 0.75rem 1rem; border: 1px solid #2a2a2a; background: #111; }
+        .roadmap-card:hover { border-color: #33ff00; }
+        .roadmap-card h3 { margin: 0 0 0.25rem; font-size: 0.9rem; color: #e0e0e0; }
+        .roadmap-card p, .roadmap-card .excerpt { margin: 0; color: #888; font-size: 0.85rem; }
+        .roadmap-kanban { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+        .roadmap-column-header { font-size: 0.85rem; margin-bottom: 0.75rem; display: flex; align-items: center; gap: 0.5rem; color: #e0e0e0; }
+        .roadmap-count { font-size: 0.75rem; color: #555; font-weight: 400; }
+        .roadmap-timeline { position: relative; padding-left: 1.5rem; }
+        .roadmap-timeline::before { content: ''; position: absolute; left: 0.4rem; top: 0; bottom: 0; width: 1px; background: #2a2a2a; }
+        .roadmap-milestone { position: relative; margin-bottom: 1.5rem; }
+        .roadmap-milestone-dot { position: absolute; left: -1.35rem; top: 0.3rem; width: 10px; height: 10px; border: 1px solid #33ff00; background: #0c0c0c; }
+        .roadmap-milestone-dot .roadmap-status { display: none; }
+        .roadmap-milestone-content h3 { margin: 0 0 0.25rem; font-size: 0.9rem; color: #e0e0e0; }
+        .roadmap-milestone-content p { margin: 0.25rem 0 0; color: #888; font-size: 0.85rem; }
+        @media (max-width: 768px) { .roadmap-kanban { grid-template-columns: 1fr; } }
+
+        /* Tables */
+        table { border-collapse: collapse; width: 100%; margin: 1.5rem 0; }
+        th, td { border: 1px solid #2a2a2a; padding: 0.4rem 0.6rem; text-align: left; font-size: 0.85rem; }
+        th { background: #111; color: #33ff00; font-weight: 400; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.05em; }
+        ul.contains-task-list, ol.contains-task-list { list-style: none; padding-left: 0; }
+        li.task-list-item { display: flex; align-items: baseline; gap: 0.5rem; }
+        li.task-list-item input[type="checkbox"] { margin: 0; pointer-events: none; }
+        .footnote-definition { font-size: 0.8rem; color: #888; border-top: 1px dashed #2a2a2a; margin-top: 2rem; padding-top: 0.75rem; }
+        .footnote-definition p { display: inline; }
+        sup.footnote-reference a { text-decoration: none; color: #33ff00; font-weight: 700; }
+
+        /* TOC & Pagination */
+        .toc { margin: 1.5rem 0; padding: 0.75rem 1rem; border: 1px solid #2a2a2a; background: #111; }
+        .toc > ul { margin: 0; padding-left: 1.25rem; }
+        .toc ul ul { padding-left: 1rem; }
+        .toc li { margin: 0.2rem 0; }
+        .toc a { text-decoration: none; color: #33ff00; }
+        .toc a:hover { text-decoration: underline; }
+        .pagination { display: flex; justify-content: space-between; align-items: center; margin-top: 2rem; padding-top: 0.75rem; border-top: 1px dashed #2a2a2a; }
+        .pagination a { text-decoration: none; color: #33ff00; }
+        .pagination a:hover { text-decoration: underline; }
+        .pagination span { color: #555; font-size: 0.85rem; }
+
+        /* Footer */
+        footer { margin-top: 3rem; padding-top: 0.75rem; border-top: 1px solid #2a2a2a; color: #555; font-size: 0.8rem; }
+        footer nav { margin-bottom: 0.5rem; }
+        footer nav a { color: #888; text-decoration: none; }
+        footer nav a:hover { color: #33ff00; }
+
+        /* Accessibility */
+        .skip-link { position: absolute; top: -100%; left: 0; padding: 0.4rem 0.75rem; background: #33ff00; color: #0c0c0c; z-index: 100; text-decoration: none; font-weight: 700; }
+        .skip-link:focus { top: 0; }
+        :focus-visible { outline: 1px solid #33ff00; outline-offset: 2px; }
+        @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } }
+
+        /* Blinking cursor on title */
+        @keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+        header h1 a::after { content: '_'; animation: blink 1s step-end infinite; color: #33ff00; }
+    </style>
+    {% block extra_css %}{% endblock %}
+    {% block head %}{% endblock %}
+</head>
+<body>
+    <a href="#main" class="skip-link">{{ t.skip_to_content }}</a>
+    <header>
+    {% block header %}
+        <h1><a href="{{ lang_prefix }}/">{{ site.title }}</a></h1>
+        {% if site.description %}<p>{{ site.description }}</p>{% endif %}
+        {% if data.nav %}
+        <nav class="site-nav" aria-label="Main navigation">
+            {% for item in data.nav %}{% if item.external %}<a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.title }}</a>{% else %}<a href="{{ lang_prefix }}{{ item.url }}">{{ item.title }}</a>{% endif %}{% endfor %}
+        </nav>
+        {% endif %}
+        {% if translations | length > 1 %}
+        <nav class="lang-switcher">
+            {% for t in translations %}{% if t.lang == lang %}<strong>{{ t.lang | upper }}</strong>{% else %}<a href="{{ t.url }}">{{ t.lang | upper }}</a>{% endif %}{% endfor %}
+        </nav>
+        {% endif %}
+        <form class="search-form" role="search" aria-label="{{ t.search_label }}" onsubmit="return false">
+            <input type="search" id="search-input" placeholder="{{ t.search_placeholder }}" autocomplete="off" aria-label="{{ t.search_label }}">
+        </form>
+        <div id="search-results" aria-live="polite"></div>
+    {% endblock %}
+    </header>
+    <main id="main">
+        {% block content %}{% endblock %}
+    </main>
+    <footer>
+        {% if data.footer %}{% if data.footer.links %}
+        <nav aria-label="Footer navigation">
+            {% for link in data.footer.links %}{% if link.external %}<a href="{{ link.url }}" target="_blank" rel="noopener">{{ link.title }}</a>{% else %}<a href="{{ lang_prefix }}{{ link.url }}">{{ link.title }}</a>{% endif %}{% if not loop.last %} | {% endif %}{% endfor %}
+        </nav>
+        {% endif %}{% endif %}
+        <p>&copy; {% if data.footer %}{% if data.footer.copyright %}{{ data.footer.copyright }}{% else %}{{ site.author }}{% endif %}{% else %}{{ site.author }}{% endif %}</p>
+    </footer>
+    <script>
+    (function(){
+        var index = null;
+        var input = document.getElementById('search-input');
+        var results = document.getElementById('search-results');
+        var basePath = {{ site.base_path | json_encode() }};
+        var indexUrl = basePath + {% if lang != default_language %}('/' + {{ lang | json_encode() }} + '/search-index.json'){% else %}'/search-index.json'{% endif %};
+        function load(cb) { if (index) { cb(); return; } fetch(indexUrl).then(function(r){return r.json();}).then(function(d){index=d;cb();}).catch(function(){index=[];}); }
+        function search(q) {
+            q = q.toLowerCase().trim();
+            if (!q) { results.innerHTML = ''; return; }
+            var hits = index.filter(function(e){
+                return (e.title||'').toLowerCase().includes(q) || (e.description||'').toLowerCase().includes(q) || (e.tags||[]).some(function(t){return t.toLowerCase().includes(q);});
+            }).slice(0, 8);
+            if (!hits.length) { results.innerHTML = '<div class="no-results">{{ t.no_results }}</div>'; return; }
+            results.innerHTML = hits.map(function(e){
+                var meta = [e.collection, e.date].filter(Boolean).join(' | ');
+                return '<a href="' + basePath + e.url + '"><strong>' + e.title + '</strong>' + (meta ? '<div class="result-meta">' + meta + '</div>' : '') + '</a>';
+            }).join('');
+        }
+        input.addEventListener('input', function(){ load(function(){ search(input.value); }); });
+    })();
+    </script>
+    {% block footer %}{% endblock %}
+    {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/src/themes/terminal.tera
+++ b/src/themes/terminal.tera
@@ -38,6 +38,9 @@
     {% if page.collection %}{% set _bc_col_url = site.base_url ~ lang_prefix ~ "/" ~ page.collection %}<script type="application/ld+json">
     {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
     </script>{% endif %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
     <style>
         /* === CRT TERMINAL THEME === */
         /* A phosphor-green CRT monitor brought to life */
@@ -63,7 +66,7 @@
             --glow-sm: 0 0 8px rgba(32,194,14,0.6);
             --glow-md: 0 0 10px rgba(32,194,14,0.8), 0 0 20px rgba(32,194,14,0.4), 0 0 40px rgba(32,194,14,0.2);
             --glow-lg: 0 0 15px rgba(32,194,14,0.15), inset 0 0 30px rgba(0,0,0,0.5);
-            --font-mono: ui-monospace, 'SFMono-Regular', 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+            --font-mono: 'JetBrains Mono', ui-monospace, 'SFMono-Regular', 'SF Mono', Menlo, Consolas, monospace;
         }
 
         ::selection { background: #20c20e; color: #0a0a0a; }
@@ -225,10 +228,88 @@
         #search-results .no-results { padding: 0.4rem 0.6rem; color: var(--text-dim); font-size: 0.85rem; }
 
         /* ==============================
+           HOMEPAGE CONTENT
+           ============================== */
+        .homepage-content {
+            margin-bottom: 2.5rem;
+            padding: 1.25rem;
+            border: 1px solid var(--border);
+            background: var(--bg-panel);
+            box-shadow: var(--glow-lg);
+        }
+        .homepage-content::before {
+            content: '/* HOMEPAGE */';
+            display: block;
+            font-size: 0.7rem;
+            color: var(--phosphor-dim);
+            margin-bottom: 0.75rem;
+            letter-spacing: 0.1em;
+        }
+        .homepage-content > h1:first-child {
+            font-size: 1.3rem;
+            font-weight: 700;
+            color: var(--phosphor);
+            margin: 0 0 0.75rem;
+            text-shadow: var(--glow-md);
+        }
+        .homepage-content > h1:first-child::before { content: '> '; color: var(--phosphor-dim); }
+        .homepage-content > h2 {
+            font-size: 1rem; font-weight: 700;
+            color: var(--phosphor); margin-top: 2rem;
+            border-bottom: 1px dashed var(--border);
+            padding-bottom: 0.25rem;
+            text-shadow: var(--glow-sm);
+        }
+        .homepage-content > h2::before { content: '## '; color: var(--phosphor-dim); }
+        .homepage-content > h3 {
+            font-size: 0.9rem; font-weight: 700;
+            color: var(--amber); margin: 1.25rem 0 0.25rem;
+        }
+        .homepage-content > h3::before { content: '### '; color: var(--phosphor-dim); }
+        .homepage-content > p { color: var(--text); }
+        .homepage-content > p strong { color: var(--phosphor); }
+        .homepage-content > hr {
+            border: none; border-top: 1px dashed var(--border); margin: 1.5rem 0;
+        }
+        .homepage-content > ul {
+            list-style: none; padding-left: 1.5rem;
+        }
+        .homepage-content > ul > li::before { content: '- '; color: var(--phosphor-dim); margin-left: -1rem; }
+        .homepage-content > ul > li strong {
+            color: var(--amber); text-shadow: 0 0 6px rgba(255,176,0,0.3);
+        }
+        .homepage-content > blockquote {
+            border-left: 2px solid var(--cyan);
+            margin-left: 0; padding-left: 1rem;
+            color: var(--text-dim);
+            box-shadow: -2px 0 8px rgba(0,191,255,0.1);
+        }
+
+        /* ==============================
+           COLLECTION SECTIONS
+           ============================== */
+        main > section {
+            margin-bottom: 2rem;
+        }
+        main > section > h2 {
+            font-size: 0.8rem;
+            font-weight: 700;
+            color: var(--phosphor);
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            margin: 0 0 1rem;
+            padding-bottom: 0.25rem;
+            border-bottom: 1px solid var(--border);
+            text-shadow: var(--glow-sm);
+        }
+        main > section > h2::before { content: '$ ls '; color: var(--phosphor-dim); font-weight: 400; }
+
+        /* ==============================
            CONTENT
            ============================== */
-        article { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px dashed var(--border); }
-        article:last-child { border-bottom: none; }
+        section > article { margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 1px dashed var(--border); }
+        section > article:last-child { border-bottom: none; }
+        main > article { margin-bottom: 2rem; }
 
         article h1 {
             font-size: 1.2rem;
@@ -255,7 +336,7 @@
         }
         article h3 a { color: var(--cyan); }
         article h3 a:hover { text-decoration: underline; }
-        article h3::before { content: '## '; color: var(--phosphor-dim); }
+        section > article h3::before { content: '## '; color: var(--phosphor-dim); }
         article h4 { font-size: 0.9rem; color: var(--phosphor); text-shadow: 0 0 4px rgba(32,194,14,0.3); }
         article p { color: var(--text); }
 

--- a/src/themes/terminal.tera
+++ b/src/themes/terminal.tera
@@ -11,13 +11,16 @@
     <meta property="og:url" content="{{ site.base_url }}{{ page.url | default(value='/') }}">
     <meta property="og:title" content="{{ page.title | default(value=site.title) }}">
     <meta property="og:description" content="{{ page.description | default(value=site.description) }}">
-    {% if page.image %}<meta property="og:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    {% if page.image %}{% set _abs_image = page.image %}{% if not page.image is starting_with("http") %}{% set _abs_image = site.base_url ~ page.image %}{% endif %}<meta property="og:image" content="{{ _abs_image }}">
+    <meta property="og:image:width" content="1200"><meta property="og:image:height" content="630">{% endif %}
     <meta property="og:site_name" content="{{ site.title }}">
     <meta property="og:locale" content="{{ lang }}">
+    {% if page.collection and page.date %}<meta property="article:published_time" content="{{ page.date }}">{% endif %}
+    {% if page.collection and page.updated %}<meta property="article:modified_time" content="{{ page.updated }}">{% endif %}
     <meta name="twitter:card" content="{% if page.image %}summary_large_image{% else %}summary{% endif %}">
     <meta name="twitter:title" content="{{ page.title | default(value=site.title) }}">
     <meta name="twitter:description" content="{{ page.description | default(value=site.description) }}">
-    {% if page.image %}<meta name="twitter:image" content="{% if page.image is starting_with(pat='http') %}{{ page.image }}{% else %}{{ site.base_url }}{{ page.image }}{% endif %}">{% endif %}
+    {% if page.image %}<meta name="twitter:image" content="{{ _abs_image }}">{% endif %}
     {% if page.robots %}<meta name="robots" content="{{ page.robots }}">{% endif %}
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ lang_prefix }}/feed.xml">
     <link rel="alternate" type="text/plain" title="LLM Summary" href="{{ lang_prefix }}/llms.txt">
@@ -32,6 +35,9 @@
     {% else %}{"@context":"https://schema.org","@type":"WebSite","name":{{ site.title | json_encode() }},"description":{{ site.description | json_encode() }},"url":{{ site.base_url | json_encode() }}}
     {% endif %}
     </script>
+    {% if page.collection %}{% set _bc_col_url = site.base_url ~ lang_prefix ~ "/" ~ page.collection %}<script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
+    </script>{% endif %}
     <style>
         *, *::before, *::after { box-sizing: border-box; }
         body { max-width: 760px; margin: 0 auto; padding: 1.5rem 1.25rem; font-family: ui-monospace, 'SFMono-Regular', 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace; font-size: 0.9rem; line-height: 1.7; color: #b0b0b0; background: #0c0c0c; }

--- a/src/themes/terminal.tera
+++ b/src/themes/terminal.tera
@@ -39,241 +39,797 @@
     {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":{{ site.title | json_encode() }},"item":{{ site.base_url | json_encode() }}},{"@type":"ListItem","position":2,"name":{{ page.collection | title | json_encode() }},"item":{{ _bc_col_url | json_encode() }}},{"@type":"ListItem","position":3,"name":{{ _ld_title | json_encode() }}}]}
     </script>{% endif %}
     <style>
+        /* === CRT TERMINAL THEME === */
+        /* A phosphor-green CRT monitor brought to life */
+
         *, *::before, *::after { box-sizing: border-box; }
-        body { max-width: 760px; margin: 0 auto; padding: 1.5rem 1.25rem; font-family: ui-monospace, 'SFMono-Regular', 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace; font-size: 0.9rem; line-height: 1.7; color: #b0b0b0; background: #0c0c0c; }
-        ::selection { background: #33ff00; color: #0c0c0c; }
-        a { color: #33ff00; text-decoration: none; }
-        a:hover { text-decoration: underline; }
 
-        /* Prompt-style header */
-        header { margin-bottom: 2rem; border: 1px solid #2a2a2a; padding: 1.25rem; background: #111; }
-        header h1 { margin: 0 0 0.25rem; font-size: 1rem; font-weight: 400; }
-        header h1 a { color: #33ff00; text-decoration: none; }
-        header h1::before { content: '~ $ '; color: #555; }
-        header p { margin: 0 0 0.75rem; color: #666; font-size: 0.85rem; }
-        header p::before { content: '# '; color: #444; }
+        /* Core palette */
+        :root {
+            --bg: #0a0a0a;
+            --bg-panel: #0e1209;
+            --bg-elevated: #111a0e;
+            --phosphor: #20c20e;
+            --phosphor-dim: #178a12;
+            --phosphor-bright: #33ff00;
+            --amber: #ffb000;
+            --cyan: #00bfff;
+            --red: #ff3333;
+            --purple: #c084fc;
+            --text: #88b884;
+            --text-dim: #4a6e47;
+            --border: #1a2e17;
+            --border-bright: #20c20e;
+            --glow-sm: 0 0 8px rgba(32,194,14,0.6);
+            --glow-md: 0 0 10px rgba(32,194,14,0.8), 0 0 20px rgba(32,194,14,0.4), 0 0 40px rgba(32,194,14,0.2);
+            --glow-lg: 0 0 15px rgba(32,194,14,0.15), inset 0 0 30px rgba(0,0,0,0.5);
+            --font-mono: ui-monospace, 'SFMono-Regular', 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+        }
+
+        ::selection { background: #20c20e; color: #0a0a0a; }
+
+        body {
+            max-width: 760px;
+            margin: 0 auto;
+            padding: 2rem 1.25rem;
+            font-family: var(--font-mono);
+            font-size: 0.9rem;
+            line-height: 1.7;
+            color: var(--text);
+            background: var(--bg);
+        }
+
+        /* CRT scanlines overlay */
+        body::after {
+            content: '';
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: repeating-linear-gradient(
+                0deg,
+                transparent,
+                transparent 2px,
+                rgba(0,0,0,0.1) 2px,
+                rgba(0,0,0,0.1) 4px
+            );
+            pointer-events: none;
+            z-index: 9999;
+        }
+
+        /* CRT vignette — darker edges like a real curved screen */
+        body::before {
+            content: '';
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: radial-gradient(
+                ellipse at center,
+                transparent 60%,
+                rgba(0,0,0,0.4) 100%
+            );
+            pointer-events: none;
+            z-index: 9998;
+        }
+
+        a { color: var(--cyan); text-decoration: none; }
+        a:hover { text-decoration: underline; text-shadow: 0 0 6px rgba(0,191,255,0.5); }
+
+        /* ==============================
+           HEADER — Terminal window chrome
+           ============================== */
+        header {
+            margin-bottom: 2rem;
+            border: 1px solid var(--phosphor);
+            padding: 1.25rem;
+            background: var(--bg-panel);
+            box-shadow: var(--glow-lg);
+            position: relative;
+        }
+
+        /* Fake window title bar dots */
+        header::before {
+            content: '\25CF  \25CF  \25CF';
+            display: block;
+            font-size: 0.55rem;
+            color: var(--phosphor-dim);
+            margin-bottom: 0.75rem;
+            letter-spacing: 0.15em;
+            opacity: 0.6;
+        }
+
+        header h1 {
+            margin: 0 0 0.25rem;
+            font-size: 1rem;
+            font-weight: 400;
+        }
+        header h1::before { content: '> '; color: var(--phosphor-dim); }
+        header h1 a {
+            color: var(--phosphor);
+            text-decoration: none;
+            text-shadow: var(--glow-md);
+        }
+
+        /* Blinking block cursor after title */
+        @keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+        header h1 a::after {
+            content: '\2588';
+            animation: blink 1s step-end infinite;
+            color: var(--phosphor);
+            margin-left: 2px;
+        }
+
+        header p {
+            margin: 0 0 0.75rem;
+            color: var(--text-dim);
+            font-size: 0.85rem;
+        }
+        header p::before { content: '# '; color: var(--phosphor-dim); opacity: 0.5; }
+
         nav.site-nav { margin-bottom: 0.75rem; }
-        nav.site-nav a { color: #33ff00; margin-right: 1.5rem; font-size: 0.85rem; }
-        nav.site-nav a::before { content: './'; color: #555; }
-        nav.site-nav a:hover { text-decoration: underline; }
+        nav.site-nav a {
+            color: var(--phosphor);
+            margin-right: 1.5rem;
+            font-size: 0.85rem;
+        }
+        nav.site-nav a::before { content: '$ '; color: var(--phosphor-dim); }
+        nav.site-nav a:hover { text-decoration: underline; text-shadow: var(--glow-sm); }
+
         .lang-switcher { display: inline-flex; gap: 0.5rem; font-size: 0.8rem; }
-        .lang-switcher a { color: #666; padding: 0.1rem 0.3rem; border: 1px solid #333; }
-        .lang-switcher a:hover { border-color: #33ff00; color: #33ff00; }
-        .lang-switcher strong { color: #33ff00; padding: 0.1rem 0.3rem; border: 1px solid #33ff00; }
+        .lang-switcher a {
+            color: var(--text-dim);
+            padding: 0.1rem 0.3rem;
+            border: 1px solid var(--border);
+        }
+        .lang-switcher a:hover { border-color: var(--phosphor); color: var(--phosphor); }
+        .lang-switcher strong {
+            color: var(--phosphor);
+            padding: 0.1rem 0.3rem;
+            border: 1px solid var(--phosphor);
+            text-shadow: var(--glow-sm);
+        }
+
+        /* Search */
         .search-form { margin-top: 0.75rem; }
-        .search-form input { width: 100%; padding: 0.4rem 0.6rem; border: 1px solid #2a2a2a; background: #0c0c0c; color: #33ff00; font-family: inherit; font-size: 0.85rem; }
-        .search-form input::placeholder { color: #444; }
-        .search-form input:focus { outline: none; border-color: #33ff00; box-shadow: 0 0 0 1px #33ff00; }
-        #search-results { border: 1px solid #2a2a2a; background: #111; }
-        #search-results a { display: block; padding: 0.4rem 0.6rem; color: #33ff00; border-bottom: 1px solid #1a1a1a; font-size: 0.85rem; }
+        .search-form input {
+            width: 100%;
+            padding: 0.4rem 0.6rem;
+            border: 1px solid var(--border);
+            background: var(--bg);
+            color: var(--phosphor);
+            font-family: var(--font-mono);
+            font-size: 0.85rem;
+        }
+        .search-form input::placeholder { color: var(--text-dim); }
+        .search-form input:focus {
+            outline: none;
+            border-color: var(--phosphor);
+            box-shadow: 0 0 8px rgba(32,194,14,0.3), 0 0 2px rgba(32,194,14,0.6);
+        }
+        #search-results { border: 1px solid var(--border); background: var(--bg-panel); }
+        #search-results a {
+            display: block;
+            padding: 0.4rem 0.6rem;
+            color: var(--cyan);
+            border-bottom: 1px solid var(--border);
+            font-size: 0.85rem;
+        }
         #search-results a:last-child { border-bottom: none; }
-        #search-results a:hover { background: #1a1a1a; }
-        #search-results a::before { content: '> '; color: #555; }
-        #search-results strong { color: #e0e0e0; }
-        #search-results .result-meta { font-size: 0.75rem; color: #555; margin-top: 0.1rem; }
-        #search-results .no-results { padding: 0.4rem 0.6rem; color: #555; font-size: 0.85rem; }
+        #search-results a:hover { background: var(--bg-elevated); }
+        #search-results a::before { content: '> '; color: var(--phosphor-dim); }
+        #search-results strong { color: var(--phosphor-bright); }
+        #search-results .result-meta { font-size: 0.75rem; color: var(--text-dim); margin-top: 0.1rem; }
+        #search-results .no-results { padding: 0.4rem 0.6rem; color: var(--text-dim); font-size: 0.85rem; }
 
-        /* Content */
-        article { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px dashed #2a2a2a; }
+        /* ==============================
+           CONTENT
+           ============================== */
+        article { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px dashed var(--border); }
         article:last-child { border-bottom: none; }
-        article h1 { font-size: 1.2rem; font-weight: 700; color: #e0e0e0; margin: 0 0 0.25rem; }
-        article h2 { font-size: 1rem; font-weight: 700; color: #e0e0e0; margin-top: 2rem; border-bottom: 1px dashed #2a2a2a; padding-bottom: 0.25rem; }
-        article h3 { font-size: 0.9rem; font-weight: 700; color: #c0c0c0; margin: 0 0 0.25rem; }
-        article h3 a { color: #33ff00; }
-        article h3 a:hover { text-decoration: underline; }
-        article h3::before { content: '## '; color: #555; }
-        article p { color: #b0b0b0; }
-        time { font-size: 0.8rem; color: #555; }
-        time::before { content: '['; }
-        time::after { content: ']'; }
-        .reading-time { color: #555; font-size: 0.8rem; }
-        .tags a, .tags span { color: #0af; font-size: 0.8rem; margin-right: 0.5rem; text-decoration: none; }
-        .tags a::before, .tags span::before { content: '#'; }
-        .tags a:hover { text-decoration: underline; }
 
-        /* Code — already monospace, so just adjust colors */
-        pre { background: #111; color: #cdd6f4; padding: 1rem; border: 1px solid #2a2a2a; overflow-x: auto; }
-        pre code { background: none; color: inherit; font-size: 0.85rem; padding: 0; }
-        code { font-size: 0.85rem; background: #1a1a1a; color: #33ff00; padding: 0.1em 0.3em; border: 1px solid #2a2a2a; }
-        blockquote { border-left: 2px solid #33ff00; margin-left: 0; padding-left: 1rem; color: #888; }
-        blockquote::before { content: ''; }
-        img { max-width: 100%; height: auto; border: 1px solid #2a2a2a; }
+        article h1 {
+            font-size: 1.2rem;
+            font-weight: 700;
+            color: var(--phosphor);
+            margin: 0 0 0.25rem;
+            text-shadow: var(--glow-md);
+        }
+        article h2 {
+            font-size: 1rem;
+            font-weight: 700;
+            color: var(--phosphor);
+            margin-top: 2rem;
+            border-bottom: 1px dashed var(--border);
+            padding-bottom: 0.25rem;
+            text-shadow: var(--glow-sm);
+        }
+        article h3 {
+            font-size: 0.9rem;
+            font-weight: 700;
+            color: var(--phosphor);
+            margin: 0 0 0.25rem;
+            text-shadow: 0 0 5px rgba(32,194,14,0.4);
+        }
+        article h3 a { color: var(--cyan); }
+        article h3 a:hover { text-decoration: underline; }
+        article h3::before { content: '## '; color: var(--phosphor-dim); }
+        article h4 { font-size: 0.9rem; color: var(--phosphor); text-shadow: 0 0 4px rgba(32,194,14,0.3); }
+        article p { color: var(--text); }
+
+        time { font-size: 0.8rem; color: var(--text-dim); }
+        time::before { content: '['; color: var(--phosphor-dim); }
+        time::after { content: ']'; color: var(--phosphor-dim); }
+        .reading-time { color: var(--text-dim); font-size: 0.8rem; }
+
+        .tags a, .tags span {
+            color: var(--cyan);
+            font-size: 0.8rem;
+            margin-right: 0.5rem;
+            text-decoration: none;
+        }
+        .tags a::before, .tags span::before { content: '#'; }
+        .tags a:hover { text-decoration: underline; text-shadow: 0 0 6px rgba(0,191,255,0.4); }
+
+        /* ==============================
+           CODE BLOCKS
+           ============================== */
+        pre {
+            background: #0d120a;
+            color: #cdd6f4;
+            padding: 1rem;
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--phosphor-dim);
+            overflow-x: auto;
+            box-shadow: inset 0 0 20px rgba(0,0,0,0.3);
+            position: relative;
+        }
+        pre::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 1px;
+            background: linear-gradient(90deg, transparent, rgba(32,194,14,0.3), transparent);
+        }
+        pre code { background: none; color: inherit; font-size: 0.85rem; padding: 0; border: none; }
+        code {
+            font-size: 0.85rem;
+            background: var(--bg-elevated);
+            color: var(--phosphor-bright);
+            padding: 0.1em 0.3em;
+            border: 1px solid var(--border);
+        }
+
+        /* Copy button for code blocks (injected by build) */
+        .code-block-wrapper { position: relative; }
+        .code-block-wrapper .copy-btn {
+            position: absolute;
+            top: 0.4rem;
+            right: 0.4rem;
+            background: var(--bg);
+            color: var(--phosphor-dim);
+            border: 1px solid var(--border);
+            padding: 0.2rem 0.5rem;
+            font-family: var(--font-mono);
+            font-size: 0.7rem;
+            cursor: pointer;
+        }
+        .code-block-wrapper .copy-btn:hover { color: var(--phosphor); border-color: var(--phosphor); }
+
+        blockquote {
+            border-left: 2px solid var(--phosphor);
+            margin-left: 0;
+            padding-left: 1rem;
+            color: var(--text-dim);
+            box-shadow: -2px 0 8px rgba(32,194,14,0.1);
+        }
+
+        img { max-width: 100%; height: auto; border: 1px solid var(--border); }
         figure { margin: 1.5rem 0; }
         figure img { display: block; }
-        figcaption { font-size: 0.8rem; color: #555; margin-top: 0.3rem; }
-        figcaption::before { content: '// '; color: #444; }
-        hr { border: none; border-top: 1px dashed #2a2a2a; margin: 2rem 0; }
+        figcaption { font-size: 0.8rem; color: var(--text-dim); margin-top: 0.3rem; }
+        figcaption::before { content: '// '; color: var(--phosphor-dim); }
+        hr { border: none; border-top: 1px dashed var(--border); margin: 2rem 0; }
 
-        /* Embeds */
-        .video-embed { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin: 1.5rem 0; border: 1px solid #2a2a2a; }
+        ul { list-style-type: none; padding-left: 1.5rem; }
+        ul > li::before { content: '- '; color: var(--phosphor-dim); margin-left: -1rem; }
+        ol { padding-left: 1.5rem; }
+        ul.contains-task-list > li::before { content: none; }
+
+        /* ==============================
+           EMBEDS
+           ============================== */
+        .video-embed {
+            position: relative;
+            padding-bottom: 56.25%;
+            height: 0;
+            overflow: hidden;
+            margin: 1.5rem 0;
+            border: 1px solid var(--border);
+            box-shadow: 0 0 10px rgba(32,194,14,0.1);
+        }
         .video-embed iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
         .gist-embed { margin: 1.5rem 0; }
 
-        /* Callouts */
-        .callout { padding: 0.75rem 1rem; margin: 1.5rem 0; border: 1px solid #2a2a2a; border-left: 3px solid #33ff00; background: #111; }
-        .callout-title { font-weight: 700; margin-bottom: 0.4rem; font-size: 0.8rem; color: #33ff00; text-transform: uppercase; }
-        .callout-info { border-left-color: #0af; }
-        .callout-info .callout-title { color: #0af; }
-        .callout-warning { border-left-color: #ffb000; }
-        .callout-warning .callout-title { color: #ffb000; }
-        .callout-danger { border-left-color: #ff3333; }
-        .callout-danger .callout-title { color: #ff3333; }
-        .callout-tip { border-left-color: #33ff00; }
-        .callout-tip .callout-title { color: #33ff00; }
-        .callout-note { border-left-color: #888; }
-        .callout-note .callout-title { color: #888; }
+        /* ==============================
+           CALLOUTS
+           ============================== */
+        .callout {
+            padding: 0.75rem 1rem;
+            margin: 1.5rem 0;
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--phosphor);
+            background: var(--bg-panel);
+        }
+        .callout-title {
+            font-weight: 700;
+            margin-bottom: 0.4rem;
+            font-size: 0.8rem;
+            color: var(--phosphor);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+        .callout-info { border-left-color: var(--cyan); }
+        .callout-info .callout-title { color: var(--cyan); }
+        .callout-warning { border-left-color: var(--amber); }
+        .callout-warning .callout-title { color: var(--amber); }
+        .callout-danger { border-left-color: var(--red); }
+        .callout-danger .callout-title { color: var(--red); }
+        .callout-tip { border-left-color: var(--phosphor-bright); }
+        .callout-tip .callout-title { color: var(--phosphor-bright); }
+        .callout-note { border-left-color: var(--text-dim); }
+        .callout-note .callout-title { color: var(--text-dim); }
         .callout p:last-child { margin-bottom: 0; }
 
-        /* Contact form */
+        /* ==============================
+           CONTACT FORM
+           ============================== */
         .contact-form { max-width: 480px; }
         .contact-form-field { margin-bottom: 1rem; }
-        .contact-form-field label { display: block; font-weight: 400; margin-bottom: 0.25rem; font-size: 0.8rem; color: #33ff00; text-transform: uppercase; }
-        .contact-form-field input, .contact-form-field textarea { width: 100%; padding: 0.5rem 0.6rem; border: 1px solid #2a2a2a; background: #0c0c0c; color: #b0b0b0; font: inherit; box-sizing: border-box; }
-        .contact-form-field input:focus, .contact-form-field textarea:focus { outline: none; border-color: #33ff00; box-shadow: 0 0 0 1px #33ff00; }
-        .contact-form-submit { background: #33ff00; color: #0c0c0c; border: none; padding: 0.5rem 1.5rem; font: inherit; font-weight: 700; cursor: pointer; }
-        .contact-form-submit:hover { background: #2be600; }
+        .contact-form-field label {
+            display: block;
+            font-weight: 400;
+            margin-bottom: 0.25rem;
+            font-size: 0.8rem;
+            color: var(--phosphor);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+        .contact-form-field input, .contact-form-field textarea {
+            width: 100%;
+            padding: 0.5rem 0.6rem;
+            border: 1px solid var(--border);
+            background: var(--bg);
+            color: var(--text);
+            font: inherit;
+            box-sizing: border-box;
+        }
+        .contact-form-field input:focus, .contact-form-field textarea:focus {
+            outline: none;
+            border-color: var(--phosphor);
+            box-shadow: 0 0 8px rgba(32,194,14,0.3), 0 0 2px rgba(32,194,14,0.6);
+        }
+        .contact-form-submit {
+            background: var(--phosphor);
+            color: var(--bg);
+            border: none;
+            padding: 0.5rem 1.5rem;
+            font: inherit;
+            font-weight: 700;
+            cursor: pointer;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+        .contact-form-submit:hover {
+            background: var(--phosphor-bright);
+            box-shadow: 0 0 12px rgba(32,194,14,0.4);
+        }
         .contact-form-honeypot { display: none; }
-        .contact-form-embed { min-height: 400px; border: 1px solid #2a2a2a; }
-        .contact-form-error { color: #ff3333; background: #1a0000; padding: 0.75rem; border: 1px solid #ff3333; }
+        .contact-form-embed { min-height: 400px; border: 1px solid var(--border); }
+        .contact-form-error {
+            color: var(--red);
+            background: #1a0800;
+            padding: 0.75rem;
+            border: 1px solid var(--red);
+        }
 
-        /* Trust center */
+        /* ==============================
+           TRUST CENTER
+           ============================== */
         .trust-hub { max-width: 760px; margin: 0 auto; }
         .trust-hero { margin-bottom: 2rem; }
-        .trust-hero h1 { font-size: 1.2rem; font-weight: 700; color: #e0e0e0; margin-bottom: 0.5rem; }
+        .trust-hero h1 {
+            font-size: 1.2rem;
+            font-weight: 700;
+            color: var(--phosphor);
+            margin-bottom: 0.5rem;
+            text-shadow: var(--glow-md);
+        }
         .trust-section { margin-bottom: 2rem; }
-        .trust-section h2 { font-size: 1rem; color: #33ff00; margin-bottom: 0.75rem; border-bottom: 1px dashed #2a2a2a; padding-bottom: 0.25rem; }
-        .trust-breadcrumb { font-size: 0.8rem; color: #555; margin-bottom: 1.5rem; }
-        .trust-breadcrumb a { color: #33ff00; text-decoration: none; }
+        .trust-section h2 {
+            font-size: 1rem;
+            color: var(--phosphor);
+            margin-bottom: 0.75rem;
+            border-bottom: 1px dashed var(--border);
+            padding-bottom: 0.25rem;
+            text-shadow: var(--glow-sm);
+        }
+        .trust-breadcrumb { font-size: 0.8rem; color: var(--text-dim); margin-bottom: 1.5rem; }
+        .trust-breadcrumb a { color: var(--cyan); text-decoration: none; }
         .trust-breadcrumb a:hover { text-decoration: underline; }
-        .trust-description { color: #888; margin-bottom: 1.5rem; line-height: 1.7; }
+        .trust-description { color: var(--text); margin-bottom: 1.5rem; line-height: 1.7; }
         .cert-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; }
-        .cert-card { border: 1px solid #2a2a2a; padding: 1rem; background: #111; }
-        .cert-card:hover { border-color: #33ff00; }
+        .cert-card {
+            border: 1px solid var(--border);
+            padding: 1rem;
+            background: var(--bg-panel);
+            transition: border-color 0.2s, box-shadow 0.2s;
+        }
+        .cert-card:hover {
+            border-color: var(--phosphor);
+            box-shadow: 0 0 10px rgba(32,194,14,0.15);
+        }
         .cert-card__header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
-        .cert-card__title { font-weight: 700; font-size: 0.9rem; color: #e0e0e0; }
-        .cert-card__desc { font-size: 0.85rem; color: #888; margin-bottom: 0.5rem; }
-        .cert-card__link { font-size: 0.8rem; color: #33ff00; text-decoration: none; }
+        .cert-card__title { font-weight: 700; font-size: 0.9rem; color: var(--phosphor); }
+        .cert-card__desc { font-size: 0.85rem; color: var(--text); margin-bottom: 0.5rem; }
+        .cert-card__link { font-size: 0.8rem; color: var(--cyan); text-decoration: none; }
         .cert-card__link:hover { text-decoration: underline; }
-        .cert-status { display: inline-block; font-size: 0.7rem; font-weight: 700; padding: 0.1rem 0.4rem; text-transform: uppercase; letter-spacing: 0.05em; border: 1px solid; }
-        .cert-status--active { border-color: #33ff00; color: #33ff00; }
-        .cert-status--in_progress { border-color: #ffb000; color: #ffb000; }
-        .cert-status--planned { border-color: #555; color: #555; }
-        .cert-detail { margin-bottom: 2rem; padding: 1rem; border: 1px solid #2a2a2a; background: #111; }
-        .cert-meta { font-size: 0.85rem; color: #888; margin-bottom: 0.25rem; }
-        .cert-meta strong { color: #e0e0e0; }
-        .trust-item { padding: 0.5rem 0; border-bottom: 1px dashed #2a2a2a; }
+        .cert-status {
+            display: inline-block;
+            font-size: 0.7rem;
+            font-weight: 700;
+            padding: 0.1rem 0.4rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            border: 1px solid;
+        }
+        .cert-status--active { border-color: var(--phosphor); color: var(--phosphor); }
+        .cert-status--in_progress { border-color: var(--amber); color: var(--amber); }
+        .cert-status--planned { border-color: var(--text-dim); color: var(--text-dim); }
+        .cert-detail {
+            margin-bottom: 2rem;
+            padding: 1rem;
+            border: 1px solid var(--border);
+            background: var(--bg-panel);
+        }
+        .cert-meta { font-size: 0.85rem; color: var(--text); margin-bottom: 0.25rem; }
+        .cert-meta strong { color: var(--phosphor); }
+        .trust-item { padding: 0.5rem 0; border-bottom: 1px dashed var(--border); }
         .trust-item:last-child { border-bottom: none; }
         .subprocessor-table-wrap { overflow-x: auto; margin: 1.5rem 0; }
         .subprocessor-table { border-collapse: collapse; width: 100%; }
-        .subprocessor-table th, .subprocessor-table td { border: 1px solid #2a2a2a; padding: 0.4rem 0.6rem; text-align: left; font-size: 0.85rem; }
-        .subprocessor-table th { background: #111; color: #33ff00; font-weight: 400; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.05em; }
+        .subprocessor-table th, .subprocessor-table td {
+            border: 1px solid var(--border);
+            padding: 0.4rem 0.6rem;
+            text-align: left;
+            font-size: 0.85rem;
+        }
+        .subprocessor-table th {
+            background: var(--bg-panel);
+            color: var(--phosphor);
+            font-weight: 400;
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+        }
+        .subprocessor-table td { color: var(--text); }
         .faq-section { margin-top: 2rem; }
-        .faq-item { border-bottom: 1px dashed #2a2a2a; }
-        .faq-item summary { padding: 0.5rem 0; cursor: pointer; color: #e0e0e0; font-size: 0.85rem; }
-        .faq-item summary:hover { color: #33ff00; }
-        .faq-answer { padding: 0 0 0.75rem; color: #888; line-height: 1.7; }
+        .faq-item { border-bottom: 1px dashed var(--border); }
+        .faq-item summary {
+            padding: 0.5rem 0;
+            cursor: pointer;
+            color: var(--phosphor);
+            font-size: 0.85rem;
+        }
+        .faq-item summary:hover { text-shadow: var(--glow-sm); }
+        .faq-answer { padding: 0 0 0.75rem; color: var(--text); line-height: 1.7; }
         .trust-page { margin-bottom: 2rem; }
 
-        /* Changelog */
+        /* ==============================
+           CHANGELOG
+           ============================== */
         .changelog-entry-header { margin-bottom: 1.5rem; }
-        .changelog-meta { display: flex; align-items: center; gap: 1rem; margin-top: 0.5rem; color: #555; font-size: 0.85rem; }
-        .changelog-summary { color: #888; font-size: 0.9rem; margin-bottom: 1.5rem; }
+        .changelog-meta {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            margin-top: 0.5rem;
+            color: var(--text-dim);
+            font-size: 0.85rem;
+        }
+        .changelog-summary { color: var(--text); font-size: 0.9rem; margin-bottom: 1.5rem; }
         .changelog-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
-        .changelog-tag { display: inline-block; padding: 0.1rem 0.5rem; font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; border: 1px solid; }
-        .changelog-tag--new { border-color: #33ff00; color: #33ff00; }
-        .changelog-tag--fix { border-color: #0af; color: #0af; }
-        .changelog-tag--breaking { border-color: #ff3333; color: #ff3333; }
-        .changelog-tag--improvement { border-color: #c084fc; color: #c084fc; }
-        .changelog-tag--deprecated { border-color: #555; color: #555; }
-        .changelog-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 1rem; margin-bottom: 2rem; }
+        .changelog-tag {
+            display: inline-block;
+            padding: 0.1rem 0.5rem;
+            font-size: 0.7rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            border: 1px solid;
+        }
+        .changelog-tag--new { border-color: var(--phosphor); color: var(--phosphor); }
+        .changelog-tag--fix { border-color: var(--cyan); color: var(--cyan); }
+        .changelog-tag--breaking { border-color: var(--red); color: var(--red); }
+        .changelog-tag--improvement { border-color: var(--purple); color: var(--purple); }
+        .changelog-tag--deprecated { border-color: var(--text-dim); color: var(--text-dim); }
+        .changelog-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            flex-wrap: wrap;
+            gap: 1rem;
+            margin-bottom: 2rem;
+        }
         .changelog-header h1 { margin-bottom: 0; }
-        .changelog-rss { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.75rem; color: #555; text-decoration: none; padding: 0.2rem 0.5rem; border: 1px solid #2a2a2a; }
-        .changelog-rss:hover { color: #33ff00; border-color: #33ff00; }
+        .changelog-rss {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            font-size: 0.75rem;
+            color: var(--text-dim);
+            text-decoration: none;
+            padding: 0.2rem 0.5rem;
+            border: 1px solid var(--border);
+        }
+        .changelog-rss:hover { color: var(--phosphor); border-color: var(--phosphor); }
         .changelog-back { margin-bottom: 1.5rem; }
-        .changelog-back a { color: #555; text-decoration: none; font-size: 0.85rem; }
-        .changelog-back a:hover { color: #33ff00; }
+        .changelog-back a { color: var(--text-dim); text-decoration: none; font-size: 0.85rem; }
+        .changelog-back a:hover { color: var(--phosphor); }
         .changelog-timeline { position: relative; padding-left: 1.5rem; }
-        .changelog-timeline::before { content: ''; position: absolute; left: 0; top: 0.5rem; bottom: 0; width: 1px; background: #2a2a2a; }
-        .changelog-item { position: relative; padding-bottom: 1.5rem; border-bottom: 1px dashed #2a2a2a; margin-bottom: 0; }
-        .changelog-item::before { content: '*'; position: absolute; left: -1.5rem; top: 0.1rem; color: #33ff00; font-weight: 700; transform: translateX(-2px); }
+        .changelog-timeline::before {
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 0.5rem;
+            bottom: 0;
+            width: 1px;
+            background: var(--border);
+        }
+        .changelog-item {
+            position: relative;
+            padding-bottom: 1.5rem;
+            border-bottom: 1px dashed var(--border);
+            margin-bottom: 0;
+        }
+        .changelog-item::before {
+            content: '\25B6';
+            position: absolute;
+            left: -1.5rem;
+            top: 0.1rem;
+            color: var(--phosphor);
+            font-size: 0.5rem;
+            font-weight: 700;
+            transform: translateX(-3px);
+            text-shadow: 0 0 6px rgba(32,194,14,0.6);
+        }
         .changelog-item:last-child { border-bottom: none; }
-        .changelog-item-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 0.5rem; }
-        .changelog-item-header h2 { margin: 0; font-size: 1rem; color: #e0e0e0; }
-        .changelog-item-header time { color: #555; font-size: 0.8rem; white-space: nowrap; }
+        .changelog-item-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+        .changelog-item-header h2 { margin: 0; font-size: 1rem; color: var(--phosphor); }
+        .changelog-item-header time { color: var(--text-dim); font-size: 0.8rem; white-space: nowrap; }
         .changelog-item .changelog-tags { margin-top: 0.5rem; }
-        .changelog-item p, .changelog-item .excerpt { margin-top: 0.5rem; color: #888; }
+        .changelog-item p, .changelog-item .excerpt { margin-top: 0.5rem; color: var(--text); }
         .changelog-feed .changelog-item::before { display: none; }
         .changelog-feed { display: flex; flex-direction: column; gap: 0; }
 
-        /* Roadmap */
+        /* ==============================
+           ROADMAP
+           ============================== */
         .roadmap-back { margin-bottom: 1.5rem; }
-        .roadmap-back a { color: #555; text-decoration: none; font-size: 0.85rem; }
-        .roadmap-back a:hover { color: #33ff00; }
+        .roadmap-back a { color: var(--text-dim); text-decoration: none; font-size: 0.85rem; }
+        .roadmap-back a:hover { color: var(--phosphor); }
         .roadmap-entry-header { margin-bottom: 1.5rem; }
-        .roadmap-summary { color: #888; font-size: 0.9rem; margin-bottom: 1.5rem; }
+        .roadmap-summary { color: var(--text); font-size: 0.9rem; margin-bottom: 1.5rem; }
         .roadmap-status-badges { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
-        .roadmap-status { display: inline-block; padding: 0.1rem 0.5rem; font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; border: 1px solid; }
-        .roadmap-status--planned { border-color: #0af; color: #0af; }
-        .roadmap-status--in-progress { border-color: #ffb000; color: #ffb000; }
-        .roadmap-status--done { border-color: #33ff00; color: #33ff00; }
-        .roadmap-status--cancelled { border-color: #555; color: #555; text-decoration: line-through; }
+        .roadmap-status {
+            display: inline-block;
+            padding: 0.1rem 0.5rem;
+            font-size: 0.7rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            border: 1px solid;
+        }
+        .roadmap-status--planned { border-color: var(--cyan); color: var(--cyan); }
+        .roadmap-status--in-progress { border-color: var(--amber); color: var(--amber); }
+        .roadmap-status--done { border-color: var(--phosphor); color: var(--phosphor); }
+        .roadmap-status--cancelled { border-color: var(--text-dim); color: var(--text-dim); text-decoration: line-through; }
         .roadmap-grouped { display: flex; flex-direction: column; gap: 2rem; }
-        .roadmap-section-header { display: flex; align-items: center; gap: 0.75rem; font-size: 0.9rem; margin-bottom: 0.75rem; color: #e0e0e0; }
+        .roadmap-section-header {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            font-size: 0.9rem;
+            margin-bottom: 0.75rem;
+            color: var(--phosphor);
+        }
         .roadmap-items { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1rem; }
-        .roadmap-card { padding: 0.75rem 1rem; border: 1px solid #2a2a2a; background: #111; }
-        .roadmap-card:hover { border-color: #33ff00; }
-        .roadmap-card h3 { margin: 0 0 0.25rem; font-size: 0.9rem; color: #e0e0e0; }
-        .roadmap-card p, .roadmap-card .excerpt { margin: 0; color: #888; font-size: 0.85rem; }
+        .roadmap-card {
+            padding: 0.75rem 1rem;
+            border: 1px solid var(--border);
+            background: var(--bg-panel);
+            transition: border-color 0.2s, box-shadow 0.2s;
+        }
+        .roadmap-card:hover {
+            border-color: var(--phosphor);
+            box-shadow: 0 0 8px rgba(32,194,14,0.1);
+        }
+        .roadmap-card h3 { margin: 0 0 0.25rem; font-size: 0.9rem; color: var(--phosphor); }
+        .roadmap-card h3::before { content: none; }
+        .roadmap-card p, .roadmap-card .excerpt { margin: 0; color: var(--text); font-size: 0.85rem; }
         .roadmap-kanban { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
-        .roadmap-column-header { font-size: 0.85rem; margin-bottom: 0.75rem; display: flex; align-items: center; gap: 0.5rem; color: #e0e0e0; }
-        .roadmap-count { font-size: 0.75rem; color: #555; font-weight: 400; }
+        .roadmap-column-header {
+            font-size: 0.85rem;
+            margin-bottom: 0.75rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            color: var(--phosphor);
+        }
+        .roadmap-count { font-size: 0.75rem; color: var(--text-dim); font-weight: 400; }
         .roadmap-timeline { position: relative; padding-left: 1.5rem; }
-        .roadmap-timeline::before { content: ''; position: absolute; left: 0.4rem; top: 0; bottom: 0; width: 1px; background: #2a2a2a; }
+        .roadmap-timeline::before {
+            content: '';
+            position: absolute;
+            left: 0.4rem;
+            top: 0;
+            bottom: 0;
+            width: 1px;
+            background: var(--border);
+        }
         .roadmap-milestone { position: relative; margin-bottom: 1.5rem; }
-        .roadmap-milestone-dot { position: absolute; left: -1.35rem; top: 0.3rem; width: 10px; height: 10px; border: 1px solid #33ff00; background: #0c0c0c; }
+        .roadmap-milestone-dot {
+            position: absolute;
+            left: -1.35rem;
+            top: 0.3rem;
+            width: 10px;
+            height: 10px;
+            border: 1px solid var(--phosphor);
+            background: var(--bg);
+            box-shadow: 0 0 6px rgba(32,194,14,0.3);
+        }
         .roadmap-milestone-dot .roadmap-status { display: none; }
-        .roadmap-milestone-content h3 { margin: 0 0 0.25rem; font-size: 0.9rem; color: #e0e0e0; }
-        .roadmap-milestone-content p { margin: 0.25rem 0 0; color: #888; font-size: 0.85rem; }
+        .roadmap-milestone-content h3 { margin: 0 0 0.25rem; font-size: 0.9rem; color: var(--phosphor); }
+        .roadmap-milestone-content h3::before { content: none; }
+        .roadmap-milestone-content p { margin: 0.25rem 0 0; color: var(--text); font-size: 0.85rem; }
         @media (max-width: 768px) { .roadmap-kanban { grid-template-columns: 1fr; } }
 
-        /* Tables */
+        /* ==============================
+           TABLES
+           ============================== */
         table { border-collapse: collapse; width: 100%; margin: 1.5rem 0; }
-        th, td { border: 1px solid #2a2a2a; padding: 0.4rem 0.6rem; text-align: left; font-size: 0.85rem; }
-        th { background: #111; color: #33ff00; font-weight: 400; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.05em; }
-        ul.contains-task-list, ol.contains-task-list { list-style: none; padding-left: 0; }
-        li.task-list-item { display: flex; align-items: baseline; gap: 0.5rem; }
-        li.task-list-item input[type="checkbox"] { margin: 0; pointer-events: none; }
-        .footnote-definition { font-size: 0.8rem; color: #888; border-top: 1px dashed #2a2a2a; margin-top: 2rem; padding-top: 0.75rem; }
-        .footnote-definition p { display: inline; }
-        sup.footnote-reference a { text-decoration: none; color: #33ff00; font-weight: 700; }
+        th, td {
+            border: 1px solid var(--border);
+            padding: 0.4rem 0.6rem;
+            text-align: left;
+            font-size: 0.85rem;
+        }
+        th {
+            background: var(--bg-panel);
+            color: var(--phosphor);
+            font-weight: 400;
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+        }
+        td { color: var(--text); }
 
-        /* TOC & Pagination */
-        .toc { margin: 1.5rem 0; padding: 0.75rem 1rem; border: 1px solid #2a2a2a; background: #111; }
+        /* Task lists */
+        ul.contains-task-list, ol.contains-task-list { list-style: none; padding-left: 0; }
+        ul.contains-task-list > li::before { content: none; }
+        li.task-list-item { display: flex; align-items: baseline; gap: 0.5rem; }
+        li.task-list-item input[type="checkbox"] { margin: 0; pointer-events: none; accent-color: var(--phosphor); }
+
+        /* Footnotes */
+        .footnote-definition {
+            font-size: 0.8rem;
+            color: var(--text);
+            border-top: 1px dashed var(--border);
+            margin-top: 2rem;
+            padding-top: 0.75rem;
+        }
+        .footnote-definition p { display: inline; }
+        sup.footnote-reference a { text-decoration: none; color: var(--phosphor); font-weight: 700; }
+
+        /* ==============================
+           TOC & PAGINATION
+           ============================== */
+        .toc {
+            margin: 1.5rem 0;
+            padding: 0.75rem 1rem;
+            border: 1px solid var(--border);
+            background: var(--bg-panel);
+        }
+        .toc::before {
+            content: '/* TABLE OF CONTENTS */';
+            display: block;
+            font-size: 0.7rem;
+            color: var(--phosphor-dim);
+            margin-bottom: 0.5rem;
+            letter-spacing: 0.1em;
+        }
         .toc > ul { margin: 0; padding-left: 1.25rem; }
         .toc ul ul { padding-left: 1rem; }
         .toc li { margin: 0.2rem 0; }
-        .toc a { text-decoration: none; color: #33ff00; }
+        .toc li::before { content: none; }
+        .toc a { text-decoration: none; color: var(--cyan); }
         .toc a:hover { text-decoration: underline; }
-        .pagination { display: flex; justify-content: space-between; align-items: center; margin-top: 2rem; padding-top: 0.75rem; border-top: 1px dashed #2a2a2a; }
-        .pagination a { text-decoration: none; color: #33ff00; }
+
+        .pagination {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-top: 2rem;
+            padding-top: 0.75rem;
+            border-top: 1px dashed var(--border);
+        }
+        .pagination a { text-decoration: none; color: var(--cyan); }
+        .pagination a::before { content: '[ '; color: var(--phosphor-dim); }
+        .pagination a::after { content: ' ]'; color: var(--phosphor-dim); }
         .pagination a:hover { text-decoration: underline; }
-        .pagination span { color: #555; font-size: 0.85rem; }
+        .pagination span { color: var(--text-dim); font-size: 0.85rem; }
 
-        /* Footer */
-        footer { margin-top: 3rem; padding-top: 0.75rem; border-top: 1px solid #2a2a2a; color: #555; font-size: 0.8rem; }
+        /* ==============================
+           TAG INDEX
+           ============================== */
+        .tag-list a { color: var(--cyan); }
+        .tag-list a::before { content: '#'; }
+
+        /* ==============================
+           FOOTER
+           ============================== */
+        footer {
+            margin-top: 3rem;
+            padding-top: 0.75rem;
+            border-top: 1px solid var(--border);
+            color: var(--text-dim);
+            font-size: 0.8rem;
+        }
         footer nav { margin-bottom: 0.5rem; }
-        footer nav a { color: #888; text-decoration: none; }
-        footer nav a:hover { color: #33ff00; }
+        footer nav a { color: var(--text); text-decoration: none; }
+        footer nav a:hover { color: var(--phosphor); text-shadow: var(--glow-sm); }
 
-        /* Accessibility */
-        .skip-link { position: absolute; top: -100%; left: 0; padding: 0.4rem 0.75rem; background: #33ff00; color: #0c0c0c; z-index: 100; text-decoration: none; font-weight: 700; }
+        /* ==============================
+           ACCESSIBILITY
+           ============================== */
+        .skip-link {
+            position: absolute;
+            top: -100%;
+            left: 0;
+            padding: 0.4rem 0.75rem;
+            background: var(--phosphor);
+            color: var(--bg);
+            z-index: 10000;
+            text-decoration: none;
+            font-weight: 700;
+        }
         .skip-link:focus { top: 0; }
-        :focus-visible { outline: 1px solid #33ff00; outline-offset: 2px; }
-        @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; } }
+        :focus-visible {
+            outline: 1px solid var(--phosphor);
+            outline-offset: 2px;
+        }
 
-        /* Blinking cursor on title */
-        @keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
-        header h1 a::after { content: '_'; animation: blink 1s step-end infinite; color: #33ff00; }
+        /* Reduced motion: disable scanlines, vignette, blink, and all glow transitions */
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                animation-duration: 0.01ms !important;
+                animation-iteration-count: 1 !important;
+                transition-duration: 0.01ms !important;
+                scroll-behavior: auto !important;
+            }
+            body::after { display: none !important; }
+            body::before { display: none !important; }
+        }
     </style>
     {% block extra_css %}{% endblock %}
     {% block head %}{% endblock %}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7042,7 +7042,18 @@ fn test_deploy_dry_run_preview() {
 #[test]
 fn test_theme_apply_all_bundled() {
     // Verify every bundled theme can be applied
-    let themes = ["default", "minimal", "dark", "docs", "brutalist", "bento"];
+    let themes = [
+        "default",
+        "minimal",
+        "dark",
+        "docs",
+        "brutalist",
+        "bento",
+        "landing",
+        "terminal",
+        "magazine",
+        "academic",
+    ];
     for theme_name in &themes {
         let tmp = TempDir::new().unwrap();
         init_site(&tmp, "thm", "Theme Test", "posts");
@@ -7780,7 +7791,7 @@ fn test_contact_setup_no_contact_page_without_pages_collection() {
 // ═══════════════════════════════════════════════════════════════════════════
 
 #[test]
-fn test_theme_list_shows_all_six_bundled() {
+fn test_theme_list_shows_all_bundled() {
     page_cmd()
         .args(["theme", "list"])
         .assert()
@@ -7791,7 +7802,11 @@ fn test_theme_list_shows_all_six_bundled() {
         .stdout(predicate::str::contains("dark"))
         .stdout(predicate::str::contains("docs"))
         .stdout(predicate::str::contains("brutalist"))
-        .stdout(predicate::str::contains("bento"));
+        .stdout(predicate::str::contains("bento"))
+        .stdout(predicate::str::contains("landing"))
+        .stdout(predicate::str::contains("terminal"))
+        .stdout(predicate::str::contains("magazine"))
+        .stdout(predicate::str::contains("academic"));
 }
 
 #[test]
@@ -8059,7 +8074,18 @@ fn test_theme_export_duplicate_name_fails() {
 #[test]
 fn test_theme_apply_then_build_with_all_themes() {
     // Test that every bundled theme produces a valid build
-    let themes = ["default", "minimal", "dark", "docs", "brutalist", "bento"];
+    let themes = [
+        "default",
+        "minimal",
+        "dark",
+        "docs",
+        "brutalist",
+        "bento",
+        "landing",
+        "terminal",
+        "magazine",
+        "academic",
+    ];
     for theme_name in &themes {
         let tmp = TempDir::new().unwrap();
         init_site(&tmp, "thall", "All Themes Build", "posts,docs,pages");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -461,7 +461,7 @@ fn test_build_homepage_without_index_page() {
     // Collection listing should work as before
     assert!(index.contains("Hello World"));
     // No homepage-content div since there's no index.md
-    assert!(!index.contains("homepage-content"));
+    assert!(!index.contains("class=\"homepage-content\""));
 }
 
 // --- multi-language (i18n) ---


### PR DESCRIPTION
## Summary

- **Add 4 new bundled themes**: landing, terminal, magazine, academic — each with distinctive visual identities, custom HTML templates, and complete SEO/GEO head blocks
- **2026 design refresh for all 10 themes**: Google Fonts, `.homepage-content` CSS for rich landing pages, safe DOM search JS (replaces innerHTML with createElement/textContent/appendChild)
- **SEO/GEO improvements**: fix image LCP optimization (skip `loading="lazy"` on first image per page), improved AI crawler management in robots.txt

### New themes
| Theme | Font | Style |
|-------|------|-------|
| Landing | Fraunces / Outfit | Light SaaS landing with hero, feature cards, stats grid, testimonials |
| Terminal | IBM Plex Mono | Dark terminal aesthetic with green accent, scanlines, monospace |
| Magazine | Playfair Display / Source Serif 4 / DM Sans | 3-column newspaper grid, editorial masthead, diamond dividers |
| Academic | EB Garamond | Tufte-inspired scholarly layout, narrow column, small-caps headings |

### Existing theme upgrades
| Theme | Font Added | Homepage Style |
|-------|-----------|---------------|
| Default | Outfit | 2-column grid, blue accent cards |
| Minimal | Lora | Literary stacked list, understated |
| Dark | Sora | Dark cards (#111), violet accent |
| Docs | IBM Plex Sans/Mono | Clean functional, blue links |
| Brutalist | Archivo + DM Mono | Bold 900-weight headings, yellow accent |
| Bento | Manrope | 4-column grid, rounded card corners |

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy` zero warnings
- [x] 1004 unit + 308 integration tests pass (1 pre-existing failure in `test_self_update_check` unrelated to this PR)
- [x] All 10 themes build successfully in workspace
- [x] Visual verification via Playwright screenshots at 1280px and 1440px viewports
- [x] Fix `test_build_homepage_without_index_page` to check for div element instead of CSS class string

🤖 Generated with [Claude Code](https://claude.com/claude-code)