### PR TITLE
v0.12.0: Auto-generate subdomain deploy steps in CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
 
           # Authenticate via DNS (key is Ed25519 PEM stored in secret)
           echo "$MCP_REGISTRY_KEY" > /tmp/key.pem
-          PRIVATE_KEY="$(openssl pkey -in /tmp/key.pem -noout -text 2>/dev/null | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n')"
+          PRIVATE_KEY="$(openssl pkey -in /tmp/key.pem -noout -text 2>/dev/null | grep -A5 "priv:" | tail -n +2 | tr -d ' :\n' | head -c 64)"
           rm -f /tmp/key.pem
           ./mcp-publisher login dns --domain "seite.sh" --private-key "$PRIVATE_KEY"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/seite-sh/content/changelog/2026-03-19-v0-12-0.md
+++ b/seite-sh/content/changelog/2026-03-19-v0-12-0.md
@@ -1,0 +1,47 @@
+---
+title: v0.12.0
+description: "Auto-generate subdomain deploy steps in CI workflows and stop pinning the seite version so projects always use the latest release."
+date: 2026-03-19
+tags:
+- feature
+---
+
+## Subdomain Deploy Steps in Generated Workflows
+
+`seite init` and `seite deploy --setup` now auto-generate deploy steps for subdomain collections. Previously, when a collection had `subdomain` and `deploy_project` configured, only the main site was deployed in CI — users had to manually add the subdomain deploy step.
+
+Now the generated Cloudflare workflow includes steps like:
+
+```yaml
+- name: Deploy docs to Cloudflare Pages
+  uses: cloudflare/wrangler-action@v3
+  with:
+    apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    command: pages deploy dist-subdomains/docs --project-name my-docs
+```
+
+Netlify workflows get equivalent steps with per-collection site ID secrets (`NETLIFY_SITE_ID_DOCS`).
+
+GitHub Pages is unchanged — it doesn't support multi-project deploys.
+
+## Always Install Latest seite in CI
+
+Generated workflows no longer pin `VERSION=x.y.z` in the install command. Instead they use:
+
+```yaml
+run: curl -fsSL https://seite.sh/install.sh | sh
+```
+
+The install script resolves the latest release via `version.txt`. This means your CI always uses the current seite version without needing to manually update the workflow or run `seite upgrade`.
+
+If you need to pin a specific version, you can still set `VERSION=0.12.0` manually in your workflow.
+
+## Upgrade Path
+
+Run `seite upgrade` to apply both changes to existing projects:
+
+1. **Version unpinning** — removes `VERSION=` from your deploy workflow and netlify.toml
+2. **Subdomain steps** — adds missing deploy steps for collections with `deploy_project`
+
+Both are non-destructive: the upgrade regenerates the workflow from your current `seite.toml` configuration.

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -164,6 +164,16 @@ const fn upgrade_steps() -> &'static [UpgradeStep] {
             label: "Atom autodiscovery in custom templates",
             check: check_atom_autodiscovery_template,
         },
+        UpgradeStep {
+            introduced_in: (0, 11, 0),
+            label: "Remove pinned VERSION from deploy workflows (use latest)",
+            check: check_deploy_version_unpinning,
+        },
+        UpgradeStep {
+            introduced_in: (0, 11, 0),
+            label: "Subdomain collection deploy steps in CI workflow",
+            check: check_subdomain_workflow,
+        },
     ]
 }
 
@@ -637,60 +647,11 @@ fn check_deploy_workflows(root: &Path) -> Vec<UpgradeAction> {
     actions
 }
 
