### PR TITLE
Fix serve watcher rebuild loop on Ubuntu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -342,8 +342,18 @@ fn watch_and_rebuild(
     while !stop.load(Ordering::Relaxed) {
         // Block until we get an event or timeout (so we can check `stop`)
         match rx.recv_timeout(Duration::from_secs(1)) {
-            Ok(Ok(_event)) => {
-                // Got a real fs event — drain any additional events within the debounce window
+            Ok(Ok(event)) => {
+                // Ignore metadata-only events (e.g. atime updates from file reads on
+                // strictatime/relatime systems) — only react to content changes.
+                if matches!(
+                    event.kind,
+                    notify::EventKind::Modify(notify::event::ModifyKind::Metadata(_))
+                        | notify::EventKind::Access(_)
+                ) {
+                    continue;
+                }
+
+                // Drain any additional events within the debounce window
                 while rx.recv_timeout(debounce).is_ok() {}
 
                 human::info("Changes detected, rebuilding...");
@@ -357,6 +367,10 @@ fn watch_and_rebuild(
                         human::error(&format!("Rebuild failed: {e}"));
                     }
                 }
+
+                // Drain events that accumulated during the build so they don't
+                // immediately trigger another rebuild.
+                while rx.try_recv().is_ok() {}
             }
             Ok(Err(e)) => {
                 human::error(&format!("Watch error: {e}"));

--- a/src/workspace/server.rs
+++ b/src/workspace/server.rs
@@ -352,6 +352,16 @@ fn watch_and_rebuild_workspace(
     while !stop.load(Ordering::Relaxed) {
         match rx.recv_timeout(Duration::from_secs(1)) {
             Ok(Ok(event)) => {
+                // Ignore metadata-only events (e.g. atime updates from file reads on
+                // strictatime/relatime systems) — only react to content changes.
+                if matches!(
+                    event.kind,
+                    notify::EventKind::Modify(notify::event::ModifyKind::Metadata(_))
+                        | notify::EventKind::Access(_)
+                ) {
+                    continue;
+                }
+
                 // Drain additional events within debounce window
                 while rx.recv_timeout(debounce).is_ok() {}
 
@@ -409,6 +419,10 @@ fn watch_and_rebuild_workspace(
                     }
                     build_version.fetch_add(1, Ordering::Relaxed);
                 }
+
+                // Drain events that accumulated during the build so they don't
+                // immediately trigger another rebuild.
+                while rx.try_recv().is_ok() {}
             }
             Ok(Err(e)) => {
                 human::error(&format!("Watch error: {e}"));


### PR DESCRIPTION
## Summary

- Filter out metadata-only events (`Metadata(_)`, `Access(_)`) from the file watcher so that `IN_ATTRIB` signals generated when the build reads from watched directories (common on Ubuntu with `relatime`/`strictatime` filesystems) do not trigger spurious rebuilds
- Drain the event channel after each build completes to discard any events that accumulated while the build was running, preventing an immediate follow-on rebuild

Fixes both the standalone server (`src/server/mod.rs`) and the workspace server (`src/workspace/server.rs`).

## Test plan

- [ ] Run `seite serve` on Ubuntu and confirm no rebuild loop occurs when no files are changed
- [ ] Edit a content file and confirm a rebuild is still triggered correctly
- [ ] Run `cargo test` — all 1054 unit + 342 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)