### PR TITLE
Major UX improvements: build progress, Vite-style server, completions

### DIFF
--- a/.claude/rules/cli-commands.md
+++ b/.claude/rules/cli-commands.md
@@ -8,14 +8,14 @@ paths:
 - Each subcommand: `src/cli/{name}.rs` with `{Command}Args` + `pub fn run(args) -> anyhow::Result<()>`
 - Interactive prompts use `dialoguer` (only when CLI args not provided)
 
-## Subcommands (14)
-init, new, build, serve, deploy, agent, theme, mcp, workspace, upgrade, contact, collection, skill, self-update
+## Subcommands (15)
+init, new, build, serve, deploy, agent, theme, mcp, workspace, upgrade, contact, collection, skill, self-update, completions
 
 ## Agent System
 `seite agent` spawns Claude Code with system prompt containing site config, content inventory, template list, frontmatter format. Two modes: `seite agent "prompt"` (non-interactive) and `seite agent` (interactive).
 
 ## Dev Server
-`seite serve` starts HTTP server + file watcher. Returns `ServerHandle`. Interactive REPL: new, agent, theme, build, status, stop. Live reload via `/__livereload` polling.
+`seite serve` starts HTTP server + file watcher. Returns `ServerHandle`. Shows Vite-style local + network URLs. `--open` flag launches browser. Interactive REPL: new, agent, theme, build, status, stop. Live reload via `/__livereload` polling.
 
 ## Workspace System
 Multi-site via `seite-workspace.toml`. `workspace::resolve_context()` returns `Standalone` or `Workspace`. `--site` flag filters. Unified serving routes `/<site-name>/...`.

--- a/.claude/rules/cli-commands.md
+++ b/.claude/rules/cli-commands.md
@@ -8,8 +8,8 @@ paths:
 - Each subcommand: `src/cli/{name}.rs` with `{Command}Args` + `pub fn run(args) -> anyhow::Result<()>`
 - Interactive prompts use `dialoguer` (only when CLI args not provided)
 
-## Subcommands (15)
-init, new, build, serve, deploy, agent, theme, mcp, workspace, upgrade, contact, collection, skill, self-update, completions
+## Subcommands (16)
+init, new, build, serve, deploy, agent, theme, mcp, workspace, upgrade, contact, collection, skill, self-update, completions, perf
 
 ## Agent System
 `seite agent` spawns Claude Code with system prompt containing site config, content inventory, template list, frontmatter format. Two modes: `seite agent "prompt"` (non-interactive) and `seite agent` (interactive).

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,8 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # nightly
         with:
+          toolchain: nightly
           components: llvm-tools-preview
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,9 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # nightly
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
-          toolchain: nightly
           components: llvm-tools-preview
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ cargo run -- init mysite --title "My Site" --collections posts,docs,pages
 cargo run -- build   # Build site from seite.toml
 cargo run -- serve   # Dev server with REPL (live reload)
 cargo run -- serve --open  # Dev server + open browser
+cargo run -- serve --host 0.0.0.0  # Bind to all interfaces
 cargo run -- new post "My Post" --tags rust,web
 cargo run -- agent "create a blog post about Rust"
 cargo run -- theme create "coral brutalist with lime accents"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ cargo clippy         # Lint — must be zero warnings
 cargo run -- init mysite --title "My Site" --collections posts,docs,pages
 cargo run -- build   # Build site from seite.toml
 cargo run -- serve   # Dev server with REPL (live reload)
+cargo run -- serve --open  # Dev server + open browser
 cargo run -- new post "My Post" --tags rust,web
 cargo run -- agent "create a blog post about Rust"
 cargo run -- theme create "coral brutalist with lime accents"
@@ -23,6 +24,7 @@ cargo run -- deploy  # Commit, push, build, and deploy
 cargo run -- skill install seomachine
 cargo run -- upgrade # Upgrade project config to current binary
 cargo run -- self-update
+cargo run -- completions bash  # Generate shell completions
 ```
 
 ## Module Map
@@ -37,7 +39,7 @@ src/
   docs.rs              Embedded docs (15 pages from seite-sh/content/docs/)
   meta.rs              Project metadata (.seite/config.json)
   mcp/                 MCP server (JSON-RPC over stdio): mod.rs, resources.rs, tools.rs
-  cli/                 14 subcommands: init, new, build, serve, deploy, agent, theme, mcp, workspace, upgrade, contact, collection, skill, self_update
+  cli/                 15 subcommands: init, new, build, serve, deploy, agent, theme, mcp, workspace, upgrade, contact, collection, skill, self_update, completions
   update_check.rs      Background update check (24h cache)
   scaffold/            Static markdown for generated CLAUDE.md + .claude/rules/ (include_str!)
   config/              SiteConfig, CollectionConfig, defaults

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ src/
   docs.rs              Embedded docs (15 pages from seite-sh/content/docs/)
   meta.rs              Project metadata (.seite/config.json)
   mcp/                 MCP server (JSON-RPC over stdio): mod.rs, resources.rs, tools.rs
-  cli/                 15 subcommands: init, new, build, serve, deploy, agent, theme, mcp, workspace, upgrade, contact, collection, skill, self_update, completions
+  cli/                 16 subcommands: init, new, build, serve, deploy, agent, theme, mcp, workspace, upgrade, contact, collection, skill, self_update, completions, perf
   update_check.rs      Background update check (24h cache)
   scaffold/            Static markdown for generated CLAUDE.md + .claude/rules/ (include_str!)
   config/              SiteConfig, CollectionConfig, defaults

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +427,19 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "console"
@@ -583,7 +605,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console",
+ "console 0.16.3",
  "fuzzy-matcher",
  "shell-words",
  "tempfile",
@@ -1097,6 +1119,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1160,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -1465,6 +1519,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,6 +1559,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "parse-zoneinfo"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1589,12 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -1696,6 +1773,12 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -2114,18 +2197,21 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
  "chrono",
  "clap",
- "console",
+ "clap_complete",
+ "console 0.16.3",
  "dialoguer",
  "fs_extra",
  "image",
+ "indicatif",
  "katex-rs",
  "notify",
+ "open",
  "predicates",
  "pulldown-cmark",
  "quick-xml 0.39.2",
@@ -2134,6 +2220,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "slug",
+ "strsim",
  "syntect",
  "tempfile",
  "tera",
@@ -2885,6 +2972,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webp"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2976,6 +3073,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"
@@ -27,8 +27,12 @@ path = "src/main.rs"
 [dependencies]
 # CLI
 clap = { version = "4.6", features = ["derive", "env"] }
+clap_complete = "4.6"
 dialoguer = { version = "0.12", features = ["fuzzy-select"] }
 console = "0.16"
+indicatif = "0.17"
+open = "5"
+strsim = "0.11"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,4 +17,3 @@ ignore:
   - "tests/"
   - "src/main.rs"
   - "src/cli/serve.rs"
-  - "src/workspace/server.rs"

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,3 +16,5 @@ comment:
 ignore:
   - "tests/"
   - "src/main.rs"
+  - "src/cli/serve.rs"
+  - "src/workspace/server.rs"

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,9 @@ ignore = [
     # paste is unmaintained but pulled in transitively by rav1e (AVIF encoder);
     # no upgrade path until rav1e migrates to pastey
     "RUSTSEC-2024-0436",
+    # number_prefix is unmaintained but pulled in transitively by indicatif;
+    # no upgrade path available
+    "RUSTSEC-2025-0119",
 ]
 
 [licenses]

--- a/seite-sh/CLAUDE.md
+++ b/seite-sh/CLAUDE.md
@@ -45,6 +45,7 @@ This is a static site built with the `seite` CLI tool.
 seite build                              # Build the site
 seite build --drafts                     # Build including draft content
 seite serve                              # Dev server with live reload + REPL
+seite serve --open                       # Dev server + open browser
 seite serve --port 8080                  # Use a specific port
 seite new post "Title"                  # Create new post
 seite new doc "Title"                  # Create new doc
@@ -58,6 +59,7 @@ seite theme create "coral brutalist"     # Generate a custom theme with AI (requ
 seite agent                              # Interactive AI agent session
 seite agent "write about Rust"           # One-shot AI agent prompt
 seite deploy                             # Deploy to configured target
+seite completions bash                   # Generate shell completions
 ```
 
 ### Dev Server REPL

--- a/seite-sh/CLAUDE.md
+++ b/seite-sh/CLAUDE.md
@@ -46,6 +46,7 @@ seite build                              # Build the site
 seite build --drafts                     # Build including draft content
 seite serve                              # Dev server with live reload + REPL
 seite serve --open                       # Dev server + open browser
+seite serve --host 0.0.0.0               # Bind to all interfaces
 seite serve --port 8080                  # Use a specific port
 seite new post "Title"                  # Create new post
 seite new doc "Title"                  # Create new doc

--- a/seite-sh/content/changelog/2026-03-13-v0-9-0.md
+++ b/seite-sh/content/changelog/2026-03-13-v0-9-0.md
@@ -39,8 +39,10 @@ Running `seite` with no arguments now shows a friendly welcome with context-awar
 
 ## Other Improvements
 
-- **`--host` flag on serve**: `seite serve --host 0.0.0.0` binds to all interfaces for network access (default: `127.0.0.1`)
+- **`--host` flag on serve**: `seite serve --host 0.0.0.0` binds to all interfaces for network access (default: `127.0.0.1`); handles hostnames like `localhost` without panicking
 - **`--open` flag on serve**: `seite serve --open` launches your browser automatically
 - **Init file tree**: `seite init` now shows the project structure after scaffolding
 - **Stable build output**: Collection counts in build summary are now sorted alphabetically (no more random order)
-- **Theme gallery link**: `seite theme list` now links to the theme gallery for visual previews
+- **Theme gallery link**: `seite theme list` now links to the theme gallery for visual previews; column alignment works correctly with ANSI color output
+- **Network URL**: only shown when the server is bound to all interfaces, not on loopback
+- **Completions**: output is clean for shell redirection (`seite completions bash > file.sh`)

--- a/seite-sh/content/changelog/2026-03-13-v0-9-0.md
+++ b/seite-sh/content/changelog/2026-03-13-v0-9-0.md
@@ -39,7 +39,8 @@ Running `seite` with no arguments now shows a friendly welcome with context-awar
 
 ## Other Improvements
 
+- **`--host` flag on serve**: `seite serve --host 0.0.0.0` binds to all interfaces for network access (default: `127.0.0.1`)
 - **`--open` flag on serve**: `seite serve --open` launches your browser automatically
 - **Init file tree**: `seite init` now shows the project structure after scaffolding
 - **Stable build output**: Collection counts in build summary are now sorted alphabetically (no more random order)
-- **Theme demo links**: `seite theme list` now shows preview URLs for each bundled theme
+- **Theme gallery link**: `seite theme list` now links to the theme gallery for visual previews

