### PR TITLE
Add collection index pages for landing pages and subdomain roots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ scripts/
 2.5. Load data files (YAML/JSON/TOML from `data/` directory → `{{ data.filename }}` in templates)
 3. Process each collection: walk content dir, parse frontmatter, **expand shortcodes**, render markdown to HTML, detect language from filename, resolve slugs/URLs, compute word count/reading time/excerpt/ToC, build translation map, sort
 3b. Inject i18n context — compute `lang_prefix` (empty for default language, `"/{lang}"` for others), `default_language`, and `t` (UI strings merged from defaults + `data/i18n/{lang}.yaml`) into every template context
-4. Render index page(s) — per-language if multilingual, with optional homepage content from `content/pages/index.md`. Also renders: paginated collection indexes, 404 page, tag index + per-tag archive pages
+4. Render index page(s) — per-language if multilingual, with optional homepage content from `content/pages/index.md` or collection `index.md` for subdomain roots. Also renders: paginated collection indexes (with optional collection `index.md` content on page 1), non-paginated collection indexes (with optional collection `index.md` content), 404 page, tag index + per-tag archive pages
 5. Generate RSS feed(s) — default language at `/feed.xml`, per-language at `/{lang}/feed.xml`
 6. Generate sitemap — all items, with `xhtml:link` alternates for translations
 7. Generate discovery files — per-language `llms.txt` and `llms-full.txt`
@@ -747,6 +747,16 @@ Filename-based translation system. Fully backward compatible — single-language
 
 If `content/pages/index.md` exists, its rendered content is injected into the index template context as `{{ page.content }}`. This allows custom hero/landing content on the homepage while still listing collections below it. The homepage page is extracted from the pages collection before rendering, so it doesn't collide with `dist/index.html`. Translations of the homepage (`index.es.md`) work as expected.
 