-/// Fix deploy workflows that use an unpinned `install.sh` (no VERSION= env var).
-///
-/// Projects created before version pinning was introduced will have workflows
-/// that always download the latest seite binary. This regenerates them with
-/// the current binary version pinned.
-fn check_deploy_version_pinning(root: &Path) -> Vec<UpgradeAction> {
-    let mut actions = Vec::new();
-
-    let config_path = root.join("seite.toml");
-    let config = match crate::config::SiteConfig::load(&config_path) {
-        Ok(c) => c,
-        Err(_) => return vec![],
-    };
-
-    // Check .github/workflows/deploy.yml
-    let workflow_path = root.join(".github/workflows/deploy.yml");
-    if workflow_path.exists() {
-        let content = fs::read_to_string(&workflow_path).unwrap_or_default();
-        if content.contains("install.sh | sh") && !content.contains("VERSION=") {
-            let new_workflow = match &config.deploy.target {
-                crate::config::DeployTarget::GithubPages => {
-                    crate::deploy::generate_github_actions_workflow(&config)
-                }
-                crate::config::DeployTarget::Cloudflare => {
-                    crate::deploy::generate_cloudflare_workflow(&config)
-                }
-                crate::config::DeployTarget::Netlify => {
-                    crate::deploy::generate_netlify_workflow(&config)
-                }
-            };
-            actions.push(UpgradeAction::Create {
-                path: workflow_path,
-                content: new_workflow,
-                description: ".github/workflows/deploy.yml (pin seite version in install command)"
-                    .into(),
-            });
-        }
-    }
-
-    // Check netlify.toml
-    let netlify_path = root.join("netlify.toml");
-    if netlify_path.exists() {
-        let content = fs::read_to_string(&netlify_path).unwrap_or_default();
-        if content.contains("install.sh | sh") && !content.contains("VERSION=") {
-            let new_config = crate::deploy::generate_netlify_config(&config);
-            actions.push(UpgradeAction::Create {
-                path: netlify_path,
-                content: new_config,
-                description: "netlify.toml (pin seite version in install command)".into(),
-            });
-        }
-    }
-
-    actions
+/// Previously pinned VERSION in deploy workflows. Now a no-op because we
+/// switched to always installing latest (the install script resolves latest
+/// via version.txt). Kept as a no-op to avoid breaking the upgrade step chain.
+fn check_deploy_version_pinning(_root: &Path) -> Vec<UpgradeAction> {
+    vec![]
 }
 
 /// Ensure CLAUDE.md has an MCP server section.
@@ -1044,6 +1005,137 @@ fn check_atom_autodiscovery_template(root: &Path) -> Vec<UpgradeAction> {
              ```html\n{snippet}\n```\n"
         ),
         description: "CLAUDE.md (Atom autodiscovery hint for custom template)".into(),
+    }]
+}
+
+/// Remove hardcoded `VERSION=x.y.z` from deploy workflows so they always install
+/// the latest seite release. The install script resolves latest via `version.txt`.
+///
+/// Previously, workflows pinned to the version that generated them, which meant
+/// projects never got seite updates in CI without manually editing the workflow
+/// or running `seite upgrade` (which itself required the new binary).
+fn check_deploy_version_unpinning(root: &Path) -> Vec<UpgradeAction> {
+    let mut actions = Vec::new();
+
+    let config_path = root.join("seite.toml");
+    let config = match crate::config::SiteConfig::load(&config_path) {
+        Ok(c) => c,
+        Err(_) => return vec![],
+    };
+
+    // Check .github/workflows/deploy.yml
+    let workflow_path = root.join(".github/workflows/deploy.yml");
+    if workflow_path.exists() {
+        let content = fs::read_to_string(&workflow_path).unwrap_or_default();
+        if content.contains("VERSION=") {
+            let new_workflow = match &config.deploy.target {
+                crate::config::DeployTarget::GithubPages => {
+                    crate::deploy::generate_github_actions_workflow(&config)
+                }
+                crate::config::DeployTarget::Cloudflare => {
+                    crate::deploy::generate_cloudflare_workflow(&config)
+                }
+                crate::config::DeployTarget::Netlify => {
+                    crate::deploy::generate_netlify_workflow(&config)
+                }
+            };
+            actions.push(UpgradeAction::Create {
+                path: workflow_path,
+                content: new_workflow,
+                description:
+                    ".github/workflows/deploy.yml (removed VERSION pin, now installs latest)"
+                        .into(),
+            });
+        }
+    }
+
+    // Check netlify.toml
+    let netlify_path = root.join("netlify.toml");
+    if netlify_path.exists() {
+        let content = fs::read_to_string(&netlify_path).unwrap_or_default();
+        if content.contains("VERSION=") {
+            let new_config = crate::deploy::generate_netlify_config(&config);
+            actions.push(UpgradeAction::Create {
+                path: netlify_path,
+                content: new_config,
+                description: "netlify.toml (removed VERSION pin, now installs latest)".into(),
+            });
+        }
+    }
+
+    actions
+}
+
+/// Regenerate the deploy workflow when subdomain collections have `deploy_project`
+/// but the workflow doesn't include their deploy steps.
+fn check_subdomain_workflow(root: &Path) -> Vec<UpgradeAction> {
+    let config_path = root.join("seite.toml");
+    let config = match crate::config::SiteConfig::load(&config_path) {
+        Ok(c) => c,
+        Err(_) => return vec![],
+    };
+
+    // Only relevant for Cloudflare/Netlify (GitHub Pages can't do multi-project)
+    let is_github_pages = matches!(
+        config.deploy.target,
+        crate::config::DeployTarget::GithubPages
+    );
+    if is_github_pages {
+        return vec![];
+    }
+
+    // Check if any subdomain collections have deploy_project configured
+    let subdomain_deploy_projects: Vec<_> = config
+        .subdomain_collections()
+        .into_iter()
+        .filter_map(|c| {
+            c.deploy_project
+                .as_deref()
+                .map(|p| (c.name.clone(), p.to_string()))
+        })
+        .collect();
+
+    if subdomain_deploy_projects.is_empty() {
+        return vec![];
+    }
+
+    let workflow_path = root.join(".github/workflows/deploy.yml");
+    if !workflow_path.exists() {
+        return vec![];
+    }
+
+    let content = fs::read_to_string(&workflow_path).unwrap_or_default();
+
+    // Check if all subdomain deploy projects are already referenced in the workflow
+    let all_present = subdomain_deploy_projects
+        .iter()
+        .all(|(_, project)| content.contains(project));
+
+    if all_present {
+        return vec![];
+    }
+
+    let missing: Vec<_> = subdomain_deploy_projects
+        .iter()
+        .filter(|(_, project)| !content.contains(project.as_str()))
+        .map(|(name, _)| name.as_str())
+        .collect();
+
+    let new_workflow = match &config.deploy.target {
+        crate::config::DeployTarget::Cloudflare => {
+            crate::deploy::generate_cloudflare_workflow(&config)
+        }
+        crate::config::DeployTarget::Netlify => crate::deploy::generate_netlify_workflow(&config),
+        crate::config::DeployTarget::GithubPages => unreachable!(),
+    };
+
+    vec![UpgradeAction::Create {
+        path: workflow_path,
+        content: new_workflow,
+        description: format!(
+            ".github/workflows/deploy.yml (added deploy steps for subdomain collections: {})",
+            missing.join(", ")
+        ),
     }]
 }
 