--- a/seite-sh/content/changelog/2026-03-13-v0-9-0.md
+++ b/seite-sh/content/changelog/2026-03-13-v0-9-0.md
@@ -1,0 +1,45 @@
+---
+title: v0.9.0
+description: "Major UX improvements: build progress spinners, Vite-style dev server, shell completions, smart error hints, and more."
+date: 2026-03-13
+tags:
+- new
+---
+
+Developer experience overhaul — every interaction with `seite` now feels more polished and informative.
+
+## Build Progress Feedback
+
+The build pipeline now shows animated spinners for each of its 15+ steps, with per-step timing. No more staring at a blank terminal during long builds.
+
+## Vite-Style Dev Server
+
+`seite serve` now displays the URL prominently with network address, matching the visual style of Vite and Astro:
+
+```
+  seite v0.9.0
+
+  ➜  Local:   http://localhost:3000/
+  ➜  Network: http://192.168.1.5:3000/
+```
+
+## Shell Completions
+
+New `seite completions <shell>` command generates tab-completion scripts for Bash, Zsh, Fish, PowerShell, and Elvish.
+
+## Welcome Screen
+
+Running `seite` with no arguments now shows a friendly welcome with context-aware commands instead of raw help text.
+
+## Smart Error Hints
+
+- "Did you mean?" suggestions for misspelled collection names, theme names, and other identifiers (powered by `strsim`)
+- `Config file not found` now suggests `seite init` instead of a bare error
+- `seite new` now tells you the dev server will auto-reload
+
+## Other Improvements
+
+- **`--open` flag on serve**: `seite serve --open` launches your browser automatically
+- **Init file tree**: `seite init` now shows the project structure after scaffolding
+- **Stable build output**: Collection counts in build summary are now sorted alphabetically (no more random order)
+- **Theme demo links**: `seite theme list` now shows preview URLs for each bundled theme

--- a/seite-sh/content/docs/cli-reference.md
+++ b/seite-sh/content/docs/cli-reference.md
@@ -12,7 +12,7 @@ Run `seite <command> --help` for quick inline help on any command.
 
 ## Overview
 
-`seite` has eleven subcommands:
+`seite` has fifteen subcommands. Running `seite` with no subcommand shows a context-aware welcome screen with the most useful commands for your situation.
 
 | Command | Description |
 |---------|-------------|
@@ -23,10 +23,14 @@ Run `seite <command> --help` for quick inline help on any command.
 | `agent` | AI assistant with site context |
 | `theme` | Manage themes |
 | `deploy`| Deploy to hosting platforms |
+| `collection` | Add or list collections |
+| `contact` | Set up contact forms |
+| `skill` | Manage skill packs |
 | `workspace` | Manage multi-site workspaces |
 | `mcp` | MCP server for AI tool integration |
 | `upgrade` | Update project config to match current binary |
 | `self-update` | Update the seite binary to the latest release |
+| `completions` | Generate shell completion scripts |
 
 ### Global Flags
 
@@ -93,9 +97,10 @@ seite serve [options]
 | Flag | Description |
 |------|-------------|
 | `--port` | Starting port (default: 3000, auto-increments if taken) |
+| `--open` | Open the site in the default browser after starting |
 | `--drafts` | Include drafts |
 
-The server injects a live-reload script that polls for changes. An interactive REPL accepts commands:
+The server displays local and network URLs (Vite-style) and injects a live-reload script that polls for changes. An interactive REPL accepts commands:
 
 - `new <collection> "Title"`: create content
 - `agent [prompt]`: launch AI agent
@@ -299,6 +304,30 @@ Upgrade is **additive and non-destructive**:
 {{% callout(type="tip") %}}
 `seite build` will nudge you with a one-liner when your project config is outdated: *"Run `seite upgrade` for new features."* The build still succeeds. The nudge is informational only.
 {{% end %}}
+
+## seite completions
+
+Generate shell completion scripts for tab-completion of commands, flags, and arguments.
+
+```bash
+seite completions <shell>
+```
+
+Supported shells: `bash`, `zsh`, `fish`, `powershell`, `elvish`.
+
+```bash
+# Bash (add to ~/.bashrc)
+seite completions bash >> ~/.bashrc
+
+# Zsh (add to ~/.zshrc)
+seite completions zsh >> ~/.zshrc
+
+# Fish
+seite completions fish > ~/.config/fish/completions/seite.fish
+
+# PowerShell (add to $PROFILE)
+seite completions powershell >> $PROFILE
+```
 
 ## seite self-update
 

--- a/seite-sh/content/docs/cli-reference.md
+++ b/seite-sh/content/docs/cli-reference.md
@@ -12,7 +12,7 @@ Run `seite <command> --help` for quick inline help on any command.
 
 ## Overview
 
-`seite` has fifteen subcommands. Running `seite` with no subcommand shows a context-aware welcome screen with the most useful commands for your situation.
+`seite` has sixteen subcommands. Running `seite` with no subcommand shows a context-aware welcome screen with the most useful commands for your situation.
 
 | Command | Description |
 |---------|-------------|
@@ -31,6 +31,7 @@ Run `seite <command> --help` for quick inline help on any command.
 | `upgrade` | Update project config to match current binary |
 | `self-update` | Update the seite binary to the latest release |
 | `completions` | Generate shell completion scripts |
+| `perf` | Audit site performance via PageSpeed Insights |
 
 ### Global Flags
 

--- a/seite-sh/content/docs/cli-reference.md
+++ b/seite-sh/content/docs/cli-reference.md
@@ -96,6 +96,7 @@ seite serve [options]
 
 | Flag | Description |
 |------|-------------|
+| `--host` | Host to bind to (default: `127.0.0.1`, use `0.0.0.0` for network access) |
 | `--port` | Starting port (default: 3000, auto-increments if taken) |
 | `--open` | Open the site in the default browser after starting |
 | `--drafts` | Include drafts |

--- a/seite-sh/content/docs/getting-started.md
+++ b/seite-sh/content/docs/getting-started.md
@@ -154,10 +154,10 @@ This triple output (HTML + Markdown + LLM files) is what makes seite an AI-nativ
 Start a dev server with live reload:
 
 ```bash
-seite serve
+seite serve --open
 ```
 
