### PR TITLE
deps: bump dialoguer 0.12, toml 1.0, quick-xml 0.39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
  "num-traits",
  "pastey",
  "rayon",
- "thiserror 2.0.18",
+ "thiserror",
  "v_frame",
  "y4m",
 ]
@@ -421,19 +421,6 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
@@ -593,15 +580,14 @@ checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "dialoguer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console 0.15.11",
+ "console",
  "fuzzy-matcher",
  "shell-words",
  "tempfile",
- "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -1197,7 +1183,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "thiserror 2.0.18",
+ "thiserror",
  "unicode-normalization",
 ]
 
@@ -1694,7 +1680,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -1845,6 +1831,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
  "serde",
 ]
 
@@ -1961,7 +1956,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "simd_helpers",
- "thiserror 2.0.18",
+ "thiserror",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -2126,7 +2121,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
- "console 0.16.2",
+ "console",
  "dialoguer",
  "fs_extra",
  "image",
@@ -2134,7 +2129,7 @@ dependencies = [
  "notify",
  "predicates",
  "pulldown-cmark",
- "quick-xml",
+ "quick-xml 0.39.2",
  "rayon",
  "serde",
  "serde_json",
@@ -2143,7 +2138,7 @@ dependencies = [
  "syntect",
  "tempfile",
  "tera",
- "thiserror 2.0.18",
+ "thiserror",
  "tiny_http",
  "toml",
  "tracing",
@@ -2204,11 +2199,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2370,7 +2365,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "walkdir",
  "yaml-rust",
 ]
@@ -2418,31 +2413,11 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2535,45 +2510,42 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tracing"
@@ -3004,15 +2976,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -3163,9 +3126,6 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,13 @@ path = "src/main.rs"
 [dependencies]
 # CLI
 clap = { version = "4.5", features = ["derive", "env"] }
-dialoguer = { version = "0.11", features = ["fuzzy-select"] }
+dialoguer = { version = "0.12", features = ["fuzzy-select"] }
 console = "0.16"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = { version = "0.8", features = ["preserve_order"] }
+toml = { version = "1.0", features = ["preserve_order"] }
 serde_yaml_ng = "0.10"
 
 # Content processing
@@ -67,7 +67,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # RSS / Sitemap generation
-quick-xml = { version = "0.38", features = ["serialize"] }
+quick-xml = { version = "0.39", features = ["serialize"] }
 
 # Slug generation
 slug = "0.1"

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -82,7 +82,7 @@ pub fn run(args: &InitArgs) -> anyhow::Result<()> {
             let options = ["github-pages", "cloudflare", "netlify"];
             let selection = dialoguer::Select::new()
                 .with_prompt("Deploy target")
-                .items(&options)
+                .items(options)
                 .default(0)
                 .interact()?;
             options[selection].to_string()
@@ -100,7 +100,7 @@ pub fn run(args: &InitArgs) -> anyhow::Result<()> {
             let defaults = &[true, false, true, false, false, false]; // posts + pages on by default
             let selections = dialoguer::MultiSelect::new()
                 .with_prompt("Collections to include")
-                .items(&preset_names)
+                .items(preset_names)
                 .defaults(defaults)
                 .interact()?;
             selections
@@ -496,7 +496,7 @@ fn prompt_trust_options(args: &InitArgs, title: &str) -> anyhow::Result<TrustOpt
             let defaults = &[true, false, false, false, false, false, false];
             let selections = dialoguer::MultiSelect::new()
                 .with_prompt("Compliance frameworks")
-                .items(&names)
+                .items(names)
                 .defaults(defaults)
                 .interact()?;
             selections
@@ -530,7 +530,7 @@ fn prompt_trust_options(args: &InitArgs, title: &str) -> anyhow::Result<TrustOpt
             let defaults = &[true, true, true, true, true, false, false];
             let selections = dialoguer::MultiSelect::new()
                 .with_prompt("Trust center sections")
-                .items(&section_names)
+                .items(section_names)
                 .defaults(defaults)
                 .interact()?;
             selections
@@ -556,7 +556,7 @@ fn prompt_trust_options(args: &InitArgs, title: &str) -> anyhow::Result<TrustOpt
             ];
             let selection = dialoguer::Select::new()
                 .with_prompt(format!("{fw_name} status"))
-                .items(&options)
+                .items(options)
                 .default(0)
                 .interact()?;
             match selection {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -128,13 +128,11 @@ fn parse_data_file(path: &Path) -> Result<serde_json::Value> {
             })
         }
         "toml" => {
-            let toml_value: toml::Value =
-                content
-                    .parse()
-                    .map_err(|e: toml::de::Error| PageError::Data {
-                        path: path.to_path_buf(),
-                        message: format!("invalid TOML: {e}"),
-                    })?;
+            let toml_value: toml::Table =
+                toml::from_str(&content).map_err(|e| PageError::Data {
+                    path: path.to_path_buf(),
+                    message: format!("invalid TOML: {e}"),
+                })?;
             serde_json::to_value(toml_value).map_err(|e| PageError::Data {
                 path: path.to_path_buf(),
                 message: format!("TOML conversion error: {e}"),


### PR DESCRIPTION
- dialoguer 0.11→0.12: .items() now takes iterators; remove unnecessary borrows in init.rs and contact.rs
- toml 0.8→1.0 (TOML spec 1.1): Value::from_str now parses a single value, not a document; switch to toml::from_str::<Table> in data file loader
- quick-xml 0.38→0.39: no code changes needed

Supersedes #41.