@@ -1478,7 +1570,15 @@ mod tests {
     }
 
     #[test]
-    fn test_check_deploy_version_pinning_already_pinned() {
+    fn test_check_deploy_version_pinning_is_noop() {
+        // check_deploy_version_pinning is now a no-op (we no longer pin versions)
+        let tmp = tempfile::TempDir::new().unwrap();
+        let actions = check_deploy_version_pinning(tmp.path());
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn test_check_deploy_version_unpinning_removes_version() {
         let tmp = tempfile::TempDir::new().unwrap();
         fs::write(
             tmp.path().join("seite.toml"),
@@ -1489,15 +1589,22 @@ mod tests {
         fs::create_dir_all(&wf_dir).unwrap();
         fs::write(
             wf_dir.join("deploy.yml"),
-            "steps:\n  - run: VERSION=0.2.0 install.sh | sh\n",
+            "steps:\n  - run: VERSION=0.2.0 curl -fsSL https://seite.sh/install.sh | sh\n",
         )
         .unwrap();
-        let actions = check_deploy_version_pinning(tmp.path());
-        assert!(actions.is_empty());
+        let actions = check_deploy_version_unpinning(tmp.path());
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            UpgradeAction::Create { content, .. } => {
+                assert!(!content.contains("VERSION="));
+                assert!(content.contains("curl -fsSL https://seite.sh/install.sh | sh"));
+            }
+            _ => panic!("expected Create action"),
+        }
     }
 
     #[test]
-    fn test_check_deploy_version_pinning_needs_pin() {
+    fn test_check_deploy_version_unpinning_already_unpinned() {
         let tmp = tempfile::TempDir::new().unwrap();
         fs::write(
             tmp.path().join("seite.toml"),
@@ -1511,8 +1618,8 @@ mod tests {
             "steps:\n  - run: curl -fsSL https://seite.sh/install.sh | sh\n",
         )
         .unwrap();
-        let actions = check_deploy_version_pinning(tmp.path());
-        assert_eq!(actions.len(), 1);
+        let actions = check_deploy_version_unpinning(tmp.path());
+        assert!(actions.is_empty());
     }
 
     #[test]
@@ -1657,5 +1764,99 @@ mod tests {
             }
             _ => panic!("expected Append action"),
         }
+    }
+
+    fn seite_toml_with_subdomain_collection() -> &'static str {
+        "[site]\ntitle = \"Test\"\ndescription = \"\"\nbase_url = \"https://example.com\"\nlanguage = \"en\"\nauthor = \"\"\n\n[[collections]]\nname = \"posts\"\nlabel = \"Posts\"\ndirectory = \"posts\"\nhas_date = true\nhas_rss = true\nlisted = true\nnested = false\nurl_prefix = \"/posts\"\ndefault_template = \"post.html\"\n\n[[collections]]\nname = \"docs\"\nlabel = \"Docs\"\ndirectory = \"docs\"\nhas_date = false\nhas_rss = true\nlisted = true\nnested = true\nurl_prefix = \"/docs\"\ndefault_template = \"doc.html\"\nsubdomain = \"docs\"\nsubdomain_base_url = \"https://docs.example.com\"\ndeploy_project = \"my-docs\"\n\n[deploy]\ntarget = \"cloudflare\"\nproject = \"my-site\"\n"
+    }
+
+    #[test]
+    fn test_check_subdomain_workflow_no_workflow() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("seite.toml"),
+            seite_toml_with_subdomain_collection(),
+        )
+        .unwrap();
+        let actions = check_subdomain_workflow(tmp.path());
+        assert!(actions.is_empty()); // no workflow file to upgrade
+    }
+
+    #[test]
+    fn test_check_subdomain_workflow_already_has_steps() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("seite.toml"),
+            seite_toml_with_subdomain_collection(),
+        )
+        .unwrap();
+        let wf_dir = tmp.path().join(".github/workflows");
+        fs::create_dir_all(&wf_dir).unwrap();
+        // Workflow already references the deploy project
+        fs::write(
+            wf_dir.join("deploy.yml"),
+            "steps:\n  - command: pages deploy dist --project-name my-site\n  - command: pages deploy dist-subdomains/docs --project-name my-docs\n",
+        )
+        .unwrap();
+        let actions = check_subdomain_workflow(tmp.path());
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn test_check_subdomain_workflow_missing_steps() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("seite.toml"),
+            seite_toml_with_subdomain_collection(),
+        )
+        .unwrap();
+        let wf_dir = tmp.path().join(".github/workflows");
+        fs::create_dir_all(&wf_dir).unwrap();
+        // Workflow only has main site deploy, no subdomain step
+        fs::write(
+            wf_dir.join("deploy.yml"),
+            "steps:\n  - command: pages deploy dist --project-name my-site\n",
+        )
+        .unwrap();
+        let actions = check_subdomain_workflow(tmp.path());
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            UpgradeAction::Create {
+                description,
+                content,
+                ..
+            } => {
+                assert!(description.contains("docs"));
+                assert!(content.contains("my-docs"));
+                assert!(content.contains("dist-subdomains/docs"));
+            }
+            _ => panic!("expected Create action"),
+        }
+    }
+
+    #[test]
+    fn test_check_subdomain_workflow_github_pages_skipped() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // GitHub Pages config with subdomain collection — should be skipped
+        let toml = "[site]\ntitle = \"Test\"\ndescription = \"\"\nbase_url = \"https://example.com\"\nlanguage = \"en\"\nauthor = \"\"\n\n[[collections]]\nname = \"docs\"\nlabel = \"Docs\"\ndirectory = \"docs\"\nhas_date = false\nhas_rss = true\nlisted = true\nnested = true\nurl_prefix = \"/docs\"\ndefault_template = \"doc.html\"\nsubdomain = \"docs\"\ndeploy_project = \"my-docs\"\n\n[deploy]\ntarget = \"github-pages\"\n";
+        fs::write(tmp.path().join("seite.toml"), toml).unwrap();
+        let wf_dir = tmp.path().join(".github/workflows");
+        fs::create_dir_all(&wf_dir).unwrap();
+        fs::write(wf_dir.join("deploy.yml"), "steps:\n").unwrap();
+        let actions = check_subdomain_workflow(tmp.path());
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn test_check_subdomain_workflow_no_deploy_project() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Subdomain collection without deploy_project — should not trigger upgrade
+        let toml = "[site]\ntitle = \"Test\"\ndescription = \"\"\nbase_url = \"https://example.com\"\nlanguage = \"en\"\nauthor = \"\"\n\n[[collections]]\nname = \"docs\"\nlabel = \"Docs\"\ndirectory = \"docs\"\nhas_date = false\nhas_rss = true\nlisted = true\nnested = true\nurl_prefix = \"/docs\"\ndefault_template = \"doc.html\"\nsubdomain = \"docs\"\n\n[deploy]\ntarget = \"cloudflare\"\nproject = \"my-site\"\n";
+        fs::write(tmp.path().join("seite.toml"), toml).unwrap();
+        let wf_dir = tmp.path().join(".github/workflows");
+        fs::create_dir_all(&wf_dir).unwrap();
+        fs::write(wf_dir.join("deploy.yml"), "steps:\n").unwrap();
+        let actions = check_subdomain_workflow(tmp.path());
+        assert!(actions.is_empty());
     }
 }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -165,12 +165,12 @@ const fn upgrade_steps() -> &'static [UpgradeStep] {
             check: check_atom_autodiscovery_template,
         },
         UpgradeStep {
-            introduced_in: (0, 11, 0),
+            introduced_in: (0, 12, 0),
             label: "Remove pinned VERSION from deploy workflows (use latest)",
             check: check_deploy_version_unpinning,
         },
         UpgradeStep {
-            introduced_in: (0, 11, 0),
+            introduced_in: (0, 12, 0),
             label: "Subdomain collection deploy steps in CI workflow",
             check: check_subdomain_workflow,
         },