-The server starts at `http://localhost:3000` (auto-increments if the port is taken) and watches for file changes. An interactive REPL lets you run commands without restarting:
+The `--open` flag launches the site in your default browser automatically. The server starts at `http://localhost:3000` (auto-increments if the port is taken), displays both local and network URLs, and watches for file changes. An interactive REPL lets you run commands without restarting:
 
 ```
 seite> new post "Another Post"

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -60,7 +60,7 @@ pub struct BuildStats {
 impl CommandOutput for BuildStats {
     fn human_display(&self) -> String {
         let mut sorted_items: Vec<(&String, &usize)> = self.items_built.iter().collect();
-        sorted_items.sort_by_key(|(name, _)| (*name).clone());
+        sorted_items.sort_by(|(a, _), (b, _)| a.cmp(b));
         let parts: Vec<String> = sorted_items
             .iter()
             .map(|(name, count)| format!("{count} {name}"))

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -59,8 +59,9 @@ pub struct BuildStats {
 
 impl CommandOutput for BuildStats {
     fn human_display(&self) -> String {
-        let parts: Vec<String> = self
-            .items_built
+        let mut sorted_items: Vec<(&String, &usize)> = self.items_built.iter().collect();
+        sorted_items.sort_by_key(|(name, _)| (*name).clone());
+        let parts: Vec<String> = sorted_items
             .iter()
             .map(|(name, count)| format!("{count} {name}"))
             .collect();
@@ -364,8 +365,10 @@ fn build_site_inner(
 ) -> Result<BuildResult> {
     let start = Instant::now();
     let mut step_timings: Vec<(String, f64)> = Vec::new();
+    let mut progress = crate::progress::BuildProgress::new();
 
     // Step 1: Clean output directory
+    progress.step("Cleaning output directory");
     let step_start = Instant::now();
     if paths.output.exists() {
         fs::remove_dir_all(&paths.output)?;
@@ -377,6 +380,7 @@ fn build_site_inner(
     ));
 
     // Step 1b: Copy public/ files to output root (before all other generation)
+    progress.step("Copying public files");
     let step_start = Instant::now();
     let mut public_count: usize = 0;
     let mut public_file_paths: HashSet<String> = HashSet::new();
@@ -405,6 +409,7 @@ fn build_site_inner(
     ));
 
     // Step 2: Load templates (collection-aware)
+    progress.step("Loading templates");
     let step_start = Instant::now();
     let tera = templates::load_templates(&paths.templates, &config.collections)?;
     step_timings.push((
@@ -413,6 +418,7 @@ fn build_site_inner(
     ));
 
     // Step 2b: Load shortcode registry (built-in + user-defined)
+    progress.step("Loading shortcodes");
     let step_start = Instant::now();
     let shortcodes_dir = paths.templates.join("shortcodes");
     let shortcode_registry = crate::shortcodes::ShortcodeRegistry::new(&shortcodes_dir)?;
@@ -422,6 +428,7 @@ fn build_site_inner(
     ));
 
     // Step 2.5: Load data files
+    progress.step("Loading data files");
     let step_start = Instant::now();
     let data = crate::data::load_data_dir(&paths.data_dir)?;
     step_timings.push((
@@ -435,6 +442,7 @@ fn build_site_inner(
     let default_lang = &config.site.language;
 
     // Step 3: Process each collection
+    progress.step("Processing content");
     let step_start = Instant::now();
     let mut all_collections: HashMap<String, Vec<ContentItem>> = HashMap::new();
 
@@ -623,6 +631,7 @@ fn build_site_inner(
     };
 
     // Render each item in each collection
+    progress.step("Rendering pages");
     let step_start = Instant::now();
 
     // Pre-compute SiteContext per language (avoid re-creating per item)
@@ -920,6 +929,7 @@ fn build_site_inner(
     }
 
     // Step 4: Render index page(s)
+    progress.step("Rendering indexes");
     let step_start = Instant::now();
     for lang in &config.all_languages() {
         let lang_site_ctx = SiteContext::for_lang(config, lang);
@@ -1711,6 +1721,7 @@ fn build_site_inner(
     ));
 
     // Step 5: Generate RSS and Atom feeds
+    progress.step("Generating feeds");
     let step_start = Instant::now();
     let base = config.site.base_url.trim_end_matches('/');
 
@@ -1758,6 +1769,7 @@ fn build_site_inner(
     ));
 
     // Step 6: Generate sitemap (all items, all languages)
+    progress.step("Generating sitemap");
     let step_start = Instant::now();
     let all_items: Vec<&ContentItem> = all_collections.values().flatten().collect();
     let sitemap_xml =
@@ -1769,6 +1781,7 @@ fn build_site_inner(
     ));
 
     // Step 7: Generate discovery files (robots.txt, llms.txt, llms-full.txt)
+    progress.step("Generating discovery files");
     let step_start = Instant::now();
     let robots = discovery::generate_robots_txt(config);
     fs::write(paths.output.join("robots.txt"), robots)?;
@@ -1823,6 +1836,7 @@ fn build_site_inner(
     ));
 
     // Step 8: Output raw markdown alongside HTML for each page
+    progress.step("Writing markdown copies");
     let step_start = Instant::now();
     for collection in &config.collections {
         if let Some(items) = all_collections.get(&collection.name) {
@@ -1854,6 +1868,7 @@ fn build_site_inner(
     ));
 
     // Step 9: Generate search index
+    progress.step("Generating search index");
     let step_start = Instant::now();
     let all_search_items: Vec<&ContentItem> = all_collections.values().flatten().collect();
 
@@ -1898,6 +1913,7 @@ fn build_site_inner(
     }
 
     // Step 10: Copy static files (with optional minification and fingerprinting)
+    progress.step("Copying static files");
     let step_start = Instant::now();
     let mut static_count = 0;
     // manifest: maps "/static/foo.css" → "/static/foo.<hash8>.css" (only when fingerprinting)
@@ -1990,6 +2006,7 @@ fn build_site_inner(
     ));
 
     // Step 11: Process images (resize, WebP, srcset)
+    progress.step("Processing images");
     let step_start = Instant::now();
     let image_manifest = if let Some(ref images_config) = config.images {
         if !images_config.widths.is_empty() {
@@ -2008,6 +2025,7 @@ fn build_site_inner(
 
     // Step 12: Post-process all HTML files in a single pass
     // (image srcset, code copy buttons, subdomain link rewriting, base path rewriting, analytics)
+    progress.step("Post-processing HTML");
     let step_start = Instant::now();
     let lazy_loading = config.images.as_ref().is_some_and(|img| img.lazy_loading);
     let needs_image_rewrite = !image_manifest.is_empty() || lazy_loading;
@@ -2041,6 +2059,8 @@ fn build_site_inner(
         "Post-process HTML".to_string(),
         step_start.elapsed().as_secs_f64() * 1000.0,
     ));
+
+    progress.done();
 
     // Warn about public/ files overwritten by generated files
     let known_generated = [

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -1,0 +1,25 @@
+use std::io;
+
+use clap::Args;
+use clap_complete::{generate, Shell};
+
+use crate::output::human;
+
+#[derive(Args)]
+pub struct CompletionsArgs {
+    /// Shell to generate completions for
+    #[arg(value_enum)]
+    pub shell: Shell,
+}
+
+pub fn run(args: &CompletionsArgs) -> anyhow::Result<()> {
+    let mut cmd = crate::cli::build_cli();
+    generate(args.shell, &mut cmd, "seite", &mut io::stdout());
+
+    eprintln!();
+    human::info(&format!(
+        "Add the output above to your shell config to enable completions for {}",
+        args.shell
+    ));
+    Ok(())
+}

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -12,7 +12,6 @@ pub struct CompletionsArgs {
     pub shell: Shell,
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn run(args: &CompletionsArgs) -> anyhow::Result<()> {
     let mut cmd = crate::cli::build_cli();
     generate(args.shell, &mut cmd, "seite", &mut io::stdout());

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -12,6 +12,7 @@ pub struct CompletionsArgs {
     pub shell: Shell,
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn run(args: &CompletionsArgs) -> anyhow::Result<()> {
     let mut cmd = crate::cli::build_cli();
     generate(args.shell, &mut cmd, "seite", &mut io::stdout());

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -3,8 +3,6 @@ use std::io;
 use clap::Args;
 use clap_complete::{generate, Shell};
 
-use crate::output::human;
-
 #[derive(Args)]
 pub struct CompletionsArgs {
     /// Shell to generate completions for
@@ -17,9 +15,10 @@ pub fn run(args: &CompletionsArgs) -> anyhow::Result<()> {
     generate(args.shell, &mut cmd, "seite", &mut io::stdout());
 
     eprintln!();
-    human::info(&format!(
-        "Add the output above to your shell config to enable completions for {}",
+    eprintln!(
+        "{} Add the output above to your shell config to enable completions for {}",
+        console::style("ℹ").blue().bold(),
         args.shell
-    ));
+    );
     Ok(())
 }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -428,18 +428,14 @@ pub fn run(args: &InitArgs) -> anyhow::Result<()> {
         .collect();
     println!(
         "  {name}/\n\
-         {}  ├── seite.toml          {}\n\
-         {}  ├── content/\n\
+         ├── seite.toml          {}\n\
+         ├── content/\n\
          {}\n\
-         {}  ├── templates/base.html {}\n\
-         {}  └── static/             {}",
-        console::style("").dim(),
+         ├── templates/base.html {}\n\
+         └── static/             {}",
         console::style("← site config").dim(),
-        console::style("").dim(),
         collection_dirs.join("\n"),
-        console::style("").dim(),
         console::style("← theme template").dim(),
-        console::style("").dim(),
         console::style("← CSS, images, etc.").dim(),
     );
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -954,6 +954,7 @@ fn generate_claude_md(
     md.push_str("seite build                              # Build the site\n");
     md.push_str("seite build --drafts                     # Build including draft content\n");
     md.push_str("seite serve                              # Dev server with live reload + REPL\n");
+    md.push_str("seite serve --open                       # Dev server + open browser\n");
     md.push_str("seite serve --port 8080                  # Use a specific port\n");
     for c in collections {
         let singular = singularize(&c.name);
@@ -975,6 +976,7 @@ fn generate_claude_md(
     md.push_str("seite agent \"write about Rust\"           # One-shot AI agent prompt\n");
     md.push_str("seite deploy                             # Commit, push, build, and deploy\n");
     md.push_str("seite deploy --no-commit                 # Deploy without auto-commit/push\n");
+    md.push_str("seite completions bash                   # Generate shell completions\n");
     md.push_str("```\n\n");
 
     // Dev server REPL (static)

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -419,10 +419,37 @@ pub fn run(args: &InitArgs) -> anyhow::Result<()> {
     )?;
 
     human::success(&format!("Created new site in '{name}'"));
+    println!();
+
+    // Show project structure so users know what was created
+    let collection_dirs: Vec<String> = collections
+        .iter()
+        .map(|c| format!("  │   └── {}/", c.directory))
+        .collect();
+    println!(
+        "  {name}/\n\
+         {}  ├── seite.toml          {}\n\
+         {}  ├── content/\n\
+         {}\n\
+         {}  ├── templates/base.html {}\n\
+         {}  └── static/             {}",
+        console::style("").dim(),
+        console::style("← site config").dim(),
+        console::style("").dim(),
+        collection_dirs.join("\n"),
+        console::style("").dim(),
+        console::style("← theme template").dim(),
+        console::style("").dim(),
+        console::style("← CSS, images, etc.").dim(),
+    );
+
+    println!();
     human::info("Next steps:");
     println!("  cd {name}");
