### PR TITLE
Support Plausible's new unique snippet format (Oct 2025+)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/seite-sh/.claude/rules/config-reference.md
+++ b/seite-sh/.claude/rules/config-reference.md
@@ -36,13 +36,13 @@ When enabled, the build pipeline auto-resizes images, generates WebP and/or AVIF
 provider = "plausible"     # "google", "gtm", "plausible", "fathom", "umami"
 id = "example.com"         # measurement/tracking ID
 cookie_consent = true      # show consent banner and gate analytics on acceptance
-# script_url = "..."       # custom script URL (required for self-hosted Umami)
-# extensions = ["tagged-events", "outbound-links"]  # Plausible script extensions
+# script_url = "..."       # unique snippet URL (recommended for Plausible; required for self-hosted Umami)
+# extensions = ["tagged-events", "outbound-links"]  # legacy Plausible script extensions
 ```
 
 Analytics scripts are injected into all HTML files at build time. When `cookie_consent = true`, a banner is shown and analytics only load after the user accepts. Consent is stored in `localStorage`.
 
-For Plausible, `extensions` appends [script extensions](https://plausible.io/docs/script-extensions) to the filename (e.g., `script.tagged-events.outbound-links.js`). Ignored when `script_url` is set or for non-Plausible providers.
+For Plausible, use `script_url` with the unique snippet URL from your dashboard (Settings → Installation). This uses `async` loading, drops `data-domain`, and includes the `plausible.init()` bootstrapper for custom events. The legacy `extensions` field still works but is deprecated — it appends [script extensions](https://plausible.io/docs/script-extensions) to the filename (e.g., `script.tagged-events.outbound-links.js`). Ignored when `script_url` is set or for non-Plausible providers.
 
 ### Subdomain Deploys
 

--- a/seite-sh/content/changelog/2026-03-16-v0-10-1.md
+++ b/seite-sh/content/changelog/2026-03-16-v0-10-1.md
@@ -1,0 +1,29 @@
+---
+title: v0.10.1
+description: "Plausible Analytics: support new unique snippet format (Oct 2025+) with async loading and init script."
+date: 2026-03-16
+tags:
+- fix
+---
+
+## Plausible New Snippet Format
+
+Plausible [replaced extension-based script URLs](https://plausible.io/docs/script-update-guide) with unique per-site snippet URLs in October 2025. seite now fully supports the new format when `script_url` is set:
+
+- Uses `async` instead of `defer` (matching Plausible's new snippet)
+- Drops `data-domain` attribute (domain is encoded in the unique URL)
+- Injects the `plausible.init()` bootstrapper for custom event support (tagged events, outbound links, etc.)
+- Works with both direct injection and cookie consent banner modes
+
+**New recommended config:**
+
+```toml
+[analytics]
+provider = "plausible"
+id = "example.com"
+script_url = "https://plausible.io/js/pa-XXXXXXXXXX.js"
+```
+
+The legacy `extensions` approach continues to work for existing setups. The `id` field is still required as a site identifier even when using `script_url`.
+
+The seite.sh website has been migrated to the new snippet format.

--- a/seite-sh/content/docs/configuration.md
+++ b/seite-sh/content/docs/configuration.md
@@ -259,13 +259,13 @@ provider = "plausible"
 id = "example.com"
 ```
 
-For new installations, Plausible now provides a **unique snippet per site** from your dashboard (Settings → Installation). Use `script_url` to point to it — features like tagged events, outbound links, and file downloads are toggled in your Plausible site settings and automatically included:
+For new installations, Plausible now provides a **unique snippet per site** from your dashboard (Settings → Installation). Use `script_url` to point to it — features like tagged events, outbound links, and file downloads are toggled in your Plausible site settings and automatically included. seite generates the correct `async` script tag plus the `plausible.init()` bootstrapper for custom event support:
 
 ```toml
 [analytics]
 provider = "plausible"
 id = "example.com"
-script_url = "https://plausible.io/js/script.XXXXXXXX.js"
+script_url = "https://plausible.io/js/pa-XXXXXXXXXX.js"
 ```
 
 **Legacy: Plausible with extensions (pre-October 2025 script)**