@@ -1085,17 +1085,13 @@ fn check_subdomain_workflow(root: &Path) -> Vec<UpgradeAction> {
     }
 
     // Check if any subdomain collections have deploy_project configured
-    let subdomain_deploy_projects: Vec<_> = config
+    let subdomain_collections: Vec<_> = config
         .subdomain_collections()
         .into_iter()
-        .filter_map(|c| {
-            c.deploy_project
-                .as_deref()
-                .map(|p| (c.name.clone(), p.to_string()))
-        })
+        .filter(|c| c.deploy_project.is_some())
         .collect();
 
-    if subdomain_deploy_projects.is_empty() {
+    if subdomain_collections.is_empty() {
         return vec![];
     }
 
@@ -1106,19 +1102,20 @@ fn check_subdomain_workflow(root: &Path) -> Vec<UpgradeAction> {
 
     let content = fs::read_to_string(&workflow_path).unwrap_or_default();
 
-    // Check if all subdomain deploy projects are already referenced in the workflow
-    let all_present = subdomain_deploy_projects
+    // Check if all subdomain collections have deploy steps by looking for
+    // `dist-subdomains/{name}` which appears in both Cloudflare and Netlify workflows
+    let all_present = subdomain_collections
         .iter()
-        .all(|(_, project)| content.contains(project));
+        .all(|c| content.contains(&format!("dist-subdomains/{}", c.name)));
 
     if all_present {
         return vec![];
     }
 
-    let missing: Vec<_> = subdomain_deploy_projects
+    let missing: Vec<_> = subdomain_collections
         .iter()
-        .filter(|(_, project)| !content.contains(project.as_str()))
-        .map(|(name, _)| name.as_str())
+        .filter(|c| !content.contains(&format!("dist-subdomains/{}", c.name)))
+        .map(|c| c.name.as_str())
         .collect();
 
     let new_workflow = match &config.deploy.target {
@@ -1901,11 +1898,7 @@ mod tests {
         fs::write(tmp.path().join("seite.toml"), toml).unwrap();
         let wf_dir = tmp.path().join(".github/workflows");
         fs::create_dir_all(&wf_dir).unwrap();
-        fs::write(
-            wf_dir.join("deploy.yml"),
-            "steps:\n  - run: seite build\n",
-        )
-        .unwrap();
+        fs::write(wf_dir.join("deploy.yml"), "steps:\n  - run: seite build\n").unwrap();
         let actions = check_subdomain_workflow(tmp.path());
         assert_eq!(actions.len(), 1);
         match &actions[0] {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1859,4 +1859,82 @@ mod tests {
         let actions = check_subdomain_workflow(tmp.path());
         assert!(actions.is_empty());
     }
+
+    #[test]
+    fn test_check_deploy_version_unpinning_netlify_toml() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let toml = "[site]\ntitle = \"Test\"\ndescription = \"\"\nbase_url = \"https://example.com\"\nlanguage = \"en\"\nauthor = \"\"\n\n[[collections]]\nname = \"posts\"\nlabel = \"Posts\"\ndirectory = \"posts\"\nhas_date = true\nhas_rss = true\nlisted = true\nnested = false\nurl_prefix = \"/posts\"\ndefault_template = \"post.html\"\n\n[deploy]\ntarget = \"netlify\"\n";
+        fs::write(tmp.path().join("seite.toml"), toml).unwrap();
+        fs::write(
+            tmp.path().join("netlify.toml"),
+            "[build]\n  command = \"VERSION=0.10.0 curl -fsSL https://seite.sh/install.sh | sh && seite build\"\n",
+        )
+        .unwrap();
+        let actions = check_deploy_version_unpinning(tmp.path());
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            UpgradeAction::Create { content, .. } => {
+                assert!(!content.contains("VERSION="));
+            }
+            _ => panic!("expected Create action"),
+        }
+    }
+
+    #[test]
+    fn test_check_deploy_version_unpinning_no_seite_toml() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let actions = check_deploy_version_unpinning(tmp.path());
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn test_check_subdomain_workflow_no_seite_toml() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let actions = check_subdomain_workflow(tmp.path());
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn test_check_subdomain_workflow_netlify_target() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let toml = "[site]\ntitle = \"Test\"\ndescription = \"\"\nbase_url = \"https://example.com\"\nlanguage = \"en\"\nauthor = \"\"\n\n[[collections]]\nname = \"posts\"\nlabel = \"Posts\"\ndirectory = \"posts\"\nhas_date = true\nhas_rss = true\nlisted = true\nnested = false\nurl_prefix = \"/posts\"\ndefault_template = \"post.html\"\n\n[[collections]]\nname = \"docs\"\nlabel = \"Docs\"\ndirectory = \"docs\"\nhas_date = false\nhas_rss = true\nlisted = true\nnested = true\nurl_prefix = \"/docs\"\ndefault_template = \"doc.html\"\nsubdomain = \"docs\"\nsubdomain_base_url = \"https://docs.example.com\"\ndeploy_project = \"my-docs\"\n\n[deploy]\ntarget = \"netlify\"\n";
+        fs::write(tmp.path().join("seite.toml"), toml).unwrap();
+        let wf_dir = tmp.path().join(".github/workflows");
+        fs::create_dir_all(&wf_dir).unwrap();
+        fs::write(
+            wf_dir.join("deploy.yml"),
+            "steps:\n  - run: seite build\n",
+        )
+        .unwrap();
+        let actions = check_subdomain_workflow(tmp.path());
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            UpgradeAction::Create { content, .. } => {
+                assert!(content.contains("NETLIFY_SITE_ID_DOCS"));
+                assert!(content.contains("dist-subdomains/docs"));
+            }
+            _ => panic!("expected Create action"),
+        }
+    }
+
+    #[test]
+    fn test_check_deploy_version_unpinning_both_workflow_and_netlify() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let toml = "[site]\ntitle = \"Test\"\ndescription = \"\"\nbase_url = \"https://example.com\"\nlanguage = \"en\"\nauthor = \"\"\n\n[[collections]]\nname = \"posts\"\nlabel = \"Posts\"\ndirectory = \"posts\"\nhas_date = true\nhas_rss = true\nlisted = true\nnested = false\nurl_prefix = \"/posts\"\ndefault_template = \"post.html\"\n\n[deploy]\ntarget = \"netlify\"\n";
+        fs::write(tmp.path().join("seite.toml"), toml).unwrap();
+        let wf_dir = tmp.path().join(".github/workflows");
+        fs::create_dir_all(&wf_dir).unwrap();
+        fs::write(
+            wf_dir.join("deploy.yml"),
+            "run: VERSION=0.10.0 curl -fsSL https://seite.sh/install.sh | sh\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("netlify.toml"),
+            "command = \"VERSION=0.10.0 curl -fsSL https://seite.sh/install.sh | sh\"\n",
+        )
+        .unwrap();
+        let actions = check_deploy_version_unpinning(tmp.path());
+        assert_eq!(actions.len(), 2);
+    }
 }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1930,4 +1930,56 @@ mod tests {
         let actions = check_deploy_version_unpinning(tmp.path());
         assert_eq!(actions.len(), 2);
     }