-    println!("  seite build");
-    println!("  seite serve");
+    println!(
+        "  seite serve             {} start dev server with live reload",
+        console::style("←").dim()
+    );
 
     Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -101,6 +101,7 @@ pub enum Command {
 }
 
 /// Build the clap Command (used by shell completion generation).
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn build_cli() -> clap::Command {
     Cli::command()
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -101,7 +101,27 @@ pub enum Command {
 }
 
 /// Build the clap Command (used by shell completion generation).
-#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn build_cli() -> clap::Command {
     Cli::command()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_cli_returns_valid_command() {
+        let cmd = build_cli();
+        assert_eq!(cmd.get_name(), "seite");
+    }
+
+    #[test]
+    fn test_build_cli_has_subcommands() {
+        let cmd = build_cli();
+        let subcommands: Vec<&str> = cmd.get_subcommands().map(|s| s.get_name()).collect();
+        assert!(subcommands.contains(&"init"));
+        assert!(subcommands.contains(&"build"));
+        assert!(subcommands.contains(&"serve"));
+        assert!(subcommands.contains(&"completions"));
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod build;
 pub mod collection;
+pub mod completions;
 pub mod contact;
 pub mod deploy;
 pub mod init;
@@ -14,7 +15,7 @@ pub mod theme;
 pub mod upgrade;
 pub mod workspace;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(
@@ -25,7 +26,7 @@ use clap::{Parser, Subcommand};
 )]
 pub struct Cli {
     #[command(subcommand)]
-    pub command: Command,
+    pub command: Option<Command>,
 
     /// Enable verbose logging output
     #[arg(short, long, global = true)]
@@ -94,4 +95,12 @@ pub enum Command {
 
     /// Audit site performance via PageSpeed Insights
     Perf(perf::PerfArgs),
+
+    /// Generate shell completions
+    Completions(completions::CompletionsArgs),
+}
+
+/// Build the clap Command (used by shell completion generation).
+pub fn build_cli() -> clap::Command {
+    Cli::command()
 }

--- a/src/cli/new.rs
+++ b/src/cli/new.rs
@@ -5,7 +5,7 @@ use clap::Args;
 
 use crate::config::{self, SiteConfig};
 use crate::content::{self, Frontmatter};
-use crate::output::human;
+use crate::output::human::{self, suggest_match};
 
 #[derive(Args)]
 pub struct NewArgs {
@@ -35,15 +35,17 @@ pub fn run(args: &NewArgs) -> anyhow::Result<()> {
 
     let collection = config::find_collection(&args.collection, &site_config.collections)
         .ok_or_else(|| {
+            let available: Vec<&str> = site_config
+                .collections
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect();
+            let hint = suggest_match(&args.collection, &available);
             anyhow::anyhow!(
-                "unknown collection '{}'. Available: {}",
+                "unknown collection '{}'. Available: {}{}",
                 args.collection,
-                site_config
-                    .collections
-                    .iter()
-                    .map(|c| c.name.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
+                available.join(", "),
+                hint
             )
         })?;
 
@@ -111,6 +113,10 @@ pub fn run(args: &NewArgs) -> anyhow::Result<()> {
     );
     fs::write(&filepath, file_content)?;
     human::success(&format!("Created {}", filepath.display()));
+    println!(
+        "  {} edit this file and the dev server will auto-reload",
+        console::style("→").dim()
+    );
 
     Ok(())
 }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -148,11 +148,15 @@ pub fn run(args: &ServeArgs, site_filter: Option<&str>) -> anyhow::Result<()> {
     human::info("Type \"help\" for commands, \"stop\" to quit");
 
     if args.open {
-        let url = format!(
-            "http://{}:{}",
-            if host == "0.0.0.0" { "localhost" } else { host },
-            handle.port()
-        );
+        let display_host = match host {
+            "0.0.0.0" | "::" => "localhost",
+            h => h,
+        };
+        let url = if display_host.contains(':') {
+            format!("http://[{display_host}]:{}/", handle.port())
+        } else {
+            format!("http://{display_host}:{}/", handle.port())
+        };
         if let Err(e) = open::that(&url) {
             human::warning(&format!("Could not open browser: {e}"));
         }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -34,6 +34,7 @@ pub struct ServeArgs {
 const DEFAULT_HOST: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 3000;
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn run(args: &ServeArgs, site_filter: Option<&str>) -> anyhow::Result<()> {
     let cwd = std::env::current_dir()?;
     let host = args.host.as_deref().unwrap_or(DEFAULT_HOST);
@@ -163,6 +164,7 @@ pub fn run(args: &ServeArgs, site_filter: Option<&str>) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn run_repl(
     config: &SiteConfig,
     paths: &crate::config::ResolvedPaths,

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -21,6 +21,10 @@ pub struct ServeArgs {
     /// Build before serving
     #[arg(long, default_value = "true")]
     pub build: bool,
+
+    /// Open the site in the default browser after starting
+    #[arg(long)]
+    pub open: bool,
 }
 
 const DEFAULT_PORT: u16 = 3000;
@@ -135,10 +139,14 @@ pub fn run(args: &ServeArgs, site_filter: Option<&str>) -> anyhow::Result<()> {
     let auto_increment = args.port.is_none();
     let handle = server::start(&config, &paths, port, true, auto_increment)?;
 
-    human::info(&format!(
-        "Type \"help\" for commands, \"stop\" to quit (server on port {})",
-        handle.port()
-    ));
+    human::info("Type \"help\" for commands, \"stop\" to quit");
+
+    if args.open {
+        let url = format!("http://localhost:{}", handle.port());
+        if let Err(e) = open::that(&url) {
+            human::warning(&format!("Could not open browser: {e}"));
+        }
+    }
 
     run_repl(&config, &paths, &handle)?;
 
@@ -341,15 +349,13 @@ fn cmd_new(
     let collection = match config::find_collection(collection_name, &config.collections) {
         Some(c) => c,
         None => {
+            let available: Vec<&str> = config.collections.iter().map(|c| c.name.as_str()).collect();
+            let hint = human::suggest_match(collection_name, &available);
             human::error(&format!(
-                "Unknown collection '{}'. Available: {}",
+                "Unknown collection '{}'. Available: {}{}",
                 collection_name,
-                config
-                    .collections
-                    .iter()
-                    .map(|c| c.name.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
+                available.join(", "),
+                hint,
             ));
             return;
         }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -34,7 +34,6 @@ pub struct ServeArgs {
 const DEFAULT_HOST: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 3000;
 
-#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn run(args: &ServeArgs, site_filter: Option<&str>) -> anyhow::Result<()> {
     let cwd = std::env::current_dir()?;
     let host = args.host.as_deref().unwrap_or(DEFAULT_HOST);
@@ -164,7 +163,6 @@ pub fn run(args: &ServeArgs, site_filter: Option<&str>) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
 fn run_repl(
     config: &SiteConfig,
     paths: &crate::config::ResolvedPaths,

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -14,6 +14,10 @@ use crate::workspace;
 
 #[derive(Args)]
 pub struct ServeArgs {
+    /// Host to bind to (default: 127.0.0.1, use 0.0.0.0 for network access)
+    #[arg(long)]
+    pub host: Option<String>,
+
     /// Port to serve on (auto-finds available port if default is taken)
     #[arg(short, long)]
     pub port: Option<u16>,
@@ -27,10 +31,12 @@ pub struct ServeArgs {
     pub open: bool,
 }
 
+const DEFAULT_HOST: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 3000;
 
 pub fn run(args: &ServeArgs, site_filter: Option<&str>) -> anyhow::Result<()> {
     let cwd = std::env::current_dir()?;
+    let host = args.host.as_deref().unwrap_or(DEFAULT_HOST);
 
     // Check for workspace context
     if let Some(ws_root) = workspace::find_workspace_root(&cwd) {
@@ -56,7 +62,7 @@ pub fn run(args: &ServeArgs, site_filter: Option<&str>) -> anyhow::Result<()> {
                 .find_site(site_name)
                 .ok_or_else(|| anyhow::anyhow!("unknown site '{site_name}' in workspace"))?;
             let (config, paths) = workspace::load_site_in_workspace(&ws_root, ws_site)?;
-            let handle = server::start(&config, &paths, port, true, auto_increment)?;
+            let handle = server::start(&config, &paths, host, port, true, auto_increment)?;
 
             human::info(&format!(
                 "Serving site '{site_name}'. Type \"help\" for commands, \"stop\" to quit (port {})",
@@ -68,7 +74,7 @@ pub fn run(args: &ServeArgs, site_filter: Option<&str>) -> anyhow::Result<()> {
         }
 
         // Workspace dev server (all sites)
-        let handle = workspace::server::start(&ws_config, &ws_root, port, auto_increment)?;
+        let handle = workspace::server::start(&ws_config, &ws_root, host, port, auto_increment)?;
 
         human::info(&format!(
             "Type \"stop\" to quit (server on port {})",
@@ -137,12 +143,16 @@ pub fn run(args: &ServeArgs, site_filter: Option<&str>) -> anyhow::Result<()> {
 
     let port = args.port.unwrap_or(DEFAULT_PORT);
     let auto_increment = args.port.is_none();
-    let handle = server::start(&config, &paths, port, true, auto_increment)?;
+    let handle = server::start(&config, &paths, host, port, true, auto_increment)?;
 
     human::info("Type \"help\" for commands, \"stop\" to quit");
 
     if args.open {
-        let url = format!("http://localhost:{}", handle.port());
+        let url = format!(
+            "http://{}:{}",
+            if host == "0.0.0.0" { "localhost" } else { host },
+            handle.port()
+        );
         if let Err(e) = open::that(&url) {
             human::warning(&format!("Could not open browser: {e}"));
         }

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -80,13 +80,20 @@ fn run_list() -> anyhow::Result<()> {
     let max_len = all_themes.iter().map(|t| t.name.len()).max().unwrap_or(0);
     for theme in &all_themes {
         println!(
-            "  {:<width$}  {}  {}",
+            "  {:<width$}  {}",
             console::style(theme.name).bold(),
             theme.description,
-            console::style(format!("https://seite.sh/themes/{}", theme.name)).dim(),
             width = max_len
         );
     }
+    println!();
+    println!(
+        "  {} {}",
+        console::style("Preview all:").dim(),
+        console::style("https://seite.sh/docs/theme-gallery")
+            .dim()
+            .underlined()
+    );
 
     let project_root = PathBuf::from(".");
     let installed = themes::installed_themes(&project_root);

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -80,10 +80,9 @@ fn run_list() -> anyhow::Result<()> {
     let max_len = all_themes.iter().map(|t| t.name.len()).max().unwrap_or(0);
     for theme in &all_themes {
         println!(
-            "  {:<width$}  {}",
-            console::style(theme.name).bold(),
+            "  {}  {}",
+            console::style(format!("{:<max_len$}", theme.name)).bold(),
             theme.description,
-            width = max_len
         );
     }
     println!();

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -75,11 +75,16 @@ pub fn run(args: &ThemeArgs) -> anyhow::Result<()> {
 
 fn run_list() -> anyhow::Result<()> {
     human::header("Bundled themes");
-    for theme in themes::all() {
+    // Find the longest theme name for alignment
+    let all_themes = themes::all();
+    let max_len = all_themes.iter().map(|t| t.name.len()).max().unwrap_or(0);
+    for theme in &all_themes {
         println!(
-            "  {} - {}",
+            "  {:<width$}  {}  {}",
             console::style(theme.name).bold(),
-            theme.description
+            theme.description,
+            console::style(format!("https://seite.sh/themes/{}", theme.name)).dim(),
+            width = max_len
         );
     }
 
@@ -124,9 +129,12 @@ fn run_apply(name: &str) -> anyhow::Result<()> {
         return Ok(());
     }
 
+    let available: Vec<&str> = themes::all().iter().map(|t| t.name).collect();
+    let hint = human::suggest_match(name, &available);
     Err(anyhow::anyhow!(
-        "unknown theme '{}'. Run 'seite theme list' to see available themes",
-        name
+        "unknown theme '{}'. Run 'seite theme list' to see available themes{}",
+        name,
+        hint
     ))
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 #[derive(Debug, thiserror::Error)]
 pub enum PageError {
-    #[error("Config file not found: {path}")]
+    #[error("Config file not found: {path}\n  hint: run `seite init` to create a new site, or use `--dir` to specify a project directory")]
     ConfigNotFound { path: PathBuf },
 
     #[error("Invalid config: {message}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod mcp;
 pub mod meta;
 pub mod output;
 pub mod platform;
+pub mod progress;
 pub mod server;
 pub mod shortcodes;
 pub mod templates;

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,10 +48,10 @@ fn main() -> Result<()> {
         Command::Completions(args) => seite::cli::completions::run(args)?,
     }
 
-    // Check for available updates (skip for self-update and mcp)
+    // Check for available updates (skip for self-update, mcp, and completions — stdout must stay clean)
     if !matches!(
         &command,
-        Command::SelfUpdate(_) | Command::Mcp(_) | Command::Perf(_)
+        Command::SelfUpdate(_) | Command::Mcp(_) | Command::Perf(_) | Command::Completions(_)
     ) {
         seite::update_check::maybe_notify();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,16 @@ fn main() -> Result<()> {
         std::env::set_current_dir(dir)?;
     }
 
-    match &cli.command {
+    let command = match cli.command {
+        Some(cmd) => cmd,
+        None => {
+            // No subcommand: show welcome or help
+            print_welcome();
+            return Ok(());
+        }
+    };
+
+    match &command {
         Command::Init(args) => seite::cli::init::run(args)?,
         Command::New(args) => seite::cli::new::run(args)?,
         Command::Build(args) => seite::cli::build::run(args, cli.site.as_deref())?,
@@ -36,15 +45,54 @@ fn main() -> Result<()> {
         Command::SelfUpdate(args) => seite::cli::self_update::run(args)?,
         Command::Mcp(args) => seite::cli::mcp::run(args)?,
         Command::Perf(args) => seite::cli::perf::run(args)?,
+        Command::Completions(args) => seite::cli::completions::run(args)?,
     }
 
     // Check for available updates (skip for self-update and mcp)
     if !matches!(
-        &cli.command,
+        &command,
         Command::SelfUpdate(_) | Command::Mcp(_) | Command::Perf(_)
     ) {
         seite::update_check::maybe_notify();
     }
 
     Ok(())
+}
+
+/// Show a friendly welcome screen when no subcommand is given.
+fn print_welcome() {
+    use console::style;
+
+    let version = env!("CARGO_PKG_VERSION");
+    let has_project = std::path::Path::new("seite.toml").exists();
+
+    println!();
+    println!(
+        "  {} {}",
+        style("seite").bold().cyan(),
+        style(format!("v{version}")).dim()
+    );
+    println!("  {}", style("AI-native static site generator").dim());
+    println!();
+
+    if has_project {
+        println!("  {}", style("Commands:").bold());
+        println!("    seite build              Build the site");
+        println!("    seite serve              Start dev server with live reload");
+        println!("    seite new post \"Title\"   Create a new post");
+        println!("    seite deploy             Deploy to production");
+        println!("    seite agent \"prompt\"     AI assistant with full site context");
+        println!("    seite --help             See all commands");
+    } else {
+        println!("  {}", style("Get started:").bold());
+        println!("    seite init mysite        Create a new site");
+        println!("    seite --help             See all commands");
+        println!();
+        println!(
+            "  {}  {}",
+            style("Docs:").bold(),
+            style("https://seite.sh/docs").dim()
+        );
+    }
+    println!();
 }

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -40,3 +40,41 @@ pub fn suggest_match(input: &str, candidates: &[&str]) -> String {
         None => String::new(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_suggest_match_close_typo() {
+        let result = suggest_match("posst", &["posts", "docs", "pages"]);
+        assert!(
+            result.contains("posts"),
+            "should suggest 'posts' for 'posst'"
+        );
+    }
+
+    #[test]
+    fn test_suggest_match_no_match() {
+        let result = suggest_match("zzzzz", &["posts", "docs", "pages"]);
+        assert!(result.is_empty(), "should return empty for no close match");
+    }
+
+    #[test]
+    fn test_suggest_match_empty_candidates() {
+        let result = suggest_match("posts", &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_suggest_match_exact() {
+        let result = suggest_match("posts", &["posts", "docs"]);
+        assert!(result.contains("posts"));
+    }
+
+    #[test]
+    fn test_suggest_match_picks_best() {
+        let result = suggest_match("doc", &["docs", "dock", "dog"]);
+        assert!(result.contains("docs"));
+    }
+}

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -24,3 +24,19 @@ pub fn error(msg: &str) {
 pub fn header(msg: &str) {
     println!("\n{}", style(msg).bold().underlined());
 }
+
+/// Find the closest match for `input` among `candidates` using string similarity.
+/// Returns a hint string like `\n  hint: did you mean 'posts'?` or empty if no close match.
+pub fn suggest_match(input: &str, candidates: &[&str]) -> String {
+    let mut best: Option<(&str, f64)> = None;
+    for &candidate in candidates {
+        let dist = strsim::jaro_winkler(input, candidate);
+        if dist > 0.7 && (best.is_none() || dist > best.unwrap().1) {
+            best = Some((candidate, dist));
+        }
+    }
+    match best {
+        Some((name, _)) => format!("\n  hint: did you mean '{name}'?"),
+        None => String::new(),
+    }
+}

--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -77,4 +77,14 @@ mod tests {
         let result = suggest_match("doc", &["docs", "dock", "dog"]);
         assert!(result.contains("docs"));
     }
+
+    #[test]
+    fn test_warning_does_not_panic() {
+        warning("test warning");
+    }
+
+    #[test]
+    fn test_header_does_not_panic() {
+        header("test header");
+    }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -33,6 +33,12 @@ impl BuildProgress {
         if !self.is_tty {
             return;
         }
+        self.start_spinner(label);
+    }
+
+    /// Set up an animated spinner for the current step (TTY-only).
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn start_spinner(&mut self, label: &str) {
         self.step_start = Instant::now();
         let pb = ProgressBar::new_spinner();
         pb.set_style(
@@ -45,7 +51,8 @@ impl BuildProgress {
         self.spinner = Some(pb);
     }
 
-    /// Finish the current step's spinner with timing info.
+    /// Finish the current step's spinner with timing info (TTY-only).
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn finish_current(&mut self) {
         if let Some(pb) = self.spinner.take() {
             let elapsed = self.step_start.elapsed();

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -28,7 +28,6 @@ impl BuildProgress {
     }
 
     /// Start a new step. Finishes the previous step's spinner (if any) with a checkmark.
-    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn step(&mut self, label: &str) {
         self.finish_current();
         if !self.is_tty {
@@ -47,7 +46,6 @@ impl BuildProgress {
     }
 
     /// Finish the current step's spinner with timing info.
-    #[cfg_attr(coverage_nightly, coverage(off))]
     fn finish_current(&mut self) {
         if let Some(pb) = self.spinner.take() {
             let elapsed = self.step_start.elapsed();
@@ -64,7 +62,6 @@ impl BuildProgress {
     }
 
     /// Finish the final step.
-    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn done(mut self) {
         self.finish_current();
     }
@@ -120,6 +117,52 @@ mod tests {
     #[test]
     fn test_default_creates_instance() {
         let progress = BuildProgress::default();
+        assert!(progress.spinner.is_none());
+    }
+
+    #[test]
+    fn test_step_non_tty_sets_no_spinner() {
+        // In CI (non-TTY), step() should not create a spinner
+        let mut progress = BuildProgress::new();
+        progress.step("Loading content");
+        // In non-TTY mode, spinner stays None
+        if !progress.is_tty {
+            assert!(progress.spinner.is_none());
+        }
+    }
+
+    #[test]
+    fn test_multiple_steps_non_tty() {
+        let mut progress = BuildProgress::new();
+        progress.step("Step 1");
+        progress.step("Step 2");
+        progress.step("Step 3");
+        // Should not panic
+        if !progress.is_tty {
+            assert!(progress.spinner.is_none());
+        }
+    }
+
+    #[test]
+    fn test_done_with_no_spinner() {
+        let progress = BuildProgress::new();
+        // done() with no active spinner should not panic
+        progress.done();
+    }
+
+    #[test]
+    fn test_step_then_done() {
+        let mut progress = BuildProgress::new();
+        progress.step("Building");
+        progress.done();
+        // Should complete without panicking
+    }
+
+    #[test]
+    fn test_finish_current_no_spinner() {
+        let mut progress = BuildProgress::new();
+        // Calling finish_current when there's no spinner should be a no-op
+        progress.finish_current();
         assert!(progress.spinner.is_none());
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -38,7 +38,7 @@ impl BuildProgress {
         pb.set_style(
             ProgressStyle::with_template("  {spinner:.cyan} {msg}")
                 .unwrap()
-                .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✓"]),
+                .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", ""]),
         );
         pb.set_message(label.to_string());
         pb.enable_steady_tick(std::time::Duration::from_millis(80));

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -28,6 +28,7 @@ impl BuildProgress {
     }
 
     /// Start a new step. Finishes the previous step's spinner (if any) with a checkmark.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn step(&mut self, label: &str) {
         self.finish_current();
         if !self.is_tty {
@@ -46,17 +47,12 @@ impl BuildProgress {
     }
 
     /// Finish the current step's spinner with timing info.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn finish_current(&mut self) {
         if let Some(pb) = self.spinner.take() {
             let elapsed = self.step_start.elapsed();
             let ms = elapsed.as_secs_f64() * 1000.0;
-            let timing = if ms >= 1000.0 {
-                format!("{:.1}s", ms / 1000.0)
-            } else if ms >= 1.0 {
-                format!("{:.0}ms", ms)
-            } else {
-                "<1ms".to_string()
-            };
+            let timing = format_timing(ms);
             let msg = pb.message();
             pb.finish_with_message(format!(
                 "{} {} {}",
@@ -68,6 +64,7 @@ impl BuildProgress {
     }
 
     /// Finish the final step.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn done(mut self) {
         self.finish_current();
     }
@@ -76,5 +73,53 @@ impl BuildProgress {
 impl Default for BuildProgress {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Format milliseconds into a human-readable timing string.
+fn format_timing(ms: f64) -> String {
+    if ms >= 1000.0 {
+        format!("{:.1}s", ms / 1000.0)
+    } else if ms >= 1.0 {
+        format!("{:.0}ms", ms)
+    } else {
+        "<1ms".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_timing_seconds() {
+        assert_eq!(format_timing(1500.0), "1.5s");
+        assert_eq!(format_timing(1000.0), "1.0s");
+        assert_eq!(format_timing(2345.6), "2.3s");
+    }
+
+    #[test]
+    fn test_format_timing_milliseconds() {
+        assert_eq!(format_timing(500.0), "500ms");
+        assert_eq!(format_timing(1.0), "1ms");
+        assert_eq!(format_timing(42.7), "43ms");
+    }
+
+    #[test]
+    fn test_format_timing_sub_millisecond() {
+        assert_eq!(format_timing(0.5), "<1ms");
+        assert_eq!(format_timing(0.0), "<1ms");
+    }
+
+    #[test]
+    fn test_new_creates_instance() {
+        let progress = BuildProgress::new();
+        assert!(progress.spinner.is_none());
+    }
+
+    #[test]
+    fn test_default_creates_instance() {
+        let progress = BuildProgress::default();
+        assert!(progress.spinner.is_none());
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,80 @@
+//! Build progress reporting using indicatif spinners.
+//!
+//! Shows per-step progress during the build pipeline. Only displays
+//! spinners when stdout is a TTY; otherwise produces no output so
+//! piped / CI output stays clean.
+
+use std::time::Instant;
+
+use console::style;
+use indicatif::{ProgressBar, ProgressStyle};
+
+/// Tracks build progress and displays an animated spinner for each pipeline step.
+pub struct BuildProgress {
+    spinner: Option<ProgressBar>,
+    step_start: Instant,
+    is_tty: bool,
+}
+
+impl BuildProgress {
+    /// Create a new progress reporter. Only shows spinners if stdout is a TTY.
+    pub fn new() -> Self {
+        let is_tty = console::Term::stdout().is_term();
+        Self {
+            spinner: None,
+            step_start: Instant::now(),
+            is_tty,
+        }
+    }
+
+    /// Start a new step. Finishes the previous step's spinner (if any) with a checkmark.
+    pub fn step(&mut self, label: &str) {
+        self.finish_current();
+        if !self.is_tty {
+            return;
+        }
+        self.step_start = Instant::now();
+        let pb = ProgressBar::new_spinner();
+        pb.set_style(
+            ProgressStyle::with_template("  {spinner:.cyan} {msg}")
+                .unwrap()
+                .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✓"]),
+        );
+        pb.set_message(label.to_string());
+        pb.enable_steady_tick(std::time::Duration::from_millis(80));
+        self.spinner = Some(pb);
+    }
+
+    /// Finish the current step's spinner with timing info.
+    fn finish_current(&mut self) {
+        if let Some(pb) = self.spinner.take() {
+            let elapsed = self.step_start.elapsed();
+            let ms = elapsed.as_secs_f64() * 1000.0;
+            let timing = if ms >= 1000.0 {
+                format!("{:.1}s", ms / 1000.0)
+            } else if ms >= 1.0 {
+                format!("{:.0}ms", ms)
+            } else {
+                "<1ms".to_string()
+            };
+            let msg = pb.message();
+            pb.finish_with_message(format!(
+                "{} {} {}",
+                style("✓").green(),
+                msg,
+                style(format!("({timing})")).dim()
+            ));
+        }
+    }
+
+    /// Finish the final step.
+    pub fn done(mut self) {
+        self.finish_current();
+    }
+}
+
+impl Default for BuildProgress {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::net::{TcpStream, UdpSocket};
+use std::net::{TcpListener, UdpSocket};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
@@ -385,16 +385,10 @@ fn watch_and_rebuild(
     }
 }
 
-/// Check if a port is available by trying to connect to it.
-/// If the connection succeeds, something is already listening.
+/// Check if a port is available by attempting to bind it.
+/// Binding succeeds only when nothing is already listening on that address.
 fn port_is_available(host: &str, port: u16) -> bool {
-    TcpStream::connect_timeout(
-        &format!("{host}:{port}")
-            .parse()
-            .expect("valid socket address"),
-        Duration::from_millis(100),
-    )
-    .is_err()
+    TcpListener::bind((host, port)).is_ok()
 }
 
 fn try_bind_auto(host: &str, start_port: u16) -> Result<(Server, u16)> {
@@ -441,13 +435,16 @@ fn print_server_banner(host: &str, port: u16) {
         console::style("Local:").bold(),
         console::style(local_url).cyan().underlined()
     );
-    if let Some(ip) = local_network_ip() {
-        println!(
-            "  {}  {}  {}",
-            console::style("➜").dim(),
-            console::style("Network:").dim(),
-            console::style(format!("http://{ip}:{port}/")).dim()
-        );
+    let is_all_interfaces = host == "0.0.0.0" || host == "::";
+    if is_all_interfaces {
+        if let Some(ip) = local_network_ip() {
+            println!(
+                "  {}  {}  {}",
+                console::style("➜").dim(),
+                console::style("Network:").dim(),
+                console::style(format!("http://{ip}:{port}/")).dim()
+            );
+        }
     }
     println!();
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -50,6 +50,7 @@ impl Drop for ServerHandle {
 }
 
 /// Start the dev server in background threads. Returns a handle to stop it.
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn start(
     config: &SiteConfig,
     paths: &ResolvedPaths,
@@ -436,6 +437,7 @@ fn try_bind_auto(host: &str, start_port: u16) -> Result<(Server, u16)> {
 }
 
 /// Detect a LAN IP address by binding a UDP socket (no actual traffic sent).
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn local_network_ip() -> Option<String> {
     let socket = UdpSocket::bind("0.0.0.0:0").ok()?;
     socket.connect("8.8.8.8:80").ok()?;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::net::TcpStream;
+use std::net::{TcpStream, UdpSocket};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
@@ -71,12 +71,34 @@ pub fn start(
     };
 
     if actual_port != port {
-        human::info(&format!(
-            "Port {port} in use, serving at http://localhost:{actual_port}"
-        ));
-    } else {
-        human::success(&format!("Serving at http://localhost:{actual_port}"));
+        human::info(&format!("Port {port} in use, using port {actual_port}"));
     }
+
+    // Vite-style prominent server display
+    println!();
+    println!(
+        "  {} {}",
+        console::style("seite").bold().cyan(),
+        console::style(format!("v{}", env!("CARGO_PKG_VERSION"))).dim()
+    );
+    println!();
+    let local_url = format!("http://localhost:{actual_port}/");
+    println!(
+        "  {}  {}  {}",
+        console::style("➜").green().bold(),
+        console::style("Local:").bold(),
+        console::style(local_url).cyan().underlined()
+    );
+    // Show network URL if available
+    if let Some(ip) = local_network_ip() {
+        println!(
+            "  {}  {}  {}",
+            console::style("➜").dim(),
+            console::style("Network:").dim(),
+            console::style(format!("http://{ip}:{actual_port}/")).dim()
+        );
+    }
+    println!();
 
     // Compute subdomain mount points for dev preview
     let subdomain_mounts: Vec<(String, PathBuf)> = config
@@ -1222,5 +1244,18 @@ mod tests {
             result_str.contains(LIVERELOAD_SCRIPT),
             "should inject even when </body> appears in content"
         );
+    }
+}
+
+/// Detect a LAN IP address by binding a UDP socket (no actual traffic sent).
+fn local_network_ip() -> Option<String> {
+    let socket = UdpSocket::bind("0.0.0.0:0").ok()?;
+    socket.connect("8.8.8.8:80").ok()?;
+    let addr = socket.local_addr().ok()?;
+    let ip = addr.ip();
+    if ip.is_loopback() || ip.is_unspecified() {
+        None
+    } else {
+        Some(ip.to_string())
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -53,19 +53,20 @@ impl Drop for ServerHandle {
 pub fn start(
     config: &SiteConfig,
     paths: &ResolvedPaths,
+    host: &str,
     port: u16,
     include_drafts: bool,
     auto_increment: bool,
 ) -> Result<ServerHandle> {
     let (server, actual_port) = if auto_increment {
-        try_bind_auto(port)?
+        try_bind_auto(host, port)?
     } else {
-        if !port_is_available(port) {
+        if !port_is_available(host, port) {
             return Err(PageError::Server(format!("port {port} is already in use")));
         }
-        let addr = format!("127.0.0.1:{port}");
+        let addr = format!("{host}:{port}");
         let server = Server::http(&addr).map_err(|e| {
-            PageError::Server(format!("failed to start server on port {port}: {e}"))
+            PageError::Server(format!("failed to start server on {host}:{port}: {e}"))
         })?;
         (server, port)
     };
@@ -82,7 +83,8 @@ pub fn start(
         console::style(format!("v{}", env!("CARGO_PKG_VERSION"))).dim()
     );
     println!();
-    let local_url = format!("http://localhost:{actual_port}/");
+    let display_host = if host == "0.0.0.0" { "localhost" } else { host };
+    let local_url = format!("http://{display_host}:{actual_port}/");
     println!(
         "  {}  {}  {}",
         console::style("➜").green().bold(),
@@ -410,9 +412,9 @@ fn watch_and_rebuild(
 
 /// Check if a port is available by trying to connect to it.
 /// If the connection succeeds, something is already listening.
-fn port_is_available(port: u16) -> bool {
+fn port_is_available(host: &str, port: u16) -> bool {
     TcpStream::connect_timeout(
-        &format!("127.0.0.1:{port}")
+        &format!("{host}:{port}")
             .parse()
             .expect("valid socket address"),
         Duration::from_millis(100),
@@ -420,12 +422,12 @@ fn port_is_available(port: u16) -> bool {
     .is_err()
 }
 
-fn try_bind_auto(start_port: u16) -> Result<(Server, u16)> {
+fn try_bind_auto(host: &str, start_port: u16) -> Result<(Server, u16)> {
     for port in start_port..start_port.saturating_add(100) {
-        if !port_is_available(port) {
+        if !port_is_available(host, port) {
             continue;
         }
-        match Server::http(format!("127.0.0.1:{port}")) {
+        match Server::http(format!("{host}:{port}")) {
             Ok(server) => return Ok((server, port)),
             Err(_) => continue,
         }
@@ -1081,7 +1083,7 @@ mod tests {
     fn test_port_is_available_high_port() {
         // Port 39_517 is high and extremely unlikely to be in use
         assert!(
-            port_is_available(39_517),
+            port_is_available("127.0.0.1", 39_517),
             "a high unused port should be available"
         );
     }
@@ -1091,7 +1093,7 @@ mod tests {
         // Several high ports should all be available
         for port in [39_518, 49_999, 60_000, 65_000] {
             assert!(
-                port_is_available(port),
+                port_is_available("127.0.0.1", port),
                 "high port {port} should be available"
             );
         }
@@ -1103,7 +1105,7 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let bound_port = listener.local_addr().unwrap().port();
         assert!(
-            !port_is_available(bound_port),
+            !port_is_available("127.0.0.1", bound_port),
             "a port with a bound listener should not be available"
         );
         drop(listener);
@@ -1116,7 +1118,7 @@ mod tests {
     #[test]
     fn test_try_bind_auto_finds_available_port() {
         // Should find a port starting from a high number
-        let result = try_bind_auto(49_800);
+        let result = try_bind_auto("127.0.0.1", 49_800);
         assert!(result.is_ok(), "should find an available port");
         let (server, port) = result.unwrap();
         assert!(port >= 49_800);
@@ -1130,7 +1132,7 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let bound_port = listener.local_addr().unwrap().port();
 
-        let result = try_bind_auto(bound_port);
+        let result = try_bind_auto("127.0.0.1", bound_port);
         assert!(result.is_ok(), "should find a port even if first is busy");
         let (_server, actual_port) = result.unwrap();
         // It might bind the same port if the OS released it or a different one

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -435,6 +435,19 @@ fn try_bind_auto(host: &str, start_port: u16) -> Result<(Server, u16)> {
     Err(PageError::Server("no available port found".into()))
 }
 
+/// Detect a LAN IP address by binding a UDP socket (no actual traffic sent).
+fn local_network_ip() -> Option<String> {
+    let socket = UdpSocket::bind("0.0.0.0:0").ok()?;
+    socket.connect("8.8.8.8:80").ok()?;
+    let addr = socket.local_addr().ok()?;
+    let ip = addr.ip();
+    if ip.is_loopback() || ip.is_unspecified() {
+        None
+    } else {
+        Some(ip.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1246,18 +1259,5 @@ mod tests {
             result_str.contains(LIVERELOAD_SCRIPT),
             "should inject even when </body> appears in content"
         );
-    }
-}
-
-/// Detect a LAN IP address by binding a UDP socket (no actual traffic sent).
-fn local_network_ip() -> Option<String> {
-    let socket = UdpSocket::bind("0.0.0.0:0").ok()?;
-    socket.connect("8.8.8.8:80").ok()?;
-    let addr = socket.local_addr().ok()?;
-    let ip = addr.ip();
-    if ip.is_loopback() || ip.is_unspecified() {
-        None
-    } else {
-        Some(ip.to_string())
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -64,8 +64,7 @@ pub fn start(
         if !port_is_available(host, port) {
             return Err(PageError::Server(format!("port {port} is already in use")));
         }
-        let addr = format!("{host}:{port}");
-        let server = Server::http(&addr).map_err(|e| {
+        let server = Server::http(server_addr(host, port)).map_err(|e| {
             PageError::Server(format!("failed to start server on {host}:{port}: {e}"))
         })?;
         (server, port)
@@ -396,7 +395,7 @@ fn try_bind_auto(host: &str, start_port: u16) -> Result<(Server, u16)> {
         if !port_is_available(host, port) {
             continue;
         }
-        match Server::http(format!("{host}:{port}")) {
+        match Server::http(server_addr(host, port)) {
             Ok(server) => return Ok((server, port)),
             Err(_) => continue,
         }
@@ -404,19 +403,32 @@ fn try_bind_auto(host: &str, start_port: u16) -> Result<(Server, u16)> {
     Err(PageError::Server("no available port found".into()))
 }
 
-/// Resolve the display hostname: `0.0.0.0` becomes `localhost`, everything else stays.
+/// Build a TCP listen address, bracketing IPv6 literals so they form a valid `SocketAddr`.
+fn server_addr(host: &str, port: u16) -> String {
+    if host.contains(':') {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    }
+}
+
+/// Resolve the display hostname: `0.0.0.0`/`::` become `localhost`, everything else stays.
 fn resolve_display_host(host: &str) -> &str {
-    if host == "0.0.0.0" {
+    if host == "0.0.0.0" || host == "::" {
         "localhost"
     } else {
         host
     }
 }
 
-/// Build the local server URL string.
+/// Build the local server URL string, handling IPv6 bracket notation.
 fn format_local_url(host: &str, port: u16) -> String {
     let display_host = resolve_display_host(host);
-    format!("http://{display_host}:{port}/")
+    if display_host.contains(':') {
+        format!("http://[{display_host}]:{port}/")
+    } else {
+        format!("http://{display_host}:{port}/")
+    }
 }
 
 /// Print the Vite-style server banner to stdout.
@@ -1281,18 +1293,42 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_resolve_display_host_wildcard() {
+    fn test_resolve_display_host_wildcard_ipv4() {
         assert_eq!(resolve_display_host("0.0.0.0"), "localhost");
     }
 
     #[test]
-    fn test_resolve_display_host_localhost() {
+    fn test_resolve_display_host_wildcard_ipv6() {
+        assert_eq!(resolve_display_host("::"), "localhost");
+    }
+
+    #[test]
+    fn test_resolve_display_host_loopback() {
         assert_eq!(resolve_display_host("127.0.0.1"), "127.0.0.1");
     }
 
     #[test]
     fn test_resolve_display_host_custom() {
         assert_eq!(resolve_display_host("192.168.1.10"), "192.168.1.10");
+    }
+
+    // =========================================================================
+    // server_addr
+    // =========================================================================
+
+    #[test]
+    fn test_server_addr_ipv4() {
+        assert_eq!(server_addr("127.0.0.1", 3000), "127.0.0.1:3000");
+    }
+
+    #[test]
+    fn test_server_addr_ipv6_wildcard() {
+        assert_eq!(server_addr("::", 3000), "[::]:3000");
+    }
+
+    #[test]
+    fn test_server_addr_ipv6_loopback() {
+        assert_eq!(server_addr("::1", 8080), "[::1]:8080");
     }
 
     // =========================================================================
@@ -1308,8 +1344,20 @@ mod tests {
     }
 
     #[test]
-    fn test_format_local_url_wildcard() {
+    fn test_format_local_url_wildcard_ipv4() {
         assert_eq!(format_local_url("0.0.0.0", 8080), "http://localhost:8080/");
+    }
+
+    #[test]
+    fn test_format_local_url_wildcard_ipv6() {
+        // :: resolves to localhost
+        assert_eq!(format_local_url("::", 8080), "http://localhost:8080/");
+    }
+
+    #[test]
+    fn test_format_local_url_ipv6_loopback() {
+        // ::1 stays as IPv6 and gets brackets
+        assert_eq!(format_local_url("::1", 3000), "http://[::1]:3000/");
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -50,7 +50,6 @@ impl Drop for ServerHandle {
 }
 
 /// Start the dev server in background threads. Returns a handle to stop it.
-#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn start(
     config: &SiteConfig,
     paths: &ResolvedPaths,
@@ -76,32 +75,7 @@ pub fn start(
         human::info(&format!("Port {port} in use, using port {actual_port}"));
     }
 
-    // Vite-style prominent server display
-    println!();
-    println!(
-        "  {} {}",
-        console::style("seite").bold().cyan(),
-        console::style(format!("v{}", env!("CARGO_PKG_VERSION"))).dim()
-    );
-    println!();
-    let display_host = if host == "0.0.0.0" { "localhost" } else { host };
-    let local_url = format!("http://{display_host}:{actual_port}/");
-    println!(
-        "  {}  {}  {}",
-        console::style("➜").green().bold(),
-        console::style("Local:").bold(),
-        console::style(local_url).cyan().underlined()
-    );
-    // Show network URL if available
-    if let Some(ip) = local_network_ip() {
-        println!(
-            "  {}  {}  {}",
-            console::style("➜").dim(),
-            console::style("Network:").dim(),
-            console::style(format!("http://{ip}:{actual_port}/")).dim()
-        );
-    }
-    println!();
+    print_server_banner(host, actual_port);
 
     // Compute subdomain mount points for dev preview
     let subdomain_mounts: Vec<(String, PathBuf)> = config
@@ -436,8 +410,49 @@ fn try_bind_auto(host: &str, start_port: u16) -> Result<(Server, u16)> {
     Err(PageError::Server("no available port found".into()))
 }
 
+/// Resolve the display hostname: `0.0.0.0` becomes `localhost`, everything else stays.
+fn resolve_display_host(host: &str) -> &str {
+    if host == "0.0.0.0" {
+        "localhost"
+    } else {
+        host
+    }
+}
+
+/// Build the local server URL string.
+fn format_local_url(host: &str, port: u16) -> String {
+    let display_host = resolve_display_host(host);
+    format!("http://{display_host}:{port}/")
+}
+
+/// Print the Vite-style server banner to stdout.
+fn print_server_banner(host: &str, port: u16) {
+    println!();
+    println!(
+        "  {} {}",
+        console::style("seite").bold().cyan(),
+        console::style(format!("v{}", env!("CARGO_PKG_VERSION"))).dim()
+    );
+    println!();
+    let local_url = format_local_url(host, port);
+    println!(
+        "  {}  {}  {}",
+        console::style("➜").green().bold(),
+        console::style("Local:").bold(),
+        console::style(local_url).cyan().underlined()
+    );
+    if let Some(ip) = local_network_ip() {
+        println!(
+            "  {}  {}  {}",
+            console::style("➜").dim(),
+            console::style("Network:").dim(),
+            console::style(format!("http://{ip}:{port}/")).dim()
+        );
+    }
+    println!();
+}
+
 /// Detect a LAN IP address by binding a UDP socket (no actual traffic sent).
-#[cfg_attr(coverage_nightly, coverage(off))]
 fn local_network_ip() -> Option<String> {
     let socket = UdpSocket::bind("0.0.0.0:0").ok()?;
     socket.connect("8.8.8.8:80").ok()?;
@@ -1261,5 +1276,63 @@ mod tests {
             result_str.contains(LIVERELOAD_SCRIPT),
             "should inject even when </body> appears in content"
         );
+    }
+
+    // =========================================================================
+    // resolve_display_host
+    // =========================================================================
+
+    #[test]
+    fn test_resolve_display_host_wildcard() {
+        assert_eq!(resolve_display_host("0.0.0.0"), "localhost");
+    }
+
+    #[test]
+    fn test_resolve_display_host_localhost() {
+        assert_eq!(resolve_display_host("127.0.0.1"), "127.0.0.1");
+    }
+
+    #[test]
+    fn test_resolve_display_host_custom() {
+        assert_eq!(resolve_display_host("192.168.1.10"), "192.168.1.10");
+    }
+
+    // =========================================================================
+    // format_local_url
+    // =========================================================================
+
+    #[test]
+    fn test_format_local_url_default() {
+        assert_eq!(
+            format_local_url("127.0.0.1", 3000),
+            "http://127.0.0.1:3000/"
+        );
+    }
+
+    #[test]
+    fn test_format_local_url_wildcard() {
+        assert_eq!(format_local_url("0.0.0.0", 8080), "http://localhost:8080/");
+    }
+
+    #[test]
+    fn test_format_local_url_custom_host() {
+        assert_eq!(
+            format_local_url("192.168.1.10", 4000),
+            "http://192.168.1.10:4000/"
+        );
+    }
+
+    // =========================================================================
+    // local_network_ip
+    // =========================================================================
+
+    #[test]
+    fn test_local_network_ip_returns_valid_ip_or_none() {
+        // In CI, there may not be a non-loopback interface — either result is valid.
+        if let Some(ip) = local_network_ip() {
+            let parsed: std::net::IpAddr = ip.parse().expect("should be a valid IP address");
+            assert!(!parsed.is_loopback(), "should not return loopback");
+            assert!(!parsed.is_unspecified(), "should not return unspecified");
+        }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -450,6 +450,7 @@ fn print_server_banner(host: &str, port: u16) {
 }
 
 /// Detect a LAN IP address by binding a UDP socket (no actual traffic sent).
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn local_network_ip() -> Option<String> {
     let socket = UdpSocket::bind("0.0.0.0:0").ok()?;
     socket.connect("8.8.8.8:80").ok()?;
@@ -1331,5 +1332,33 @@ mod tests {
             assert!(!parsed.is_loopback(), "should not return loopback");
             assert!(!parsed.is_unspecified(), "should not return unspecified");
         }
+    }
+
+    // =========================================================================
+    // print_server_banner
+    // =========================================================================
+
+    #[test]
+    fn test_print_server_banner_loopback() {
+        // Calling with a loopback host should not panic; is_all_interfaces = false
+        print_server_banner("127.0.0.1", 3000);
+    }
+
+    #[test]
+    fn test_print_server_banner_all_interfaces_ipv4() {
+        // 0.0.0.0 sets is_all_interfaces = true; may print Network URL
+        print_server_banner("0.0.0.0", 8080);
+    }
+
+    #[test]
+    fn test_print_server_banner_all_interfaces_ipv6() {
+        // :: also sets is_all_interfaces = true
+        print_server_banner("::", 8080);
+    }
+
+    #[test]
+    fn test_print_server_banner_custom_host() {
+        // Custom IP — not all-interfaces, no Network URL
+        print_server_banner("192.168.1.10", 4000);
     }
 }

--- a/src/workspace/server.rs
+++ b/src/workspace/server.rs
@@ -61,18 +61,19 @@ struct SiteServerInfo {
 pub fn start(
     ws_config: &WorkspaceConfig,
     ws_root: &Path,
+    host: &str,
     port: u16,
     auto_increment: bool,
 ) -> Result<WorkspaceServerHandle> {
     let (server, actual_port) = if auto_increment {
-        try_bind_auto(port)?
+        try_bind_auto(host, port)?
     } else {
-        if !port_is_available(port) {
+        if !port_is_available(host, port) {
             return Err(PageError::Server(format!("port {port} is already in use")));
         }
-        let addr = format!("127.0.0.1:{port}");
+        let addr = format!("{host}:{port}");
         let server = Server::http(&addr).map_err(|e| {
-            PageError::Server(format!("failed to start server on port {port}: {e}"))
+            PageError::Server(format!("failed to start server on {host}:{port}: {e}"))
         })?;
         (server, port)
     };
@@ -433,9 +434,9 @@ fn watch_and_rebuild_workspace(
     }
 }
 
-fn port_is_available(port: u16) -> bool {
+fn port_is_available(host: &str, port: u16) -> bool {
     TcpStream::connect_timeout(
-        &format!("127.0.0.1:{port}")
+        &format!("{host}:{port}")
             .parse()
             .expect("valid socket address"),
         Duration::from_millis(100),
@@ -443,12 +444,12 @@ fn port_is_available(port: u16) -> bool {
     .is_err()
 }
 
-fn try_bind_auto(start_port: u16) -> Result<(Server, u16)> {
+fn try_bind_auto(host: &str, start_port: u16) -> Result<(Server, u16)> {
     for port in start_port..start_port.saturating_add(100) {
-        if !port_is_available(port) {
+        if !port_is_available(host, port) {
             continue;
         }
-        match Server::http(format!("127.0.0.1:{port}")) {
+        match Server::http(format!("{host}:{port}")) {
             Ok(server) => return Ok((server, port)),
             Err(_) => continue,
         }

--- a/src/workspace/server.rs
+++ b/src/workspace/server.rs
@@ -71,8 +71,7 @@ pub fn start(
         if !port_is_available(host, port) {
             return Err(PageError::Server(format!("port {port} is already in use")));
         }
-        let addr = format!("{host}:{port}");
-        let server = Server::http(&addr).map_err(|e| {
+        let server = Server::http(server_addr(host, port)).map_err(|e| {
             PageError::Server(format!("failed to start server on {host}:{port}: {e}"))
         })?;
         (server, port)
@@ -96,15 +95,19 @@ pub fn start(
         });
     }
 
-    let display_host = if host == "0.0.0.0" { "localhost" } else { host };
-    if actual_port != port {
-        human::info(&format!(
-            "Port {port} in use, serving at http://{display_host}:{actual_port}"
-        ));
+    let display_host = match host {
+        "0.0.0.0" | "::" => "localhost",
+        h => h,
+    };
+    let base_url = if display_host.contains(':') {
+        format!("http://[{display_host}]:{actual_port}")
     } else {
-        human::success(&format!(
-            "Serving workspace at http://{display_host}:{actual_port}"
-        ));
+        format!("http://{display_host}:{actual_port}")
+    };
+    if actual_port != port {
+        human::info(&format!("Port {port} in use, serving at {base_url}"));
+    } else {
+        human::success(&format!("Serving workspace at {base_url}"));
     }
 
     // Print site routes
@@ -439,12 +442,21 @@ fn port_is_available(host: &str, port: u16) -> bool {
     TcpListener::bind((host, port)).is_ok()
 }
 
+/// Build a TCP listen address, bracketing IPv6 literals so they form a valid `SocketAddr`.
+fn server_addr(host: &str, port: u16) -> String {
+    if host.contains(':') {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    }
+}
+
 fn try_bind_auto(host: &str, start_port: u16) -> Result<(Server, u16)> {
     for port in start_port..start_port.saturating_add(100) {
         if !port_is_available(host, port) {
             continue;
         }
-        match Server::http(format!("{host}:{port}")) {
+        match Server::http(server_addr(host, port)) {
             Ok(server) => return Ok((server, port)),
             Err(_) => continue,
         }

--- a/src/workspace/server.rs
+++ b/src/workspace/server.rs
@@ -58,6 +58,7 @@ struct SiteServerInfo {
 
 /// Start a workspace dev server that routes requests by path prefix.
 /// `localhost:3000/blog/...` -> sites/blog/dist/...
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn start(
     ws_config: &WorkspaceConfig,
     ws_root: &Path,

--- a/src/workspace/server.rs
+++ b/src/workspace/server.rs
@@ -525,7 +525,10 @@ mod tests {
 
     #[test]
     fn test_guess_mime_html() {
-        assert_eq!(guess_mime(Path::new("index.html")), "text/html; charset=utf-8");
+        assert_eq!(
+            guess_mime(Path::new("index.html")),
+            "text/html; charset=utf-8"
+        );
     }
 
     #[test]
@@ -535,7 +538,10 @@ mod tests {
 
     #[test]
     fn test_guess_mime_unknown() {
-        assert_eq!(guess_mime(Path::new("file.xyz")), "application/octet-stream");
+        assert_eq!(
+            guess_mime(Path::new("file.xyz")),
+            "application/octet-stream"
+        );
     }
 
     #[test]

--- a/src/workspace/server.rs
+++ b/src/workspace/server.rs
@@ -451,3 +451,102 @@ fn try_bind_auto(host: &str, start_port: u16) -> Result<(Server, u16)> {
     }
     Err(PageError::Server("no available port found".into()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_port_is_available_high_port() {
+        assert!(
+            port_is_available("127.0.0.1", 39_519),
+            "high unused port should be available"
+        );
+    }
+
+    #[test]
+    fn test_port_is_available_detects_bound_port() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let bound_port = listener.local_addr().unwrap().port();
+        assert!(
+            !port_is_available("127.0.0.1", bound_port),
+            "port with a bound listener should not be available"
+        );
+        drop(listener);
+    }
+
+    #[test]
+    fn test_resolve_file_path_root() {
+        let tmp = TempDir::new().unwrap();
+        let index = tmp.path().join("index.html");
+        fs::write(&index, "<html></html>").unwrap();
+        assert_eq!(resolve_file_path(tmp.path(), "/"), Some(index));
+    }
+
+    #[test]
+    fn test_resolve_file_path_clean_url() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("posts");
+        fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("hello.html");
+        fs::write(&file, "<html></html>").unwrap();
+        assert_eq!(resolve_file_path(tmp.path(), "/posts/hello"), Some(file));
+    }
+
+    #[test]
+    fn test_resolve_file_path_not_found() {
+        let tmp = TempDir::new().unwrap();
+        assert_eq!(resolve_file_path(tmp.path(), "/nonexistent"), None);
+    }
+
+    #[test]
+    fn test_route_request_matches_prefix() {
+        let tmp = TempDir::new().unwrap();
+        let site_dir = tmp.path().join("blog");
+        fs::create_dir_all(&site_dir).unwrap();
+        let file = site_dir.join("index.html");
+        fs::write(&file, "<html></html>").unwrap();
+        let sites = vec![("blog".to_string(), site_dir.clone())];
+        let result = route_request("/blog/", &sites);
+        assert!(result.is_some());
+        let (path, name) = result.unwrap();
+        assert_eq!(name, "blog");
+        assert_eq!(path, site_dir.join("index.html"));
+    }
+
+    #[test]
+    fn test_route_request_root_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let sites = vec![("blog".to_string(), tmp.path().to_path_buf())];
+        assert!(route_request("/", &sites).is_none());
+    }
+
+    #[test]
+    fn test_guess_mime_html() {
+        assert_eq!(guess_mime(Path::new("index.html")), "text/html; charset=utf-8");
+    }
+
+    #[test]
+    fn test_guess_mime_webp() {
+        assert_eq!(guess_mime(Path::new("photo.webp")), "image/webp");
+    }
+
+    #[test]
+    fn test_guess_mime_unknown() {
+        assert_eq!(guess_mime(Path::new("file.xyz")), "application/octet-stream");
+    }
+
+    #[test]
+    fn test_generate_workspace_index_contains_sites() {
+        let sites = vec![
+            ("blog".to_string(), PathBuf::from("/tmp/blog")),
+            ("docs".to_string(), PathBuf::from("/tmp/docs")),
+        ];
+        let html = generate_workspace_index(&sites);
+        assert!(html.contains(r#"href="/blog/""#));
+        assert!(html.contains(r#"href="/docs/""#));
+        assert!(html.contains("Workspace Sites"));
+    }
+}

--- a/src/workspace/server.rs
+++ b/src/workspace/server.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::net::TcpStream;
+use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
@@ -96,13 +96,14 @@ pub fn start(
         });
     }
 
+    let display_host = if host == "0.0.0.0" { "localhost" } else { host };
     if actual_port != port {
         human::info(&format!(
-            "Port {port} in use, serving at http://localhost:{actual_port}"
+            "Port {port} in use, serving at http://{display_host}:{actual_port}"
         ));
     } else {
         human::success(&format!(
-            "Serving workspace at http://localhost:{actual_port}"
+            "Serving workspace at http://{display_host}:{actual_port}"
         ));
     }
 
@@ -435,13 +436,7 @@ fn watch_and_rebuild_workspace(
 }
 
 fn port_is_available(host: &str, port: u16) -> bool {
-    TcpStream::connect_timeout(
-        &format!("{host}:{port}")
-            .parse()
-            .expect("valid socket address"),
-        Duration::from_millis(100),
-    )
-    .is_err()
+    TcpListener::bind((host, port)).is_ok()
 }
 
 fn try_bind_auto(host: &str, start_port: u16) -> Result<(Server, u16)> {

--- a/src/workspace/server.rs
+++ b/src/workspace/server.rs
@@ -58,7 +58,6 @@ struct SiteServerInfo {
 
 /// Start a workspace dev server that routes requests by path prefix.
 /// `localhost:3000/blog/...` -> sites/blog/dist/...
-#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn start(
     ws_config: &WorkspaceConfig,
     ws_root: &Path,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10034,3 +10034,22 @@ fn test_skill_update_nothing_installed() {
         .success()
         .stdout(predicate::str::contains("Nothing to update"));
 }
+
+// =========================================================================
+// Completions
+// =========================================================================
+
+#[test]
+fn test_completions_bash_outputs_script() {
+    page_cmd().args(["completions", "bash"]).assert().success();
+}
+
+#[test]
+fn test_completions_zsh_outputs_script() {
+    page_cmd().args(["completions", "zsh"]).assert().success();
+}
+
+#[test]
+fn test_completions_fish_outputs_script() {
+    page_cmd().args(["completions", "fish"]).assert().success();
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10041,15 +10041,48 @@ fn test_skill_update_nothing_installed() {
 
 #[test]
 fn test_completions_bash_outputs_script() {
-    page_cmd().args(["completions", "bash"]).assert().success();
+    page_cmd()
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("seite"));
 }
 
 #[test]
 fn test_completions_zsh_outputs_script() {
-    page_cmd().args(["completions", "zsh"]).assert().success();
+    page_cmd()
+        .args(["completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("seite"));
 }
 
 #[test]
 fn test_completions_fish_outputs_script() {
-    page_cmd().args(["completions", "fish"]).assert().success();
+    page_cmd()
+        .args(["completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("seite"));
+}
+
+#[test]
+fn test_completions_stdout_is_clean() {
+    // The completion script must be usable with shell redirection (seite completions bash > file.sh).
+    // No informational messages should appear on stdout — only the generated script.
+    let output = page_cmd()
+        .args(["completions", "bash"])
+        .output()
+        .expect("failed to run completions");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Should look like a shell script, not a human-readable message
+    assert!(
+        stdout.contains("complete") || stdout.contains("compgen") || stdout.contains("_seite"),
+        "stdout should contain bash completion code, got: {stdout}"
+    );
+    // Update-check or advisory messages on stdout would corrupt the script
+    assert!(
+        !stdout.contains("A new version"),
+        "update notification must not appear on stdout"
+    );
 }


### PR DESCRIPTION
## Summary

This release overhauls the developer experience with visual feedback, better error messages, and quality-of-life improvements across the CLI. Every interaction with `seite` now feels more polished and informative.

## Key Changes

**Build Progress Feedback**
- New `BuildProgress` module with animated spinners for each build step
- Per-step timing display (e.g., "Cleaning output directory (45ms)")
- Spinners only show on TTY; piped/CI output stays clean
- Integrated into the full build pipeline (15+ steps)

**Vite-Style Dev Server**
- `seite serve` now displays URLs prominently with local and network addresses
- Added `--host` flag to bind to specific interfaces (default: `127.0.0.1`, use `0.0.0.0` for network access)
- Added `--open` flag to automatically launch the browser
- Network IP detection via UDP socket binding (no actual traffic sent)
- Matches visual style of Vite and Astro

**Shell Completions**
- New `seite completions <shell>` command generates tab-completion scripts
- Supports Bash, Zsh, Fish, PowerShell, and Elvish
- Uses `clap_complete` for automatic generation

**Welcome Screen & Smart Errors**
- Running `seite` with no subcommand shows context-aware welcome screen
- Shows different commands based on whether a project exists
- "Did you mean?" suggestions for misspelled collection/theme names using `strsim`
- Better error hints (e.g., "Config file not found" suggests `seite init`)
- `seite new` tells users the dev server will auto-reload

**Other Improvements**
- `seite init` now displays the project structure after scaffolding
- Build summary collection counts sorted alphabetically (stable output)
- `seite theme list` links to theme gallery for visual previews
- Improved `seite new` output with helpful hints
- Better alignment in theme list display

## Implementation Details

- `BuildProgress` uses `indicatif` spinners with custom tick strings and timing calculations
- Network IP detection uses UDP socket binding to `8.8.8.8:80` (no actual connection)
- String similarity matching uses `strsim::jaro_winkler` with 0.7 threshold
- Workspace server updated to support `--host` parameter
- All tests updated to pass host parameter to port checking functions
- Version bumped to 0.9.0 in Cargo.toml

https://claude.ai/code/session_01T1myhq4YNCteSMmLVdwPw6