### PR TITLE
Fix upgrade not stamping version when no file changes needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/seite-sh/content/changelog/2026-02-28-v0-4-4.md
+++ b/seite-sh/content/changelog/2026-02-28-v0-4-4.md
@@ -1,0 +1,14 @@
+---
+title: v0.4.4
+description: "Fix seite upgrade not updating project version when no file changes needed"
+date: 2026-02-28
+tags:
+- fix
+---
+
+## Bug Fix: Upgrade Version Stamping
+
+- Fixed `seite upgrade` not updating the version in `.seite/config.json` when no file-level actions were needed
+- Previously, if all upgrade step checks found nothing to create/merge/append (e.g., upgrading from 0.4.0 to 0.4.3 with no new upgrade steps), the version would remain at the old value even though the upgrade reported success
+- Now the version is always stamped to the current binary version, even when there are no file changes to apply
+- Fixed "page" references in upgrade success messages to say "seite"


### PR DESCRIPTION
## Summary
Fixed a bug in `seite upgrade` where the project version in `.seite/config.json` was not being updated when no file-level changes were needed, even though the upgrade completed successfully.

## Key Changes
- **Version stamping logic**: Added explicit version stamping in the "no actions" code path when the project version is behind the binary version. This handles cases where upgrade steps exist but their checks found nothing to do (files already present), or where the binary was bumped without adding new upgrade steps.
- **Message corrections**: Fixed two user-facing messages that incorrectly referred to "page" instead of "seite" in upgrade success output.
- **Version bump**: Updated to v0.4.4 and added changelog entry documenting the fix.

## Implementation Details
The fix ensures that even when `actions.is_empty()` (no file changes to apply), if `project_ver < binary_ver`, the code now:
1. Loads the existing metadata
2. Stamps it with the current binary version using `stamp_current_version()`
3. Writes the updated metadata back to disk

This preserves other metadata fields like `initialized_at` while updating only the version field, ensuring the project's version record stays in sync with the binary version that performed the upgrade.

https://claude.ai/code/session_01DsTERzZZ7U9X5CWWLdQuRS