+
+    fn valid_seite_toml_cloudflare() -> &'static str {
+        "[site]\ntitle = \"Test\"\ndescription = \"\"\nbase_url = \"http://localhost\"\nlanguage = \"en\"\nauthor = \"\"\n\n[[collections]]\nname = \"posts\"\nlabel = \"Posts\"\ndirectory = \"posts\"\nhas_date = true\nhas_rss = true\nlisted = true\nnested = false\nurl_prefix = \"/posts\"\ndefault_template = \"post.html\"\n\n[deploy]\ntarget = \"cloudflare\"\nproject = \"my-site\"\n"
+    }
+
+    #[test]
+    fn test_check_deploy_version_unpinning_cloudflare() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        fs::write(tmp.path().join("seite.toml"), valid_seite_toml_cloudflare()).unwrap();
+        let wf_dir = tmp.path().join(".github/workflows");
+        fs::create_dir_all(&wf_dir).unwrap();
+        fs::write(
+            wf_dir.join("deploy.yml"),
+            "run: VERSION=0.10.0 curl -fsSL https://seite.sh/install.sh | sh\n",
+        )
+        .unwrap();
+        let actions = check_deploy_version_unpinning(tmp.path());
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            UpgradeAction::Create { content, .. } => {
+                assert!(!content.contains("VERSION="));
+                assert!(content.contains("Cloudflare"));
+            }
+            _ => panic!("expected Create action"),
+        }
+    }
+
+    #[test]
+    fn test_check_deploy_version_unpinning_github_pages() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("seite.toml"),
+            valid_seite_toml_with_deploy(),
+        )
+        .unwrap();
+        let wf_dir = tmp.path().join(".github/workflows");
+        fs::create_dir_all(&wf_dir).unwrap();
+        fs::write(
+            wf_dir.join("deploy.yml"),
+            "run: VERSION=0.10.0 curl -fsSL https://seite.sh/install.sh | sh\n",
+        )
+        .unwrap();
+        let actions = check_deploy_version_unpinning(tmp.path());
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            UpgradeAction::Create { content, .. } => {
+                assert!(!content.contains("VERSION="));
+                assert!(content.contains("GitHub Pages"));
+            }
+            _ => panic!("expected Create action"),
+        }
+    }
 }

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -5751,4 +5751,16 @@ target = "github-pages"
         assert!(!workflow.contains("dist-subdomains"));
         assert!(workflow.contains("deploy-pages@v4"));
     }
