### PR TITLE
Fix security and attribute extraction bugs in v0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/seite-sh/content/changelog/2026-03-13-v0-8-2.md
+++ b/seite-sh/content/changelog/2026-03-13-v0-8-2.md
@@ -1,0 +1,24 @@
+---
+title: v0.8.2
+description: "Security fix: heading XSS, i18n language context bug, Plausible warning spam"
+date: 2026-03-13
+tags:
+- fix
+- security
+---
+
+## Heading HTML Injection (Security Fix)
+
+Markdown headings containing HTML special characters (e.g., `<`, `>`, `&`) were rendered without escaping, allowing raw HTML injection into the page. A heading like `## Use <script> tags` would inject a literal `<script>` element into the output.
+
+Heading text is now HTML-escaped before being written into `<h>` tags, matching the behavior of all other inline content.
+
+## Multilingual `site.language` Incorrect for Non-Default Languages
+
+`SiteContext::for_lang()` always set `site.language` to the default language from `seite.toml` instead of the language actually being rendered. This meant `<html lang="...">` and any template logic using `{{ site.language }}` would show the wrong language code on translated pages.
+
+`site.language` now correctly reflects the page's language for every render pass.
+
+## Plausible Deprecation Warning Printed Once Per HTML File
+
+The Plausible `extensions` deprecation notice was emitted inside the per-file analytics injection loop, which runs in parallel via Rayon. On a site with 200 pages, the warning printed 200 times. The warning is now emitted once before the post-processing loop.

--- a/seite-sh/content/changelog/2026-03-13-v0-8-2.md
+++ b/seite-sh/content/changelog/2026-03-13-v0-8-2.md
@@ -1,6 +1,6 @@
 ---
 title: v0.8.2
-description: "Security fix: heading XSS, i18n language context bug, Plausible warning spam"
+description: "Security fix: heading XSS, i18n language context bug, Plausible warning spam, image attribute extraction"
 date: 2026-03-13
 tags:
 - fix
@@ -22,3 +22,9 @@ Heading text is now HTML-escaped before being written into `<h>` tags, matching 
 ## Plausible Deprecation Warning Printed Once Per HTML File
 
 The Plausible `extensions` deprecation notice was emitted inside the per-file analytics injection loop, which runs in parallel via Rayon. On a site with 200 pages, the warning printed 200 times. The warning is now emitted once before the post-processing loop.
+
+## Image `src` Attribute Extraction Matched Partial Names
+
+The `extract_attr` helper used during image post-processing matched attribute names by substring. Searching for `src` would match `data-src` if it appeared earlier in the tag, causing the wrong URL to be used for srcset generation and `<picture>` element construction.
+
+Attribute matching now requires a whitespace boundary before the attribute name, so `data-src` no longer shadows `src`.