+### Collection Index Pages
+
+Any collection can have a custom index page via `content/{collection}/index.md`. This works identically to the homepage pattern: the `index.md` content is extracted from the collection (so it doesn't appear as a regular item) and injected into the collection's index template context as `{{ page.content }}`.
+
+This powers:
+- **Collection landing pages**: `content/docs/index.md` → custom content at `/docs/`
+- **Subdomain root pages**: when a collection has `subdomain` set, its `index.md` becomes the subdomain root content (e.g., `docs.example.com/`)
+- **Paginated collections**: `index.md` content appears only on page 1
+
+All frontmatter fields from the `index.md` are available in the template context (`page.title`, `page.description`, `page.extra`, etc.).
 
 ### Theme Builder Skill (Claude Code)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ scripts/
 2.5. Load data files (YAML/JSON/TOML from `data/` directory → `{{ data.filename }}` in templates)
 3. Process each collection: walk content dir, parse frontmatter, **expand shortcodes**, render markdown to HTML, detect language from filename, resolve slugs/URLs, compute word count/reading time/excerpt/ToC, build translation map, sort
 3b. Inject i18n context — compute `lang_prefix` (empty for default language, `"/{lang}"` for others), `default_language`, and `t` (UI strings merged from defaults + `data/i18n/{lang}.yaml`) into every template context
-4. Render index page(s) — per-language if multilingual, with optional homepage content from `content/pages/index.md` or collection `index.md` for subdomain roots. Also renders: paginated collection indexes (with optional collection `index.md` content on page 1), non-paginated collection indexes (with optional collection `index.md` content), 404 page, tag index + per-tag archive pages
+4. Render index page(s) — per-language if multilingual, with optional homepage content from `content/pages/index.md` or collection `index.md` for subdomain roots (with `redirect_to` support). Also renders: paginated collection indexes (with optional collection `index.md` content on page 1 + cached nav), non-paginated collection indexes (with optional collection `index.md` content + cached nav + `redirect_to`), 404 page, tag index + per-tag archive pages. Docs collections use `docs-index.html` template with sidebar nav and auto-generated section overview.
 5. Generate RSS feed(s) — default language at `/feed.xml`, per-language at `/{lang}/feed.xml`
 6. Generate sitemap — all items, with `xhtml:link` alternates for translations
 7. Generate discovery files — per-language `llms.txt` and `llms-full.txt`
@@ -664,7 +664,7 @@ When adding a new config section, CLI command, or build behavior, ensure all of 
 - Create items: `seite new roadmap "Feature Name" --tags planned`
 
 ### Collection-Specific Index Templates
-The build pipeline checks for `{collection.name}-index.html` before falling back to `index.html`. This applies to both paginated and non-paginated collections. Changelog and roadmap ship dedicated index templates; any collection can override its index this way.
+The build pipeline checks for `{collection.name}-index.html` before falling back to `index.html`. This applies to both paginated and non-paginated collections. Changelog, roadmap, and docs ship dedicated index templates; any collection can override its index this way. The docs collection uses `docs-index.html` which includes sidebar navigation and auto-generated section overview.
 
 ### Trust Center
 
@@ -755,8 +755,15 @@ This powers:
 - **Collection landing pages**: `content/docs/index.md` → custom content at `/docs/`
 - **Subdomain root pages**: when a collection has `subdomain` set, its `index.md` becomes the subdomain root content (e.g., `docs.example.com/`)
 - **Paginated collections**: `index.md` content appears only on page 1
+- **Redirect to a specific page**: set `extra.redirect_to` in the index.md frontmatter to generate an instant redirect (e.g., `/docs/` → `/docs/getting-started`)
 
 All frontmatter fields from the `index.md` are available in the template context (`page.title`, `page.description`, `page.extra`, etc.).
+
+**Docs index template**: The docs collection ships a dedicated `docs-index.html` template that renders sidebar navigation alongside the index content. With `index.md`, it shows custom content with sidebar; without it, it auto-generates a section overview grouped by subdirectory.
+
+**Sidebar nav on collection indexes**: The `{{ nav }}` variable (pre-built for nested collections like docs) is passed to all collection index templates — both paginated and non-paginated. This is cached via `collection_nav_cache` during individual page rendering and reused in index rendering steps.
+
+**Redirect support**: Collection index pages support `extra.redirect_to` in frontmatter. When set, the build pipeline writes an instant HTML redirect (meta refresh + JavaScript) instead of rendering the template. Works for both regular collection indexes and subdomain roots.
 
 ### Theme Builder Skill (Claude Code)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/seite-sh/content/changelog/2026-02-27-v0-4-3.md
+++ b/seite-sh/content/changelog/2026-02-27-v0-4-3.md
@@ -1,7 +1,7 @@
 ---
 title: v0.4.3
-description: "Collection index pages for subdomain roots and collection landing pages"
-date: 2026-02-27
+description: "Collection index pages with sidebar nav, redirect_to, and docs-index template"
+date: 2026-02-28
 tags:
 - new
 ---
@@ -11,12 +11,22 @@ tags:
 - Added support for `content/{collection}/index.md` — any collection can now have a custom index page that injects content into the collection's index template as `{{ page.content }}`
 - Works identically to how `content/pages/index.md` provides homepage content, but for any collection
 - The `index.md` is extracted from the collection listing so it doesn't appear as a regular item
+- For paginated collections, the `index.md` content appears on page 1
+
+## Docs Index Template
+
+- New default `docs-index.html` template — docs collections now get a dedicated index page with sidebar navigation, matching individual doc pages
+- When `content/docs/index.md` exists, it renders as the landing page with full sidebar
+- When no `index.md` exists, auto-generates a section overview grouped by subdirectory
+- Sidebar nav (`{{ nav }}`) is now passed to all collection index templates (both paginated and non-paginated), not just individual pages
+
+## Redirect Support
+
+- Collection index pages now support `extra.redirect_to` in frontmatter — set a URL to redirect `/docs/` to a specific doc page (e.g., `/docs/getting-started`)
+- Works for both regular collection indexes and subdomain roots
+- Generates an instant HTML redirect (meta refresh + JavaScript)
 
 ## Subdomain Root Pages
 
 - Subdomain collections now support root pages via `content/{collection}/index.md` — e.g., `content/docs/index.md` renders at `docs.example.com/`
-- Previously, subdomain roots could only show an auto-generated collection listing with no custom content
-
-## Paginated Collections
-
-- For paginated collections, the `index.md` content appears on page 1 of the collection index
+- Subdomain roots also support `redirect_to` for routing to a specific page

--- a/seite-sh/content/changelog/2026-02-27-v0-4-3.md
+++ b/seite-sh/content/changelog/2026-02-27-v0-4-3.md
@@ -1,0 +1,22 @@
+---
+title: v0.4.3
+description: "Collection index pages for subdomain roots and collection landing pages"
+date: 2026-02-27
+tags:
+- new
+---
+
+## Collection Index Pages
+
+- Added support for `content/{collection}/index.md` — any collection can now have a custom index page that injects content into the collection's index template as `{{ page.content }}`
+- Works identically to how `content/pages/index.md` provides homepage content, but for any collection
+- The `index.md` is extracted from the collection listing so it doesn't appear as a regular item
+
+## Subdomain Root Pages
+
+- Subdomain collections now support root pages via `content/{collection}/index.md` — e.g., `content/docs/index.md` renders at `docs.example.com/`
+- Previously, subdomain roots could only show an auto-generated collection listing with no custom content
+
+## Paginated Collections
+
+- For paginated collections, the `index.md` content appears on page 1 of the collection index

--- a/seite-sh/content/docs/collections.md
+++ b/seite-sh/content/docs/collections.md
@@ -206,6 +206,16 @@ When `subdomain` is set:
 - It gets its own sitemap, RSS, robots.txt, llms.txt, and search index
 - It's excluded from the main site's build output
 
+### Subdomain Root Page
+
+To customize what appears at the subdomain root (e.g., `docs.example.com/`), create `content/{collection}/index.md`:
+
+```
+content/docs/index.md    → docs.example.com/  (subdomain root)
+```
+
+The `index.md` content is injected into the index template as `{{ page.content }}`, exactly like `content/pages/index.md` works for the main site homepage. This lets you add a custom hero, introduction, or landing page above the collection listing. Without an `index.md`, the subdomain root shows a plain collection listing.
+
 If your `base_url` contains `www` (e.g., `https://www.example.com`), the auto-derived URL would be `docs.www.example.com`. Use `subdomain_base_url` to set an explicit override:
 
 ```toml
@@ -219,6 +229,19 @@ deploy_project = "my-docs"
 The dev server previews subdomain content at `/{name}-preview/` (e.g., `localhost:3000/docs-preview/`).
 
 Deploy with `seite deploy` — subdomain collections are deployed automatically after the main site. GitHub Pages does not support per-collection subdomains; use Cloudflare Pages or Netlify.
+
+## Collection Index Pages
+
+Any collection can have a custom index page by creating `content/{collection}/index.md`. This content is injected into the collection's index template as `{{ page.content }}`:
+
+```
+content/docs/index.md        → /docs/     (collection index)
+content/changelog/index.md   → /changelog/ (collection index)
+```
+
+This works identically to how `content/pages/index.md` provides content for the site homepage. The `index.md` is extracted from the collection — it won't appear as a regular item in listings. All frontmatter fields are available in the template context (`page.title`, `page.description`, `page.extra`, etc.).
+
+For paginated collections, the `index.md` content appears only on page 1.
 
 ## Pagination
 

--- a/seite-sh/content/docs/collections.md
+++ b/seite-sh/content/docs/collections.md
@@ -243,6 +243,31 @@ This works identically to how `content/pages/index.md` provides content for the 
 
 For paginated collections, the `index.md` content appears only on page 1.
 
+### Docs Index with Sidebar
+
+The docs collection ships a dedicated `docs-index.html` template that renders the same sidebar navigation as individual doc pages. When using the docs theme:
+
+- **With `index.md`**: Shows your custom content alongside the sidebar
+- **Without `index.md`**: Auto-generates a section overview grouped by subdirectory
+
+The sidebar nav (`{{ nav }}`) is available in all collection index templates, so custom templates can also render it.
+
+### Redirect to a Specific Page
+
+Instead of showing custom content, you can redirect the collection index to an existing page using `redirect_to` in the `extra` field:
+
+```yaml
+---
+title: Docs
+extra:
+  redirect_to: /docs/getting-started
+---
+```
+
+This generates an instant redirect at `/docs/` → `/docs/getting-started`. This is the most common pattern for docs sites — route the docs landing page directly to the first doc.
+
+Redirects work for both regular collection indexes and subdomain roots.
+
 ## Pagination
 
 Enable pagination on any listed collection:

--- a/seite-sh/content/roadmap/avif-image-format.md
+++ b/seite-sh/content/roadmap/avif-image-format.md
@@ -2,8 +2,8 @@
 title: AVIF Image Format
 description: Generate AVIF variants alongside WebP in the image pipeline
 tags:
-- planned
+- done
 weight: 5
 ---
 
-Generate AVIF variants alongside WebP in the image pipeline. AVIF is smaller than WebP at comparable quality. Add to `<picture>` element sources with proper type attribute.
+AVIF image generation is now supported. Enable with `avif = true` in `[images]` config. AVIF variants are generated alongside WebP at all configured widths, with configurable quality via `avif_quality` (default 70). The post-processing step adds AVIF sources to `<picture>` elements with the correct `type="image/avif"` attribute, ordered before WebP for optimal browser selection.

--- a/seite-sh/content/roadmap/math-and-latex-rendering.md
+++ b/seite-sh/content/roadmap/math-and-latex-rendering.md
@@ -2,8 +2,8 @@
 title: Math and LaTeX Rendering
 description: Server-side KaTeX rendering for inline and display math blocks in markdown
 tags:
-- planned
+- done
 weight: 4
 ---
 
-Server-side KaTeX or MathJax rendering in markdown. Render `$inline$` and `$$display$$` math blocks to HTML during markdown processing. Important for technical and academic sites.
+Server-side KaTeX rendering is now built in. Enable with `math = true` in `[build]` config. Supports `$inline$` and `$$display$$` math blocks, rendered to HTML during the markdown processing step. No client-side JavaScript required — all rendering happens at build time.

--- a/seite-sh/content/roadmap/theme-community-ecosystem.md
+++ b/seite-sh/content/roadmap/theme-community-ecosystem.md
@@ -2,11 +2,20 @@
 title: Theme Community Ecosystem
 description: Curated theme registry, browse command, validation, and contributor guide
 tags:
-- planned
+- in-progress
 weight: 7
 ---
 
-Build discoverability and a contributor on-ramp for community themes.
+Build discoverability and a contributor on-ramp for community themes. Theme sharing infrastructure is partially complete — install from URL and export are shipped.
+
+### Completed
+
+- **`seite theme install <url>`** — download and install `.tera` themes from any URL
+- **`seite theme export <name>`** — package the current theme as a shareable `.tera` file with metadata
+- **Theme metadata** — `{#- theme-description: ... -#}` convention in theme files
+- **AI-generated themes** — `seite theme create "<description>"` generates custom themes via Claude Code
+
+### Remaining
 
 - **Curated theme registry** — `themes.json` listing community themes with name, description, author, install URL, and preview
 - **`seite theme browse`** — fetch and display available community themes with filtering

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1132,16 +1132,15 @@ fn build_site_inner(
                 ctx.insert("pagination", &pagination);
                 ctx.insert("translations", &Vec::<TranslationLink>::new());
 
-                // Pass sidebar nav for nested collections
-                if let Some(nav_langs) = collection_nav_cache.get(&c.name) {
-                    if let Some(nav_val) = nav_langs.get(lang.as_str()) {
-                        ctx.insert("nav", nav_val);
-                    } else {
-                        ctx.insert("nav", &empty_nav_value);
-                    }
-                } else {
-                    ctx.insert("nav", &empty_nav_value);
-                }
+                // Pass sidebar nav for nested collections.
+                // If this language has items (guaranteed — we skip empty above), its
+                // nav was built from those same items, so the lookup always succeeds
+                // when the collection is in the cache.
+                let nav_val = collection_nav_cache
+                    .get(&c.name)
+                    .and_then(|langs| langs.get(lang.as_str()))
+                    .unwrap_or(&empty_nav_value);
+                ctx.insert("nav", nav_val);
 
                 // Always provide a page context so SEO meta tags can access page.url etc.
                 // Insert items directly so collection-specific index templates can use {% for item in items %}

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1300,15 +1300,11 @@ fn build_site_inner(
 
             // Pass sidebar nav for nested collections (e.g., docs) so the
             // collection index template can render the same sidebar as individual pages.
-            if let Some(nav_langs) = collection_nav_cache.get(&c.name) {
-                if let Some(nav_val) = nav_langs.get(lang.as_str()) {
-                    ctx.insert("nav", nav_val);
-                } else {
-                    ctx.insert("nav", &empty_nav_value);
-                }
-            } else {
-                ctx.insert("nav", &empty_nav_value);
-            }
+            let nav_val = collection_nav_cache
+                .get(&c.name)
+                .and_then(|langs| langs.get(lang.as_str()))
+                .unwrap_or(&empty_nav_value);
+            ctx.insert("nav", nav_val);
 
             // Use collection's index.md content if available (content/{collection}/index.md)
             let col_index_page = collection_index_pages

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -77,6 +77,45 @@ pub const DEFAULT_DOC: &str = r##"{% extends "base.html" %}
 </article>
 {% endblock %}"##;
 
+pub const DEFAULT_DOCS_INDEX: &str = r##"{% extends "base.html" %}
+{% block title %}{% if page.title %}{{ page.title }} — {% endif %}{{ site.title }}{% endblock %}
+{% block content %}
+{% if page.content %}
+<article>
+    <h1>{{ page.title }}</h1>
+    {% if page.toc | length > 1 %}
+    <nav class="toc">
+        <h4>{{ t.contents }}</h4>
+        <ul>
+        {% for entry in page.toc %}<li class="toc-level-{{ entry.level }}"><a href="#{{ entry.id }}">{{ entry.text }}</a></li>
+        {% endfor %}</ul>
+    </nav>
+    {% endif %}
+    <div class="content">{{ page.content | safe }}</div>
+</article>
+{% else %}
+<h1>{{ page.title | default(value=t.documentation) }}</h1>
+{% if nav %}
+{% for section in nav %}
+<section class="docs-section-overview">
+    {% if section.label %}<h2>{{ section.label }}</h2>{% endif %}
+    <ul class="docs-section-list">
+    {% for item in section.items %}
+        <li><a href="{{ item.url }}">{{ item.title }}</a></li>
+    {% endfor %}
+    </ul>
+</section>
+{% endfor %}
+{% elif items %}
+<ul>
+{% for item in items %}
+    <li><a href="{{ item.url }}">{{ item.title }}</a>{% if item.description %} — {{ item.description }}{% endif %}</li>
+{% endfor %}
+</ul>
+{% endif %}
+{% endif %}
+{% endblock %}"##;
+
 pub const DEFAULT_PAGE: &str = r#"{% extends "base.html" %}
 {% block title %}{{ page.title }} - {{ site.title }}{% endblock %}
 {% block content %}
@@ -461,6 +500,7 @@ fn get_default_template(name: &str) -> Option<&'static str> {
         "index.html" => Some(DEFAULT_INDEX),
         "post.html" => Some(DEFAULT_POST),
         "doc.html" => Some(DEFAULT_DOC),
+        "docs-index.html" => Some(DEFAULT_DOCS_INDEX),
         "page.html" => Some(DEFAULT_PAGE),
         "trust-item.html" => Some(DEFAULT_TRUST_ITEM),
         "trust-index.html" => Some(DEFAULT_TRUST_INDEX),
@@ -553,6 +593,7 @@ mod tests {
         assert!(get_default_template("index.html").is_some());
         assert!(get_default_template("post.html").is_some());
         assert!(get_default_template("doc.html").is_some());
+        assert!(get_default_template("docs-index.html").is_some());
         assert!(get_default_template("page.html").is_some());
         assert!(get_default_template("404.html").is_some());
         assert!(get_default_template("tags.html").is_some());
@@ -593,6 +634,7 @@ mod tests {
         let tera = load_templates(path, &collections).unwrap();
         assert!(tera.get_template("post.html").is_ok());
         assert!(tera.get_template("doc.html").is_ok());
+        assert!(tera.get_template("docs-index.html").is_ok());
     }
 
     #[test]
@@ -645,6 +687,7 @@ mod tests {
             "index.html",
             "post.html",
             "doc.html",
+            "docs-index.html",
             "page.html",
             "404.html",
             "tags.html",

--- a/src/themes/academic.tera
+++ b/src/themes/academic.tera
@@ -505,6 +505,10 @@
         .pagination a { text-decoration: none; color: #a00000; }
         .pagination a:hover { text-decoration: underline; }
         .pagination span { color: #999; font-size: 0.85rem; }
+        .docs-section-overview { margin-bottom: 2rem; }
+        .docs-section-overview h2 { font-size: 1.3rem; margin-bottom: 0.5rem; }
+        .docs-section-list { list-style: none; padding: 0; }
+        .docs-section-list li { margin-bottom: 0.3rem; }
 
         /* === EMBEDS === */
         .video-embed {

--- a/src/themes/bento.tera
+++ b/src/themes/bento.tera
@@ -260,6 +260,11 @@
         .pagination a { text-decoration: none; }
         .pagination a:hover { text-decoration: underline; }
         .pagination span { color: #9ca3af; font-size: 0.9rem; }
+        .docs-section-overview { margin-bottom: 2rem; }
+        .docs-section-overview h2 { font-size: 1.3rem; margin-bottom: 0.5rem; }
+        .docs-section-list { list-style: none; padding: 0; }
+        .docs-section-list li { margin-bottom: 0.3rem; }
+        .docs-section-list a { color: #5046e5; }
         footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #e5e7eb; color: #9ca3af; font-size: 0.85rem; }
         :focus-visible { outline: 2px solid #5046e5; outline-offset: 2px; border-radius: 4px; }
         @media (max-width: 600px) {

--- a/src/themes/brutalist.tera
+++ b/src/themes/brutalist.tera
@@ -241,6 +241,10 @@
         .pagination a { text-decoration: none; }
         .pagination a:hover { text-decoration: underline; }
         .pagination span { color: #666; font-size: 0.9rem; }
+        .docs-section-overview { margin-bottom: 2rem; }
+        .docs-section-overview h2 { font-size: 1.3rem; margin-bottom: 0.5rem; border-bottom: 3px solid #000; }
+        .docs-section-list { list-style: none; padding: 0; }
+        .docs-section-list li { margin-bottom: 0.3rem; }
         footer { border: 3px solid #000; padding: 1rem 1.5rem; margin-top: 2rem; font-weight: 700; font-size: 0.85rem; }
         :focus-visible { outline: 3px solid #000; outline-offset: 2px; }
         .skip-link { position: absolute; top: -100%; left: 0; padding: 0.5rem 1rem; background: #000; color: #ffe600; z-index: 100; text-decoration: none; font-weight: 900; text-transform: uppercase; border: 3px solid #ffe600; }

--- a/src/themes/dark.tera
+++ b/src/themes/dark.tera
@@ -231,6 +231,11 @@
         .pagination a { text-decoration: none; }
         .pagination a:hover { text-decoration: underline; }
         .pagination span { color: #888; font-size: 0.9rem; }
+        .docs-section-overview { margin-bottom: 2rem; }
+        .docs-section-overview h2 { font-size: 1.3rem; margin-bottom: 0.5rem; }
+        .docs-section-list { list-style: none; padding: 0; }
+        .docs-section-list li { margin-bottom: 0.3rem; }
+        .docs-section-list a { color: #8b5cf6; }
         footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #1e1e1e; color: #555; font-size: 0.85rem; }
         :focus-visible { outline: 2px solid #8b5cf6; outline-offset: 2px; }
         .skip-link { position: absolute; top: -100%; left: 0; padding: 0.5rem 1rem; background: #8b5cf6; color: #fff; z-index: 100; text-decoration: none; }

--- a/src/themes/default.tera
+++ b/src/themes/default.tera
@@ -226,6 +226,11 @@
         .pagination a { text-decoration: none; }
         .pagination a:hover { text-decoration: underline; }
         .pagination span { color: #666; font-size: 0.9rem; }
+        .docs-section-overview { margin-bottom: 2rem; }
+        .docs-section-overview h2 { font-size: 1.3rem; margin-bottom: 0.5rem; }
+        .docs-section-list { list-style: none; padding: 0; }
+        .docs-section-list li { margin-bottom: 0.3rem; }
+        .docs-section-list a { color: #0057b7; }
         footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #eee; color: #666; font-size: 0.85rem; }
         .skip-link { position: absolute; top: -100%; left: 0; padding: 0.5rem 1rem; background: #0057b7; color: #fff; z-index: 100; text-decoration: none; }
         .skip-link:focus { top: 0; }

--- a/src/themes/docs.tera
+++ b/src/themes/docs.tera
@@ -237,6 +237,11 @@
         .pagination a { text-decoration: none; }
         .pagination a:hover { text-decoration: underline; }
         .pagination span { color: #666; font-size: 0.9rem; }
+        .docs-section-overview { margin-bottom: 2rem; }
+        .docs-section-overview h2 { font-size: 1.3rem; margin-bottom: 0.5rem; border-bottom: 1px solid #eaecef; padding-bottom: 0.3rem; }
+        .docs-section-list { list-style: none; padding: 0; }
+        .docs-section-list li { margin-bottom: 0.3rem; }
+        .docs-section-list a { color: #0366d6; }
         footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #e1e4e8; color: #666; font-size: 0.85rem; }
         @media (max-width: 768px) {
             .sidebar { position: static; width: 100%; border-right: none; border-bottom: 1px solid #e1e4e8; }

--- a/src/themes/landing.tera
+++ b/src/themes/landing.tera
@@ -733,6 +733,10 @@
         }
         .pagination a:hover { background: var(--accent-subtle); border-color: rgba(79,70,229,0.3); }
         .pagination span { color: var(--muted); font-size: 0.9rem; }
+        .docs-section-overview { margin-bottom: 2rem; }
+        .docs-section-overview h2 { font-size: 1.3rem; margin-bottom: 0.5rem; }
+        .docs-section-list { list-style: none; padding: 0; }
+        .docs-section-list li { margin-bottom: 0.3rem; }
 
         /* ---------- Footer ---------- */
         .site-footer {

--- a/src/themes/magazine.tera
+++ b/src/themes/magazine.tera
@@ -242,6 +242,10 @@
         .pagination a { text-decoration: none; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; color: #111; }
         .pagination a:hover { color: #e63946; }
         .pagination span { color: #888; font-size: 0.8rem; }
+        .docs-section-overview { margin-bottom: 2rem; }
+        .docs-section-overview h2 { font-size: 1.3rem; margin-bottom: 0.5rem; }
+        .docs-section-list { list-style: none; padding: 0; }
+        .docs-section-list li { margin-bottom: 0.3rem; }
 
         /* ===== TRUST CENTER ===== */
         .trust-hub { max-width: 1000px; margin: 0 auto; }

--- a/src/themes/minimal.tera
+++ b/src/themes/minimal.tera
@@ -227,6 +227,10 @@
         .pagination a { text-decoration: none; }
         .pagination a:hover { text-decoration: underline; }
         .pagination span { color: #999; font-size: 0.9rem; }
+        .docs-section-overview { margin-bottom: 2rem; }
+        .docs-section-overview h2 { font-size: 1.3rem; margin-bottom: 0.5rem; }
+        .docs-section-list { list-style: none; padding: 0; }
+        .docs-section-list li { margin-bottom: 0.3rem; }
         footer { margin-top: 4rem; font-size: 0.85rem; color: #aaa; }
         .skip-link { position: absolute; top: -100%; left: 0; padding: 0.5rem 1rem; background: #333; color: #fff; z-index: 100; text-decoration: none; font-family: system-ui, sans-serif; }
         .skip-link:focus { top: 0; }

--- a/src/themes/terminal.tera
+++ b/src/themes/terminal.tera
@@ -859,6 +859,11 @@
         .pagination a::after { content: ' ]'; color: var(--phosphor-dim); }
         .pagination a:hover { text-decoration: underline; }
         .pagination span { color: var(--text-dim); font-size: 0.85rem; }
+        .docs-section-overview { margin-bottom: 2rem; }
+        .docs-section-overview h2 { font-size: 1.3rem; margin-bottom: 0.5rem; }
+        .docs-section-list { list-style: none; padding: 0; }
+        .docs-section-list li { margin-bottom: 0.3rem; }
+        .docs-section-list a { color: var(--accent); }
 
         /* ==============================
            TAG INDEX


### PR DESCRIPTION
## Summary

This PR adds support for `content/{collection}/index.md` files that inject custom content into collection index pages, similar to how `content/pages/index.md` works for the site homepage. This enables custom landing pages for any collection and allows subdomain-deployed collections to have custom root pages.

## Key Changes

- **Extract collection index pages**: Added logic to identify and extract `index.md` files from each collection (except `pages`, which is already handled separately) into a `collection_index_pages` HashMap before rendering
- **Inject into collection indexes**: When rendering paginated collection indexes, the `index.md` content is injected into the page context on page 1 only
- **Inject into non-paginated collection indexes**: For collections without pagination, the `index.md` content is always available in the page context
- **Support subdomain root pages**: When a collection has a `subdomain` configured with an empty `url_prefix`, its `index.md` becomes the subdomain root page (e.g., `content/docs/index.md` → `docs.example.com/`)
- **Exclude from listings**: Extracted `index.md` files are removed from the collection items list so they don't appear as regular items in collection listings
- **Full frontmatter support**: All frontmatter fields from collection `index.md` files are available in templates (`page.title`, `page.description`, `page.extra`, `page.tags`, etc.)

## Implementation Details

- The extraction happens early in the build process (after all collections are loaded but before rendering)
- Uses a simple slug-based check (`items[i].slug == "index"`) to identify index pages
- Maintains language-specific variants of index pages (e.g., `index.en.md`, `index.fr.md`)
- For paginated collections, index content only appears on page 1 to avoid duplication
- Gracefully falls back to default/empty page context if no `index.md` exists for a collection
- Added comprehensive integration tests covering: collection index content injection, exclusion from listings, subdomain root pages, and fallback behavior

## Documentation

- Updated `collections.md` with sections on "Subdomain Root Page" and "Collection Index Pages"
- Added changelog entry for v0.4.3
- Updated CLAUDE.md to reflect the new rendering pipeline
- Version bumped to 0.4.3

https://claude.ai/code/session_012W6PHthLpX5iWZVMHGa7eX