+
+    #[test]
+    fn test_netlify_workflow_sanitizes_secret_suffix() {
+        let mut config = config_with_subdomain();
+        config.deploy.target = crate::config::DeployTarget::Netlify;
+        // Rename collection to have a hyphen
+        config.collections[1].name = "api-docs".into();
+        let workflow = generate_netlify_workflow(&config);
+        // Hyphen should be replaced with underscore in secret name
+        assert!(workflow.contains("NETLIFY_SITE_ID_API_DOCS"));
+        assert!(workflow.contains("dist-subdomains/api-docs"));
+    }
 }

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -3899,9 +3899,6 @@ target = "github-pages"
     }
 
     // Helper for the test above to avoid name collision with "workflow.contains"
-    fn workflow_contains_substr(s: &str, sub: &str) -> bool {
-        s.contains(sub)
-    }
 
     // -----------------------------------------------------------------------
     // update_deploy_config — additional edge cases

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -1751,7 +1751,13 @@ pub fn generate_netlify_workflow(config: &SiteConfig) -> String {
         if let Some(ref _deploy_proj) = col.deploy_project {
             // Use uppercase collection name for the secret name convention:
             // NETLIFY_SITE_ID_DOCS for a collection named "docs"
-            let secret_suffix = col.name.to_uppercase();
+            // Sanitize to valid GitHub secret name chars (A-Z0-9_)
+            let secret_suffix: String = col
+                .name
+                .to_uppercase()
+                .chars()
+                .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+                .collect();
             subdomain_steps.push_str(&format!(
                 r#"
       - name: Deploy {name} to Netlify

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -1616,7 +1616,6 @@ pub fn update_collection_deploy_project(
 /// Generate a GitHub Actions workflow YAML for building and deploying with GitHub Pages.
 pub fn generate_github_actions_workflow(config: &SiteConfig) -> String {
     let output_dir = &config.build.output_dir;
-    let version = env!("CARGO_PKG_VERSION");
     format!(
         r#"name: Deploy to GitHub Pages
 
@@ -1641,7 +1640,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install seite
-        run: VERSION={version} curl -fsSL https://seite.sh/install.sh | sh
+        run: curl -fsSL https://seite.sh/install.sh | sh
 
       - name: Build site
         run: seite build
@@ -1666,6 +1665,9 @@ jobs:
 }
 
 /// Generate a GitHub Actions workflow for Cloudflare Pages deployment.
+///
+/// When the config has collections with `subdomain` + `deploy_project`, additional
+/// deploy steps are generated for each subdomain collection.
 pub fn generate_cloudflare_workflow(config: &SiteConfig) -> String {
     let output_dir = &config.build.output_dir;
     let project = config
@@ -1673,7 +1675,24 @@ pub fn generate_cloudflare_workflow(config: &SiteConfig) -> String {
         .project
         .as_deref()
         .unwrap_or("your-project-name");
-    let version = env!("CARGO_PKG_VERSION");
+
+    let mut subdomain_steps = String::new();
+    for col in config.subdomain_collections() {
+        if let Some(ref deploy_proj) = col.deploy_project {
+            subdomain_steps.push_str(&format!(
+                r#"
+      - name: Deploy {name} to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{{{ secrets.CLOUDFLARE_API_TOKEN }}}}
+          accountId: ${{{{ secrets.CLOUDFLARE_ACCOUNT_ID }}}}
+          command: pages deploy dist-subdomains/{name} --project-name {deploy_proj}
+"#,
+                name = col.name,
+            ));
+        }
+    }
+
     format!(
         r#"name: Deploy to Cloudflare Pages
 
@@ -1689,7 +1708,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install seite
-        run: VERSION={version} curl -fsSL https://seite.sh/install.sh | sh
+        run: curl -fsSL https://seite.sh/install.sh | sh
 
       - name: Build site
         run: seite build
@@ -1700,17 +1719,16 @@ jobs:
           apiToken: ${{{{ secrets.CLOUDFLARE_API_TOKEN }}}}
           accountId: ${{{{ secrets.CLOUDFLARE_ACCOUNT_ID }}}}
           command: pages deploy {output_dir} --project-name {project}
-"#
+{subdomain_steps}"#
     )
 }
 
 /// Generate a Netlify configuration file (netlify.toml).
 pub fn generate_netlify_config(config: &SiteConfig) -> String {
     let output_dir = &config.build.output_dir;
-    let version = env!("CARGO_PKG_VERSION");
     format!(
         r#"[build]
-  command = "VERSION={version} curl -fsSL https://seite.sh/install.sh | sh && seite build"
+  command = "curl -fsSL https://seite.sh/install.sh | sh && seite build"
   publish = "{output_dir}"
 
 [[redirects]]
@@ -1722,9 +1740,34 @@ pub fn generate_netlify_config(config: &SiteConfig) -> String {
 }
 
 /// Generate a GitHub Actions workflow for Netlify deployment.
+///
+/// When the config has collections with `subdomain` + `deploy_project`, additional
+/// deploy steps are generated for each subdomain collection using separate site IDs.
 pub fn generate_netlify_workflow(config: &SiteConfig) -> String {
     let output_dir = &config.build.output_dir;
-    let version = env!("CARGO_PKG_VERSION");
+
+    let mut subdomain_steps = String::new();
+    for col in config.subdomain_collections() {
+        if let Some(ref _deploy_proj) = col.deploy_project {
+            // Use uppercase collection name for the secret name convention:
+            // NETLIFY_SITE_ID_DOCS for a collection named "docs"
+            let secret_suffix = col.name.to_uppercase();
+            subdomain_steps.push_str(&format!(
+                r#"
+      - name: Deploy {name} to Netlify
+        uses: nwtgck/actions-netlify@v3
+        with:
+          publish-dir: dist-subdomains/{name}
+          production-deploy: true
+        env:
+          NETLIFY_AUTH_TOKEN: ${{{{ secrets.NETLIFY_AUTH_TOKEN }}}}
+          NETLIFY_SITE_ID: ${{{{ secrets.NETLIFY_SITE_ID_{secret_suffix} }}}}
+"#,
+                name = col.name,
+            ));
+        }
+    }
+
     format!(
         r#"name: Deploy to Netlify
 
@@ -1740,7 +1783,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install seite
-        run: VERSION={version} curl -fsSL https://seite.sh/install.sh | sh
+        run: curl -fsSL https://seite.sh/install.sh | sh
 
       - name: Build site
         run: seite build
@@ -1753,7 +1796,7 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{{{ secrets.NETLIFY_AUTH_TOKEN }}}}
           NETLIFY_SITE_ID: ${{{{ secrets.NETLIFY_SITE_ID }}}}
-"#
+{subdomain_steps}"#
     )
 }
 
@@ -3757,11 +3800,11 @@ target = "github-pages"
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_generate_github_actions_workflow_contains_version() {
+    fn test_generate_github_actions_workflow_no_version_pin() {
         let config = test_config("https://example.com");
         let workflow = generate_github_actions_workflow(&config);
-        let version = env!("CARGO_PKG_VERSION");
-        assert!(workflow.contains(version));
+        assert!(!workflow.contains("VERSION="));
+        assert!(workflow.contains("curl -fsSL https://seite.sh/install.sh | sh"));
     }
 
     #[test]
@@ -3781,11 +3824,11 @@ target = "github-pages"
     }
 
     #[test]
-    fn test_generate_cloudflare_workflow_contains_version() {
+    fn test_generate_cloudflare_workflow_no_version_pin() {
         let config = test_config("https://example.com");
         let workflow = generate_cloudflare_workflow(&config);
-        let version = env!("CARGO_PKG_VERSION");
-        assert!(workflow.contains(version));
+        assert!(!workflow.contains("VERSION="));
+        assert!(workflow.contains("curl -fsSL https://seite.sh/install.sh | sh"));
     }
 
     #[test]
@@ -3799,11 +3842,11 @@ target = "github-pages"
     }
 
     #[test]
-    fn test_generate_netlify_config_contains_version() {
+    fn test_generate_netlify_config_no_version_pin() {
         let config = test_config("https://example.com");
         let netlify = generate_netlify_config(&config);
-        let version = env!("CARGO_PKG_VERSION");
-        assert!(workflow_contains_substr(&netlify, version));
+        assert!(!netlify.contains("VERSION="));
+        assert!(netlify.contains("curl -fsSL https://seite.sh/install.sh | sh && seite build"));
     }
 
     #[test]
@@ -3815,11 +3858,11 @@ target = "github-pages"
     }
 
     #[test]
-    fn test_generate_netlify_workflow_contains_version() {
+    fn test_generate_netlify_workflow_no_version_pin() {
         let config = test_config("https://example.com");
         let workflow = generate_netlify_workflow(&config);
-        let version = env!("CARGO_PKG_VERSION");
-        assert!(workflow.contains(version));
+        assert!(!workflow.contains("VERSION="));
+        assert!(workflow.contains("curl -fsSL https://seite.sh/install.sh | sh"));
     }
 
     #[test]
@@ -5591,5 +5634,118 @@ target = "github-pages"
             "passed message should include the output path: {}",
             check.message
         );
+    }
+
+    fn config_with_subdomain() -> SiteConfig {
+        SiteConfig {
+            site: crate::config::SiteSection {
+                title: "Test".into(),
+                description: "".into(),
+                base_url: "https://example.com".into(),
+                language: "en".into(),
+                author: "".into(),
+            },
+            collections: vec![
+                crate::config::CollectionConfig {
+                    name: "posts".into(),
+                    label: "Posts".into(),
+                    directory: "posts".into(),
+                    has_date: true,
+                    has_rss: true,
+                    listed: true,
+                    nested: false,
+                    url_prefix: "/posts".into(),
+                    default_template: "post.html".into(),
+                    subdomain: None,
+                    subdomain_base_url: None,
+                    deploy_project: None,
+                    paginate: None,
+                },
+                crate::config::CollectionConfig {
+                    name: "docs".into(),
+                    label: "Docs".into(),
+                    directory: "docs".into(),
+                    has_date: false,
+                    has_rss: true,
+                    listed: true,
+                    nested: true,
+                    url_prefix: "/docs".into(),
+                    default_template: "doc.html".into(),
+                    subdomain: Some("docs".into()),
+                    subdomain_base_url: Some("https://docs.example.com".into()),
+                    deploy_project: Some("my-docs".into()),
+                    paginate: None,
+                },
+            ],
+            build: Default::default(),
+            deploy: crate::config::DeploySection {
+                target: crate::config::DeployTarget::Cloudflare,
+                auto_commit: true,
+                project: Some("my-site".into()),
+                repo: None,
+                domain: None,
+            },
+            languages: Default::default(),
+            images: Default::default(),
+            analytics: None,
+            trust: None,
+            contact: None,
+        }
+    }
+
+    #[test]
+    fn test_cloudflare_workflow_includes_subdomain_deploy() {
+        let config = config_with_subdomain();
+        let workflow = generate_cloudflare_workflow(&config);
+        // Should have the main deploy step
+        assert!(workflow.contains("--project-name my-site"));
+        // Should have the subdomain deploy step
+        assert!(workflow.contains("--project-name my-docs"));
+        assert!(workflow.contains("dist-subdomains/docs"));
+        assert!(workflow.contains("Deploy docs to Cloudflare Pages"));
+    }
+
+    #[test]
+    fn test_cloudflare_workflow_no_subdomain() {
+        let mut config = config_with_subdomain();
+        // Remove subdomain collection
+        config.collections.retain(|c| c.subdomain.is_none());
+        let workflow = generate_cloudflare_workflow(&config);
+        assert!(workflow.contains("--project-name my-site"));
+        assert!(!workflow.contains("dist-subdomains"));
+    }
+
+    #[test]
+    fn test_netlify_workflow_includes_subdomain_deploy() {
+        let mut config = config_with_subdomain();
+        config.deploy.target = crate::config::DeployTarget::Netlify;
+        let workflow = generate_netlify_workflow(&config);
+        // Should have the main deploy step
+        assert!(workflow.contains("NETLIFY_SITE_ID"));
+        // Should have the subdomain deploy step with uppercase secret
+        assert!(workflow.contains("NETLIFY_SITE_ID_DOCS"));
+        assert!(workflow.contains("dist-subdomains/docs"));
+        assert!(workflow.contains("Deploy docs to Netlify"));
+    }
+
+    #[test]
+    fn test_netlify_workflow_no_subdomain() {
+        let mut config = config_with_subdomain();
+        config.deploy.target = crate::config::DeployTarget::Netlify;
+        config.collections.retain(|c| c.subdomain.is_none());
+        let workflow = generate_netlify_workflow(&config);
+        assert!(workflow.contains("NETLIFY_SITE_ID"));
+        assert!(!workflow.contains("NETLIFY_SITE_ID_DOCS"));
+        assert!(!workflow.contains("dist-subdomains"));
+    }
+
+    #[test]
+    fn test_github_pages_workflow_unchanged() {
+        let mut config = config_with_subdomain();
+        config.deploy.target = crate::config::DeployTarget::GithubPages;
+        let workflow = generate_github_actions_workflow(&config);
+        // GitHub Pages can't handle subdomain deploys, so no subdomain steps
+        assert!(!workflow.contains("dist-subdomains"));
+        assert!(workflow.contains("deploy-pages@v4"));
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6307,8 +6307,8 @@ jobs:
         "upgrade should use shell installer"
     );
     assert!(
-        content.contains(&format!("VERSION={}", env!("CARGO_PKG_VERSION"))),
-        "upgrade should pin seite version"
+        !content.contains("VERSION="),
+        "upgrade should not pin seite version (installs latest)"
     );
     assert!(
         content.contains("seite build"),


### PR DESCRIPTION
## Summary

- **Subdomain deploy steps** — Generated GitHub Actions workflows now include deploy steps for collections with `subdomain` + `deploy_project` configured (Cloudflare and Netlify). Previously users had to manually add these steps.
- **Remove VERSION pinning** — Generated workflows no longer hardcode `VERSION=x.y.z`. The install script resolves latest via `version.txt`, so CI always uses the current seite release without manual workflow updates.
- **Upgrade path** — `seite upgrade` on existing projects removes stale VERSION pins and adds missing subdomain deploy steps.
- **Fix Ed25519 key extraction** for mcp-publisher (unrelated fix, included in branch).

## Test plan

- [x] All 1,598 tests pass (1,236 unit + 362 integration)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` zero warnings
- [ ] Verify `seite upgrade` on a project with subdomain collections adds the deploy steps
- [ ] Verify `seite init` with subdomain collection generates correct workflow