--- a/src/build/analytics.rs
+++ b/src/build/analytics.rs
@@ -164,17 +164,6 @@ document.getElementById('seite-cookie-decline').addEventListener('click',functio
 /// - Without consent: injects script before `</head>` and optional noscript after `<body>`
 /// - With consent: injects consent banner + gated loader before `</body>`
 pub fn inject_analytics(html: &str, config: &AnalyticsSection) -> String {
-    if config.provider == AnalyticsProvider::Plausible
-        && !config.extensions.is_empty()
-        && config.script_url.is_none()
-    {
-        crate::output::human::warning(
-            "Plausible `extensions` are deprecated (Oct 2025). Retrieve your unique snippet \
-             from Plausible → Settings → Installation and set `script_url` in seite.toml. \
-             Your current config still works. \
-             See https://plausible.io/docs/script-update-guide",
-        );
-    }
     if config.cookie_consent {
         // Consent mode: inject banner + gated script before </body>
         let banner = consent_banner_html(config);

--- a/src/build/images.rs
+++ b/src/build/images.rs
@@ -373,11 +373,19 @@ pub fn rewrite_html_images(
 
 fn extract_attr(tag: &str, attr_name: &str) -> Option<String> {
     let search = format!("{attr_name}=\"");
-    let start = tag.find(&search)?;
-    let value_start = start + search.len();
-    let rest = &tag[value_start..];
-    let end = rest.find('"')?;
-    Some(rest[..end].to_string())
+    let mut offset = 0;
+    while let Some(pos) = tag[offset..].find(&search) {
+        let abs_pos = offset + pos;
+        // Ensure the match is a full attribute name (preceded by whitespace or tag start)
+        if abs_pos == 0 || tag.as_bytes()[abs_pos - 1].is_ascii_whitespace() {
+            let value_start = abs_pos + search.len();
+            let rest = &tag[value_start..];
+            let end = rest.find('"')?;
+            return Some(rest[..end].to_string());
+        }
+        offset = abs_pos + search.len();
+    }
+    None
 }
 
 fn build_picture_element(img_tag: &str, processed: &ProcessedImage, lazy_loading: bool) -> String {
@@ -1229,17 +1237,10 @@ mod tests {
 
     #[test]
     fn test_extract_attr_similar_prefix_names() {
-        // Make sure "data-src" doesn't match when looking for "src"
+        // "data-src" must NOT match when looking for "src"
         let tag = r#"<img data-src="/lazy.jpg" src="/real.jpg">"#;
-        assert_eq!(
-            extract_attr(tag, "src"),
-            Some("/lazy.jpg".to_string()).or(extract_attr(tag, "src"))
-        );
-        // The function searches for 'src="' — "data-src" also contains "src=" so it will
-        // find data-src first. This is expected behavior for the current implementation.
-        // Let's test what it actually returns.
-        let result = extract_attr(tag, "src");
-        assert!(result.is_some());
+        assert_eq!(extract_attr(tag, "src"), Some("/real.jpg".to_string()));
+        assert_eq!(extract_attr(tag, "data-src"), Some("/lazy.jpg".to_string()));
     }
 
     #[test]

--- a/src/build/markdown.rs
+++ b/src/build/markdown.rs
@@ -119,7 +119,9 @@ pub fn markdown_to_html(markdown: &str) -> (String, Vec<TocEntry>) {
                 });
                 html_output.push_str(&format!(
                     "<h{} id=\"{}\">{}",
-                    heading_level, id, heading_text
+                    heading_level,
+                    id,
+                    html_escape(&heading_text)
                 ));
                 html_output.push_str(&format!("</h{}>\n", heading_level));
             }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -340,6 +340,18 @@ fn build_subdomain_sites(
     Ok(results)
 }
 
+/// Check whether the Plausible analytics config uses deprecated `extensions` without `script_url`.
+fn needs_plausible_extensions_warning(analytics: Option<&AnalyticsSection>) -> bool {
+    match analytics {
+        Some(a) => {
+            a.provider == crate::config::AnalyticsProvider::Plausible
+                && !a.extensions.is_empty()
+                && a.script_url.is_none()
+        }
+        None => false,
+    }
+}
+
 /// Inner build pipeline. This is the actual 14-step build.
 ///
 /// `subdomain_rewrites_override`: if `Some`, used instead of computing from config.
@@ -2008,19 +2020,13 @@ fn build_site_inner(
             &computed_rewrites
         }
     };
-    // Emit Plausible extensions deprecation warning once (not per HTML file)
-    if let Some(ref analytics) = config.analytics {
-        if analytics.provider == crate::config::AnalyticsProvider::Plausible
-            && !analytics.extensions.is_empty()
-            && analytics.script_url.is_none()
-        {
-            crate::output::human::warning(
-                "Plausible `extensions` are deprecated (Oct 2025). Retrieve your unique snippet \
-                 from Plausible → Settings → Installation and set `script_url` in seite.toml. \
-                 Your current config still works. \
-                 See https://plausible.io/docs/script-update-guide",
-            );
-        }
+    if needs_plausible_extensions_warning(config.analytics.as_ref()) {
+        crate::output::human::warning(
+            "Plausible `extensions` are deprecated (Oct 2025). Retrieve your unique snippet \
+             from Plausible → Settings → Installation and set `script_url` in seite.toml. \
+             Your current config still works. \
+             See https://plausible.io/docs/script-update-guide",
+        );
     }
     let post_ctx = HtmlPostProcessContext {
         image_manifest: &image_manifest,
@@ -3440,6 +3446,61 @@ mod tests {
         config.site.base_url = "https://user.github.io/repo".into();
         let ctx = SiteContext::from_config(&config);
         assert_eq!(ctx.base_path, "/repo");
+    }
+
+    // ── needs_plausible_extensions_warning ─────────────────────────────
+
+    #[test]
+    fn test_plausible_warning_with_legacy_extensions() {
+        let analytics = AnalyticsSection {
+            provider: crate::config::AnalyticsProvider::Plausible,
+            id: "example.com".into(),
+            extensions: vec!["hash".into()],
+            script_url: None,
+            cookie_consent: false,
+        };
+        assert!(needs_plausible_extensions_warning(Some(&analytics)));
+    }
+
+    #[test]
+    fn test_plausible_no_warning_with_script_url() {
+        let analytics = AnalyticsSection {
+            provider: crate::config::AnalyticsProvider::Plausible,
+            id: "example.com".into(),
+            extensions: vec!["hash".into()],
+            script_url: Some("https://plausible.io/js/script.hash.js".into()),
+            cookie_consent: false,
+        };
+        assert!(!needs_plausible_extensions_warning(Some(&analytics)));
+    }
+
+    #[test]
+    fn test_plausible_no_warning_without_extensions() {
+        let analytics = AnalyticsSection {
+            provider: crate::config::AnalyticsProvider::Plausible,
+            id: "example.com".into(),
+            extensions: vec![],
+            script_url: None,
+            cookie_consent: false,
+        };
+        assert!(!needs_plausible_extensions_warning(Some(&analytics)));
+    }
+
+    #[test]
+    fn test_plausible_no_warning_for_other_providers() {
+        let analytics = AnalyticsSection {
+            provider: crate::config::AnalyticsProvider::Google,
+            id: "G-XXXXXXXX".into(),
+            extensions: vec!["hash".into()],
+            script_url: None,
+            cookie_consent: false,
+        };
+        assert!(!needs_plausible_extensions_warning(Some(&analytics)));
+    }
+
+    #[test]
+    fn test_plausible_no_warning_when_none() {
+        assert!(!needs_plausible_extensions_warning(None));
     }
 
     // ── build_page_context ──────────────────────────────────────────────

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -226,7 +226,7 @@ impl SiteContext {
             description: config.description_for_lang(lang).to_string(),
             base_url: config.site.base_url.clone(),
             base_path: config.base_path(),
-            language: config.site.language.clone(),
+            language: lang.to_string(),
             author: config.site.author.clone(),
         }
     }
@@ -2008,6 +2008,20 @@ fn build_site_inner(
             &computed_rewrites
         }
     };
+    // Emit Plausible extensions deprecation warning once (not per HTML file)
+    if let Some(ref analytics) = config.analytics {
+        if analytics.provider == crate::config::AnalyticsProvider::Plausible
+            && !analytics.extensions.is_empty()
+            && analytics.script_url.is_none()
+        {
+            crate::output::human::warning(
+                "Plausible `extensions` are deprecated (Oct 2025). Retrieve your unique snippet \
+                 from Plausible → Settings → Installation and set `script_url` in seite.toml. \
+                 Your current config still works. \
+                 See https://plausible.io/docs/script-update-guide",
+            );
+        }
+    }
     let post_ctx = HtmlPostProcessContext {
         image_manifest: &image_manifest,
         lazy_loading,
@@ -3397,9 +3411,9 @@ mod tests {
         let ctx = SiteContext::for_lang(&config, "es");
         assert_eq!(ctx.title, "Sitio de Prueba");
         assert_eq!(ctx.description, "Una prueba");
-        // base_url and language remain the same (they're site-level)
         assert_eq!(ctx.base_url, "https://example.com");
-        assert_eq!(ctx.language, "en");
+        // language should reflect the requested language, not the default
+        assert_eq!(ctx.language, "es");
     }
 
     #[test]

--- a/src/cli/perf.rs
+++ b/src/cli/perf.rs
@@ -189,7 +189,10 @@ mod tests {
     #[test]
     fn test_fetch_psi_url_encoding() {
         // Verify urlencoding::encode handles characters that would break query params
-        assert_eq!(urlencoding::encode("https://example.com"), "https%3A%2F%2Fexample.com");
+        assert_eq!(
+            urlencoding::encode("https://example.com"),
+            "https%3A%2F%2Fexample.com"
+        );
         assert_eq!(
             urlencoding::encode("https://example.com/page with spaces"),
             "https%3A%2F%2Fexample.com%2Fpage%20with%20spaces"


### PR DESCRIPTION
## Summary
This release addresses four bugs: a heading HTML injection vulnerability, incorrect language context in multilingual sites, redundant Plausible warnings, and faulty image attribute extraction that could match partial attribute names.

## Key Changes

- **Security: Heading HTML Injection** — Markdown heading text is now HTML-escaped before rendering into `<h>` tags, preventing raw HTML injection from special characters like `<`, `>`, and `&`.

- **Multilingual: Fix `site.language` Context** — `SiteContext::for_lang()` now correctly sets `site.language` to the requested language instead of always using the default language from `seite.toml`. This fixes `<html lang="...">` attributes and template logic on translated pages.

- **Analytics: Eliminate Plausible Warning Spam** — Moved the Plausible deprecation warning outside the per-file HTML post-processing loop (which runs in parallel via Rayon). The warning now emits once before processing instead of once per HTML file.

- **Image Processing: Fix Attribute Name Matching** — Rewrote `extract_attr()` to require a whitespace boundary before attribute names. Previously, searching for `src` would incorrectly match `data-src` if it appeared earlier in the tag, causing wrong URLs in srcset generation and `<picture>` element construction. Updated test expectations to verify correct behavior.

## Implementation Details

- The attribute extraction fix uses a loop with offset tracking to find all occurrences of the search pattern, then validates each match by checking that the preceding character is either the start of the tag or whitespace.
- The language context fix is a one-line change in `SiteContext::for_lang()` to use the passed `lang` parameter instead of the config default.
- The Plausible warning is now emitted in `build_site_inner()` before the `HtmlPostProcessContext` is created, ensuring it runs once during the build.

https://claude.ai/code/session_01KvUQW5uCHjrQX2ZDLRFfj5