### PR TITLE
Fix AVIF image errors, add i18n for callout shortcode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/seite-sh/content/changelog/2026-03-18-v0-10-2.md
+++ b/seite-sh/content/changelog/2026-03-18-v0-10-2.md
@@ -1,0 +1,44 @@
+---
+title: v0.10.2
+description: "Fix AVIF image processing errors and add i18n support for shortcode callout labels."
+date: 2026-03-18
+tags:
+- fix
+---
+
+## AVIF Image Processing Fix
+
+seite no longer attempts to decode `.avif` files in the image processing pipeline. The `image` crate's `avif` feature only enables AVIF *encoding* (generating AVIF variants from PNG/JPG/WebP sources), not *decoding*. Previously, `.avif` files in `static/` would trigger a `The image format Avif is not supported` warning on every build.
+
+AVIF files are still copied to `dist/` and served correctly — they just skip the resize/optimize step. Since AVIF is already heavily compressed, re-processing provides no benefit.
+
+## Translatable Callout Shortcode Labels
+
+The built-in `callout` shortcode now supports i18n. Previously, callout titles (`Info`, `Tip`, `Warning`, `Danger`) were hardcoded in English regardless of the site language.
+
+Shortcode templates now receive the `{{ t }}` translation object, matching the convention used by page templates. Callout labels use these new UI string keys:
+
+- `callout_info` (default: "Info")
+- `callout_tip` (default: "Tip")
+- `callout_warning` (default: "Warning")
+- `callout_danger` (default: "Danger")
+
+Override them in `data/i18n/{lang}.yaml`:
+
+```yaml
+# data/i18n/de.yaml
+callout_info: "Hinweis"
+callout_tip: "Tipp"
+callout_warning: "Warnung"
+callout_danger: "Gefahr"
+```
+
+You can also pass a `title` argument to any callout for a one-off override:
+
+```markdown
+{{% callout(type="tip", title="Pro-Tipp") %}}
+Custom title regardless of language.
+{{% end %}}
+```
+
+User-defined shortcode templates can now use `{{ t.any_key }}` to access translated UI strings.

--- a/seite-sh/content/changelog/2026-03-18-v0-11-0.md
+++ b/seite-sh/content/changelog/2026-03-18-v0-11-0.md
@@ -1,5 +1,5 @@
 ---
-title: v0.10.2
+title: v0.11.0
 description: "Fix AVIF image processing errors and add i18n support for shortcode callout labels."
 date: 2026-03-18
 tags:

--- a/src/build/images.rs
+++ b/src/build/images.rs
@@ -14,7 +14,7 @@ use crate::config::{ImageSection, ResolvedPaths};
 use crate::error::{PageError, Result};
 
 /// Supported input image extensions.
-const IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp", "avif"];
+const IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp"];
 
 /// An entry in the image manifest mapping original paths to processed outputs.
 #[derive(Debug, Clone)]

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -555,6 +555,17 @@ fn build_site_inner(
         None
     };
 
+    // Pre-compute i18n strings per language for shortcode templates.
+    // Built before the collection loop so the cache can be captured by par_iter closures.
+    let sc_i18n_cache: HashMap<String, serde_json::Value> = config
+        .all_languages()
+        .into_iter()
+        .map(|lang| {
+            let t = ui_strings_for_lang(&lang, &data);
+            (lang, t)
+        })
+        .collect();
+
     // Pre-compute shortcode site context (identical for every page)
     let sc_site = serde_json::json!({
         "title": &config.site.title,
@@ -623,8 +634,10 @@ fn build_site_inner(
                         "collection": &collection.name,
                         "tags": &fm.tags,
                     });
+                    let empty_i18n = serde_json::json!({});
+                    let sc_i18n = sc_i18n_cache.get(&lang).unwrap_or(&empty_i18n);
                     let expanded_body =
-                        shortcode_registry.expand(&raw_body, path, &sc_page, &sc_site)?;
+                        shortcode_registry.expand(&raw_body, path, &sc_page, &sc_site, sc_i18n)?;
                     let excerpt = content::extract_excerpt(&expanded_body);
                     let html_input = if config.build.math {
                         math::render_math(&expanded_body)
@@ -2726,7 +2739,11 @@ fn ui_strings_for_lang(lang: &str, data: &serde_json::Value) -> serde_json::Valu
         "contact_email": "Email",
         "contact_message": "Message",
         "contact_submit": "Send Message",
-        "documentation": "Documentation"
+        "documentation": "Documentation",
+        "callout_info": "Info",
+        "callout_tip": "Tip",
+        "callout_warning": "Warning",
+        "callout_danger": "Danger"
     });
 
     // Check data.i18n.{lang} for overrides, merge on top of defaults