--- a/seite-sh/seite.toml
+++ b/seite-sh/seite.toml
@@ -74,6 +74,6 @@ domain = "seite.sh"
 [analytics]
 provider = "plausible"
 id = "seite.sh"
-extensions = ["tagged-events", "outbound-links", "file-downloads"]
+script_url = "https://plausible.io/js/pa-OJfj4Th8cNkDRd_c7LB8I.js"
 
 [languages]

--- a/src/build/analytics.rs
+++ b/src/build/analytics.rs
@@ -37,11 +37,23 @@ fn analytics_script(config: &AnalyticsSection) -> String {
         }
         AnalyticsProvider::Plausible => {
             let src = plausible_script_url(config);
-            format!(
-                r#"<script defer data-domain="{id}" src="{src}"></script>"#,
-                id = config.id,
-                src = src,
-            )
+            if config.script_url.is_some() {
+                // New Plausible snippet format (unique URL per site, Oct 2025+).
+                // The domain is encoded in the URL — no data-domain needed.
+                // The init script sets up the plausible() function for custom events.
+                format!(
+                    r#"<script async src="{src}"></script>
+<script>window.plausible=window.plausible||function(){{(plausible.q=plausible.q||[]).push(arguments)}},plausible.init=plausible.init||function(i){{plausible.o=i||{{}}}};plausible.init()</script>"#,
+                    src = src,
+                )
+            } else {
+                // Legacy Plausible snippet (defer + data-domain).
+                format!(
+                    r#"<script defer data-domain="{id}" src="{src}"></script>"#,
+                    id = config.id,
+                    src = src,
+                )
+            }
         }
         AnalyticsProvider::Fathom => {
             let src = config
@@ -86,11 +98,20 @@ fn analytics_loader_js(config: &AnalyticsSection) -> String {
         }
         AnalyticsProvider::Plausible => {
             let src = plausible_script_url(config);
-            format!(
-                r#"var s=document.createElement('script');s.defer=true;s.setAttribute('data-domain','{id}');s.src='{src}';document.head.appendChild(s)"#,
-                id = config.id,
-                src = src,
-            )
+            if config.script_url.is_some() {
+                // New Plausible snippet: async, no data-domain, plus init script.
+                format!(
+                    r#"var s=document.createElement('script');s.async=true;s.src='{src}';document.head.appendChild(s);window.plausible=window.plausible||function(){{(plausible.q=plausible.q||[]).push(arguments)}},plausible.init=plausible.init||function(i){{plausible.o=i||{{}}}};plausible.init()"#,
+                    src = src,
+                )
+            } else {
+                // Legacy Plausible snippet: defer + data-domain.
+                format!(
+                    r#"var s=document.createElement('script');s.defer=true;s.setAttribute('data-domain','{id}');s.src='{src}';document.head.appendChild(s)"#,
+                    id = config.id,
+                    src = src,
+                )
+            }
         }
         AnalyticsProvider::Fathom => {
             let src = config
@@ -417,6 +438,62 @@ mod tests {
         let result = inject_analytics(SIMPLE_HTML, &config);
         assert!(result.contains("proxy.example.com/js/script.js"));
         assert!(!result.contains("tagged-events"));
+        // New format: async instead of defer, no data-domain, has init script
+        assert!(result.contains("async"));
+        assert!(!result.contains("data-domain"));
+        assert!(result.contains("plausible.init()"));
+    }
+
+    #[test]
+    fn test_plausible_unique_snippet_url() {
+        let config = AnalyticsSection {
+            provider: AnalyticsProvider::Plausible,
+            id: "example.com".to_string(),
+            cookie_consent: false,
+            script_url: Some("https://plausible.io/js/pa-OJfj4Th8cNkDRd_c7LB8I.js".into()),
+            extensions: vec![],
+        };
+        let result = inject_analytics(SIMPLE_HTML, &config);
+        assert!(result.contains("pa-OJfj4Th8cNkDRd_c7LB8I.js"));
+        assert!(result.contains("<script async"));
+        assert!(!result.contains("defer"));
+        assert!(!result.contains("data-domain"));
+        assert!(result.contains("plausible.init()"));
+        assert!(result.contains("plausible.q"));
+    }
+
+    #[test]
+    fn test_plausible_unique_snippet_with_consent() {
+        let config = AnalyticsSection {
+            provider: AnalyticsProvider::Plausible,
+            id: "example.com".to_string(),
+            cookie_consent: true,
+            script_url: Some("https://plausible.io/js/pa-OJfj4Th8cNkDRd_c7LB8I.js".into()),
+            extensions: vec![],
+        };
+        let result = inject_analytics(SIMPLE_HTML, &config);
+        assert!(result.contains("seite-cookie-banner"));
+        assert!(result.contains("pa-OJfj4Th8cNkDRd_c7LB8I.js"));
+        assert!(result.contains("plausible.init()"));
+        // Script should NOT be in <head> (consent-gated)
+        let head_end = result.find("</head>").unwrap();
+        let head_section = &result[..head_end];
+        assert!(!head_section.contains("plausible.io/js/pa-"));
+    }
+
+    #[test]
+    fn test_plausible_legacy_still_uses_defer_and_data_domain() {
+        let config = AnalyticsSection {
+            provider: AnalyticsProvider::Plausible,
+            id: "example.com".to_string(),
+            cookie_consent: false,
+            script_url: None,
+            extensions: vec![],
+        };
+        let result = inject_analytics(SIMPLE_HTML, &config);
+        assert!(result.contains("defer"));
+        assert!(result.contains("data-domain=\"example.com\""));
+        assert!(!result.contains("plausible.init()"));
     }
 
     #[test]

--- a/src/scaffold/config-reference.md
+++ b/src/scaffold/config-reference.md
@@ -38,7 +38,7 @@ cookie_consent = true      # show consent banner and gate analytics on acceptanc
 
 Analytics scripts are injected into all HTML files at build time. When `cookie_consent = true`, a banner is shown and analytics only load after the user accepts. Consent is stored in `localStorage`.
 
-For new Plausible installations, retrieve your unique snippet URL from Plausible → Settings → Installation and set it as `script_url`. The `extensions` field uses the legacy filename-based approach (e.g., `script.tagged-events.js`) which still works but won't receive new Plausible features. See the [Plausible script update guide](https://plausible.io/docs/script-update-guide).
+For new Plausible installations, retrieve your unique snippet URL from Plausible → Settings → Installation and set it as `script_url`. seite generates the correct `async` script tag and `plausible.init()` bootstrapper for custom event support. The legacy `extensions` field (e.g., `script.tagged-events.js`) still works but is deprecated. See the [Plausible script update guide](https://plausible.io/docs/script-update-guide).
 
 ### Subdomain Deploys
 


### PR DESCRIPTION
## Summary
Add support for Plausible Analytics' new unique per-site snippet format introduced in October 2025, while maintaining backward compatibility with the legacy extension-based approach.

## Key Changes

- **Conditional snippet generation**: When `script_url` is set, generate the new Plausible snippet format with:
  - `async` loading instead of `defer`
  - Removal of `data-domain` attribute (domain is encoded in the unique URL)
  - Injection of `plausible.init()` bootstrapper for custom event support
  
- **Dual-mode support**: 
  - New format: Uses `script_url` field pointing to unique snippet URL from Plausible dashboard
  - Legacy format: Falls back to `extensions` field with filename-based approach when `script_url` is not set

- **Both injection modes supported**: New snippet format works correctly with both direct HTML injection and cookie consent banner gating

- **Comprehensive test coverage**: Added three new tests covering:
  - New unique snippet URL format
  - New format with cookie consent enabled
  - Legacy format still uses `defer` and `data-domain`

- **Documentation updates**: Updated configuration reference and docs to recommend the new `script_url` approach and clarify that `extensions` is now deprecated

- **Version bump**: Updated to v0.10.1 with changelog entry

## Implementation Details

The changes are localized to the Plausible provider branch in `analytics_script()` and `analytics_loader_js()` functions, checking `config.script_url.is_some()` to determine which format to use. The init script includes the queue-based event handler pattern that Plausible's new snippet uses for custom events (tagged events, outbound links, etc.).

https://claude.ai/code/session_011DLBUwJgxgTzmvfCXR8oa2