@@ -4302,6 +4319,11 @@ mod tests {
             "contact_email",
             "contact_message",
             "contact_submit",
+            "documentation",
+            "callout_info",
+            "callout_tip",
+            "callout_warning",
+            "callout_danger",
         ];
         for key in expected_keys {
             assert!(obj.contains_key(key), "Missing UI string key: {key}");

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -565,6 +565,7 @@ fn build_site_inner(
             (lang, t)
         })
         .collect();
+    let sc_i18n_empty = serde_json::json!({});
 
     // Pre-compute shortcode site context (identical for every page)
     let sc_site = serde_json::json!({
@@ -634,8 +635,7 @@ fn build_site_inner(
                         "collection": &collection.name,
                         "tags": &fm.tags,
                     });
-                    let empty_i18n = serde_json::json!({});
-                    let sc_i18n = sc_i18n_cache.get(&lang).unwrap_or(&empty_i18n);
+                    let sc_i18n = sc_i18n_cache.get(&lang).unwrap_or(&sc_i18n_empty);
                     let expanded_body =
                         shortcode_registry.expand(&raw_body, path, &sc_page, &sc_site, sc_i18n)?;
                     let excerpt = content::extract_excerpt(&expanded_body);

--- a/src/shortcodes/builtins/callout.html
+++ b/src/shortcodes/builtins/callout.html
@@ -1,5 +1,5 @@
 <div class="callout callout-{{ type | default(value='info') }}">
-<div class="callout-title">{% if type == "warning" %}Warning{% elif type == "danger" %}Danger{% elif type == "tip" %}Tip{% else %}Info{% endif %}</div>
+<div class="callout-title">{% if title %}{{ title }}{% elif type == "warning" %}{{ t.callout_warning | default(value="Warning") }}{% elif type == "danger" %}{{ t.callout_danger | default(value="Danger") }}{% elif type == "tip" %}{{ t.callout_tip | default(value="Tip") }}{% else %}{{ t.callout_info | default(value="Info") }}{% endif %}</div>
 
 {{ body }}
 

--- a/src/shortcodes/mod.rs
+++ b/src/shortcodes/mod.rs
@@ -80,12 +80,16 @@ impl ShortcodeRegistry {
     /// where the `body` variable contains the raw markdown body content.
     ///
     /// Shortcodes inside code blocks are left untouched.
+    ///
+    /// The `i18n` parameter provides translated UI strings as `{{ t }}` inside
+    /// shortcode templates, matching the convention used by page templates.
     pub fn expand(
         &self,
         input: &str,
         source_path: &Path,
         page_context: &serde_json::Value,
         site_context: &serde_json::Value,
+        i18n: &serde_json::Value,
     ) -> Result<String> {
         let calls = parser::parse_shortcodes(input, source_path)?;
 
@@ -113,7 +117,8 @@ impl ShortcodeRegistry {
         // Replace spans back-to-front so byte offsets stay valid
         let mut output = input.to_string();
         for call in calls.iter().rev() {
-            let rendered = self.render_shortcode(call, source_path, page_context, site_context)?;
+            let rendered =
+                self.render_shortcode(call, source_path, page_context, site_context, i18n)?;
             output.replace_range(call.span.0..call.span.1, &rendered);
         }
 
@@ -127,6 +132,7 @@ impl ShortcodeRegistry {
         source_path: &Path,
         page_context: &serde_json::Value,
         site_context: &serde_json::Value,
+        i18n: &serde_json::Value,
     ) -> Result<String> {
         let template_name = format!("shortcodes/{}.html", call.name);
         let mut ctx = tera::Context::new();
@@ -144,6 +150,9 @@ impl ShortcodeRegistry {
         // Insert page and site context
         ctx.insert("page", page_context);
         ctx.insert("site", site_context);
+
+        // Insert i18n translations (matches `{{ t }}` convention in page templates)
+        ctx.insert("t", i18n);
 
         self.tera
             .render(&template_name, &ctx)
@@ -176,17 +185,21 @@ mod tests {
         ShortcodeRegistry::new(&PathBuf::from("/nonexistent")).unwrap()
     }
 
-    fn empty_contexts() -> (serde_json::Value, serde_json::Value) {
-        (serde_json::json!({}), serde_json::json!({}))
+    fn empty_contexts() -> (serde_json::Value, serde_json::Value, serde_json::Value) {
+        (
+            serde_json::json!({}),
+            serde_json::json!({}),
+            serde_json::json!({}),
+        )
     }
 
     #[test]
     fn test_expand_youtube_shortcode() {
         let registry = test_registry();
-        let (page, site) = empty_contexts();
+        let (page, site, i18n) = empty_contexts();
         let input = r#"{{< youtube(id="dQw4w9WgXcQ") >}}"#;
         let result = registry
-            .expand(input, &PathBuf::from("test.md"), &page, &site)
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
             .unwrap();
         assert!(result.contains("youtube.com/embed/dQw4w9WgXcQ"));
         assert!(result.contains("video-embed"));
@@ -195,10 +208,10 @@ mod tests {
     #[test]
     fn test_expand_vimeo_shortcode() {
         let registry = test_registry();
-        let (page, site) = empty_contexts();
+        let (page, site, i18n) = empty_contexts();
         let input = r#"{{< vimeo(id="123456") >}}"#;
         let result = registry
-            .expand(input, &PathBuf::from("test.md"), &page, &site)
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
             .unwrap();
         assert!(result.contains("player.vimeo.com/video/123456"));
     }
@@ -206,10 +219,10 @@ mod tests {
     #[test]
     fn test_expand_gist_shortcode() {
         let registry = test_registry();
-        let (page, site) = empty_contexts();
+        let (page, site, i18n) = empty_contexts();
         let input = r#"{{< gist(user="octocat", id="abc123") >}}"#;
         let result = registry
-            .expand(input, &PathBuf::from("test.md"), &page, &site)
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
             .unwrap();
         assert!(result.contains("gist.github.com/octocat/abc123.js"));
     }
@@ -217,10 +230,10 @@ mod tests {
     #[test]
     fn test_expand_callout_body_shortcode() {
         let registry = test_registry();
-        let (page, site) = empty_contexts();
+        let (page, site, i18n) = empty_contexts();
         let input = "{{% callout(type=\"warning\") %}}\nThis is **important**\n{{% end %}}";
         let result = registry
-            .expand(input, &PathBuf::from("test.md"), &page, &site)
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
             .unwrap();
         assert!(result.contains("callout-warning"));
         assert!(result.contains("This is **important**"));
@@ -229,10 +242,10 @@ mod tests {
     #[test]
     fn test_expand_figure_shortcode() {
         let registry = test_registry();
-        let (page, site) = empty_contexts();
+        let (page, site, i18n) = empty_contexts();
         let input = r#"{{< figure(src="/static/img.jpg", caption="A photo", alt="Photo") >}}"#;
         let result = registry
-            .expand(input, &PathBuf::from("test.md"), &page, &site)
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
             .unwrap();
         assert!(result.contains("<figure"));
         assert!(result.contains("src=\"/static/img.jpg\""));
@@ -243,9 +256,9 @@ mod tests {
     #[test]
     fn test_expand_unknown_shortcode_errors() {
         let registry = test_registry();
-        let (page, site) = empty_contexts();
+        let (page, site, i18n) = empty_contexts();
         let input = r#"{{< nonexistent(x="y") >}}"#;
-        let result = registry.expand(input, &PathBuf::from("test.md"), &page, &site);
+        let result = registry.expand(input, &PathBuf::from("test.md"), &page, &site, &i18n);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("unknown shortcode `nonexistent`"));
@@ -254,10 +267,10 @@ mod tests {
     #[test]
     fn test_expand_no_shortcodes_returns_input() {
         let registry = test_registry();
-        let (page, site) = empty_contexts();
+        let (page, site, i18n) = empty_contexts();
         let input = "Just regular markdown.";
         let result = registry
-            .expand(input, &PathBuf::from("test.md"), &page, &site)
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
             .unwrap();
         assert_eq!(result, input);
     }
@@ -265,10 +278,10 @@ mod tests {
     #[test]
     fn test_expand_preserves_surrounding_content() {
         let registry = test_registry();
-        let (page, site) = empty_contexts();
+        let (page, site, i18n) = empty_contexts();
         let input = r#"Before {{< youtube(id="test") >}} after"#;
         let result = registry
-            .expand(input, &PathBuf::from("test.md"), &page, &site)
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
             .unwrap();
         assert!(result.starts_with("Before "));
         assert!(result.ends_with(" after"));
@@ -278,10 +291,10 @@ mod tests {
     #[test]
     fn test_expand_preserves_code_blocks() {
         let registry = test_registry();
-        let (page, site) = empty_contexts();
+        let (page, site, i18n) = empty_contexts();
         let input = "```\n{{< youtube(id=\"test\") >}}\n```";
         let result = registry
-            .expand(input, &PathBuf::from("test.md"), &page, &site)
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
             .unwrap();
         assert_eq!(result, input);
     }
@@ -289,12 +302,12 @@ mod tests {
     #[test]
     fn test_expand_multiple_shortcodes() {
         let registry = test_registry();
-        let (page, site) = empty_contexts();
+        let (page, site, i18n) = empty_contexts();
         let input = r#"{{< youtube(id="a") >}}
 
 {{< vimeo(id="b") >}}"#;
         let result = registry
-            .expand(input, &PathBuf::from("test.md"), &page, &site)
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
             .unwrap();
         assert!(result.contains("youtube.com/embed/a"));
         assert!(result.contains("player.vimeo.com/video/b"));
@@ -308,10 +321,10 @@ mod tests {
         std::fs::write(sc_dir.join("youtube.html"), "<custom>{{ id }}</custom>").unwrap();
 
         let registry = ShortcodeRegistry::new(&sc_dir).unwrap();
-        let (page, site) = empty_contexts();
+        let (page, site, i18n) = empty_contexts();
         let input = r#"{{< youtube(id="test") >}}"#;
         let result = registry
-            .expand(input, &PathBuf::from("test.md"), &page, &site)
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
             .unwrap();
         assert!(result.contains("<custom>test</custom>"));
         assert!(!result.contains("youtube.com"));
@@ -351,10 +364,10 @@ mod tests {
         std::fs::write(sc_dir.join("custom.html"), "<div>{{ text }}</div>").unwrap();
 
         let registry = ShortcodeRegistry::new(&sc_dir).unwrap();
-        let (page, site) = empty_contexts();
+        let (page, site, i18n) = empty_contexts();
         let input = r#"{{< custom(text="hello") >}}"#;
         let result = registry
-            .expand(input, &PathBuf::from("test.md"), &page, &site)
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
             .unwrap();
         assert!(result.contains("<div>hello</div>"));
     }
@@ -364,10 +377,11 @@ mod tests {
         let registry = test_registry();
         let page = serde_json::json!({"title": "My Page"});
         let site = serde_json::json!({"base_url": "https://example.com"});
+        let i18n = serde_json::json!({});
         // youtube shortcode doesn't use page context, but the rendering shouldn't fail
         let input = r#"{{< youtube(id="abc") >}}"#;
         let result = registry
-            .expand(input, &PathBuf::from("test.md"), &page, &site)
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
             .unwrap();
         assert!(result.contains("youtube.com/embed/abc"));
     }
@@ -382,8 +396,9 @@ mod tests {
                 "endpoint": "xpznqkdl"
             }
         });
+        let i18n = serde_json::json!({});
         let input = r#"{{< contact_form() >}}"#;
-        let result = registry.expand(input, &PathBuf::from("test.md"), &page, &site);
+        let result = registry.expand(input, &PathBuf::from("test.md"), &page, &site, &i18n);
         // Contact form renders even without provider — it just won't have an action URL
         assert!(result.is_ok());
     }
@@ -401,6 +416,65 @@ mod tests {
     }
 
     #[test]
+    fn test_callout_uses_i18n_translations() {
+        let registry = test_registry();
+        let page = serde_json::json!({});
+        let site = serde_json::json!({});
+        let i18n = serde_json::json!({
+            "callout_tip": "Tipp",
+            "callout_warning": "Warnung",
+            "callout_danger": "Gefahr",
+            "callout_info": "Hinweis"
+        });
+        let input = "{{% callout(type=\"tip\") %}}\nSome text\n{{% end %}}";
+        let result = registry
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
+            .unwrap();
+        assert!(
+            result.contains("Tipp"),
+            "Expected translated 'Tipp' in: {result}"
+        );
+        assert!(
+            !result.contains(">Tip<"),
+            "Should not contain English 'Tip'"
+        );
+    }
+
+    #[test]
+    fn test_callout_title_arg_overrides_i18n() {
+        let registry = test_registry();
+        let page = serde_json::json!({});
+        let site = serde_json::json!({});
+        let i18n = serde_json::json!({"callout_tip": "Tipp"});
+        let input = "{{% callout(type=\"tip\", title=\"Custom Title\") %}}\nText\n{{% end %}}";
+        let result = registry
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
+            .unwrap();
+        assert!(
+            result.contains("Custom Title"),
+            "Expected custom title in: {result}"
+        );
+        assert!(
+            !result.contains("Tipp"),
+            "i18n should be overridden by title arg"
+        );
+    }
+
+    #[test]
+    fn test_callout_falls_back_to_english_without_i18n() {
+        let registry = test_registry();
+        let (page, site, i18n) = empty_contexts();
+        let input = "{{% callout(type=\"tip\") %}}\nText\n{{% end %}}";
+        let result = registry
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
+            .unwrap();
+        assert!(
+            result.contains(">Tip<"),
+            "Expected English fallback 'Tip' in: {result}"
+        );
+    }
+
+    #[test]
     fn test_user_shortcode_non_html_skipped() {
         let tmp = tempfile::TempDir::new().unwrap();
         let sc_dir = tmp.path().join("shortcodes");
@@ -410,10 +484,10 @@ mod tests {
 
         let registry = ShortcodeRegistry::new(&sc_dir).unwrap();
         // "readme" should not be registered, "valid" should
-        let (page, site) = empty_contexts();
+        let (page, site, i18n) = empty_contexts();
         let input = r#"{{< valid(text="ok") >}}"#;
         let result = registry
-            .expand(input, &PathBuf::from("test.md"), &page, &site)
+            .expand(input, &PathBuf::from("test.md"), &page, &site, &i18n)
             .unwrap();
         assert!(result.contains("<p>ok</p>"));
     }


### PR DESCRIPTION
## Summary

- **AVIF fix**: Remove `avif` from `IMAGE_EXTENSIONS` — the `image` crate's `avif` feature only enables encoding, not decoding. Eliminates `The image format Avif is not supported` warnings on every build. AVIF files in `static/` still get copied to `dist/` as-is.
- **Callout i18n**: Pass `{{ t }}` translations into shortcode template context. The callout shortcode now uses translatable keys (`callout_tip`, `callout_warning`, `callout_danger`, `callout_info`) with English fallbacks, plus an optional `title` arg for per-instance overrides. User-defined shortcodes also gain access to `{{ t }}`.
- Version bump to v0.11.0 (minor — `ShortcodeRegistry::expand` gained a new `i18n` parameter) with changelog entry.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — 1,582 tests pass (1,220 unit + 362 integration)
- [x] `cargo-semver-checks` — passes with v0.11.0
- [ ] Verify AVIF files in `static/` no longer produce warnings during `seite build`
- [ ] Verify German callout labels render correctly with `data/i18n/de.yaml` overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)