### PR TITLE
Per-language data values (i18n resolution) — v0.14.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ src/
   shortcodes/          ShortcodeRegistry, parser, builtins (youtube, vimeo, gist, callout, figure, contact_form)
   build/               15-step build pipeline (mod.rs), analytics, base_path, code_copy, links, markdown, feed, sitemap, discovery, images, math
   docs.rs              Embedded docs (15 pages from seite-sh/content/docs/)
+  i18n.rs              Language-map resolution + `i18n`/`localize` Tera filter (per-language data values)
   meta.rs              Project metadata (.seite/config.json)
   mcp/                 MCP server (JSON-RPC over stdio): mod.rs, resources.rs, tools.rs
   cli/                 16 subcommands: init, new, build, serve, deploy, agent, theme, mcp, workspace, upgrade, contact, collection, skill, self_update, completions, perf
@@ -127,7 +128,7 @@ endpoint = "xpznqkdl"
 6. CLAUDE.md → update this file
 7. Tests → unit + integration
 8. Deploy fixtures → update `src/deploy/mod.rs` if SiteConfig changed
-9. i18n → `{{ t.key }}` for UI text, `{{ lang_prefix }}` for links
+9. i18n → `{{ t.key }}` for UI text, `{{ lang_prefix }}` for links, `{{ value | i18n(lang=lang) }}` for per-language data prose (language maps; see `src/i18n.rs`)
 
 ### Generated Site Structure
 - `seite init` creates lean CLAUDE.md + `.claude/rules/*.md` (path-scoped context)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/seite-sh/content/changelog/2026-06-24-v0-14-0.md
+++ b/seite-sh/content/changelog/2026-06-24-v0-14-0.md
@@ -1,0 +1,47 @@
+---
+title: v0.14.0
+description: "Data file values can now carry per-language variants. A value like { en: \"Cloud infrastructure\", de: \"Cloud-Infrastruktur\" } resolves to the current page language, so the bundled Trust Center is bilingual out of the box. Plain single-language data is unchanged."
+date: 2026-06-24
+tags:
+- feature
+---
+
+## Per-language data values (i18n for data-driven templates)
+
+Data files (`data/**`) can now provide **language maps** — values whose keys are your configured language codes — and they resolve to the language of the page being rendered. This makes data-driven templates like the bundled **Trust Center** bilingual without duplicating data files.
+
+### Language maps
+
+Any data value may be a map keyed by language code:
+
+```yaml
+# data/trust/faq.yaml
+- question:
+    en: Where is data stored?
+    de: Wo werden Daten gespeichert?
+  answer:
+    en: Data is stored in the EU.
+    de: Daten werden in der EU gespeichert.
+```
+
+When the page renders for `de`, the value resolves to the German variant; for `en`, the English one. Resolution falls back to the default language, then to the first present entry, so a partially translated value still renders something sensible.
+
+A map is only treated as a language map when **all** of its keys are configured language codes. A map like `{ icon: "shield", label: "Security" }` is left untouched, and plain strings, numbers, and booleans pass through byte-for-byte — existing single-language sites produce identical output.
+
+### The `i18n` filter
+
+Resolution is exposed as a Tera filter (alias `localize`) for use in any template:
+
+```html
+{{ value | i18n(lang=lang) }}
+```
+
+The bundled `trust-index.html` and `trust-item.html` templates already apply it to all prose fields — certification name/description/scope/auditor, subprocessor name/purpose/location, and FAQ question/answer — so the Trust Center is bilingual out of the box.
+
+### Missing-translation warnings
+
+When a value is present in some but not all configured languages, the build prints a warning that points at the path and the missing language(s), so gaps in translation are easy to spot:
+
+```
+⚠ Warning: data.trust.faq[0].answer: language map missing translation(s) for de
+```

--- a/seite-sh/content/docs/configuration.md
+++ b/seite-sh/content/docs/configuration.md
@@ -172,6 +172,18 @@ copyright: "2026 My Company"
 
 The build will error if two data files share the same stem (e.g., `authors.yaml` and `authors.json`) or if a file and directory conflict (e.g., `nav.yaml` and `nav/main.yaml`). Unknown file extensions are skipped with a warning.
 
+### Per-language values
+
+On a multi-language site, any data value may be a **language map** — a mapping keyed by your configured language codes — and it resolves to the page's language at build time:
+
+```yaml
+purpose:
+  en: "Cloud infrastructure"
+  de: "Cloud-Infrastruktur"
+```
+
+Plain values are unchanged; only maps whose keys are *all* configured language codes are resolved. See [Per-Language Data Values](/docs/i18n#per-language-data-values).
+
 ## [deploy]
 
 | Field | Type | Default | Description |

--- a/seite-sh/content/docs/i18n.md
+++ b/seite-sh/content/docs/i18n.md
@@ -161,6 +161,48 @@ older: "Más antiguos"
 
 See [Templates & Themes](/docs/templates) for the full list of available keys.
 
+## Per-Language Data Values
+
+UI strings cover theme chrome. For **prose inside data files** — the kind that drives the [Trust Center](/docs/trust-center) (certification descriptions, subprocessor purposes, FAQ answers) — any value may be a **language map**: a mapping whose keys are exactly your configured language codes.
+
+```yaml
+# data/trust/faq.yaml
+- question:
+    en: Where is data stored?
+    de: Wo werden Daten gespeichert?
+  answer:
+    en: Data is stored in the EU.
+    de: Daten werden in der EU gespeichert.
+```
+
+When the page renders for `de`, each value resolves to its German variant; for the default language, the English one. The same data file serves both `/trust/` and `/de/trust/`.
+
+### Resolution rules
+
+- For language `L`, a language map resolves to `value[L]`, falling back to the **default language**, then to the **first present entry**.
+- A map is treated as a language map **only when every key is a configured language code**. A map like `{ icon: "shield", label: "Security" }` is left untouched.
+- Plain strings, numbers, and booleans pass through unchanged — single-language sites produce byte-identical output and need no migration.
+
+### The `i18n` filter
+
+Resolution is also exposed as a Tera filter (alias `localize`) for use in your own templates:
+
+```html
+{{ value | i18n(lang=lang) }}
+```
+
+Pass `lang=lang` to resolve to the current page language. An optional `default="…"` overrides the fallback language; with no `lang` argument the filter resolves to the default language. The bundled `trust-index.html` and `trust-item.html` templates already apply it to every prose field, so the Trust Center is bilingual out of the box.
+
+### Missing-translation warnings
+
+If a value is present in some — but not all — configured languages, the build prints a warning pointing at the path and the missing language(s):
+
+```
+⚠ Warning: data.trust.faq[0].answer: language map missing translation(s) for de
+```
+
+The page still renders using the fallback, so a partial translation never breaks the build.
+
 ## Next Steps
 
 - [Collections](/docs/collections): how translations work across posts, docs, and pages

--- a/seite-sh/content/docs/trust-center.md
+++ b/seite-sh/content/docs/trust-center.md
@@ -169,7 +169,21 @@ seite build
 
 ## Multi-language Support
 
-Data files (`data/trust/*.yaml`) are language-neutral: structured data like dates, statuses, and vendor names don't change per language.
+Structured data like dates, statuses, and vendor names is language-neutral. **Prose fields can be translated** by writing a [language map](/docs/i18n#per-language-data-values) — a value keyed by your configured language codes:
+
+```yaml
+# data/trust/subprocessors.yaml
+- name: "AWS"                         # language-neutral
+  purpose:                            # language map → resolves per page
+    en: "Cloud infrastructure and hosting"
+    de: "Cloud-Infrastruktur und Hosting"
+  location:
+    en: "United States"
+    de: "Vereinigte Staaten"
+  dpa: true
+```
+
+The bundled `trust-index.html` and `trust-item.html` templates resolve language maps automatically for certification `name`/`description`/`scope`/`auditor`, subprocessor `name`/`purpose`/`location`, and FAQ `question`/`answer`. Plain single-language strings are rendered unchanged, so existing data needs no migration. See [Per-Language Data Values](/docs/i18n#per-language-data-values) for the full rules.
 
 Content pages get translated using the standard i18n filename convention:
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -506,7 +506,7 @@ fn build_site_inner(
     // Step 2: Load templates (collection-aware)
     progress.step("Loading templates");
     let step_start = Instant::now();
-    let tera = templates::load_templates(&paths.templates, &config.collections)?;
+    let mut tera = templates::load_templates(&paths.templates, &config.collections)?;
     step_timings.push((
         "Load templates".to_string(),
         step_start.elapsed().as_secs_f64() * 1000.0,
@@ -535,6 +535,16 @@ fn build_site_inner(
     let configured_langs = config.configured_lang_codes();
     let is_multilingual = config.is_multilingual();
     let default_lang = &config.site.language;
+
+    // Register the i18n filter so templates can resolve per-language "language
+    // maps" in data values (e.g. `{{ cert.description | i18n(lang=lang) }}`).
+    // Then warn about partial language maps (some configured languages missing).
+    let lang_codes: std::collections::HashSet<String> =
+        config.all_languages().into_iter().collect();
+    crate::i18n::register_filters(&mut tera, default_lang, &lang_codes);
+    for warning in crate::i18n::partial_language_map_warnings(&data, &lang_codes) {
+        eprintln!("⚠ Warning: {warning}");
+    }
 
     // Step 3: Process each collection
     progress.step("Processing content");

--- a/src/cli/telemetry.rs
+++ b/src/cli/telemetry.rs
@@ -23,11 +23,15 @@ pub fn run(args: &TelemetryArgs) -> anyhow::Result<()> {
         }
         TelemetryCommand::On => match crate::telemetry::set_enabled(true) {
             Some(()) => println!("Telemetry enabled."),
-            None => eprintln!("Could not save telemetry preference (could not write ~/.seite/telemetry.json)."),
+            None => eprintln!(
+                "Could not save telemetry preference (could not write ~/.seite/telemetry.json)."
+            ),
         },
         TelemetryCommand::Off => match crate::telemetry::set_enabled(false) {
             Some(()) => println!("Telemetry disabled."),
-            None => eprintln!("Could not save telemetry preference (could not write ~/.seite/telemetry.json)."),
+            None => eprintln!(
+                "Could not save telemetry preference (could not write ~/.seite/telemetry.json)."
+            ),
         },
     }
     Ok(())

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -38,13 +38,13 @@ pub fn resolve_value(
 ) -> Value {
     if let Value::Object(obj) = value {
         if is_language_map(obj, lang_codes) {
-            if let Some(v) = obj.get(lang) {
-                return v.clone();
-            }
-            if let Some(v) = obj.get(default_lang) {
-                return v.clone();
-            }
-            if let Some((_, v)) = obj.iter().next() {
+            // Requested language, then the default, then any entry.
+            // `is_language_map` guarantees a non-empty map, so this always yields.
+            if let Some(v) = obj
+                .get(lang)
+                .or_else(|| obj.get(default_lang))
+                .or_else(|| obj.values().next())
+            {
                 return v.clone();
             }
         }
@@ -57,6 +57,7 @@ pub fn resolve_value(
 /// configured languages. Only meaningful for multilingual sites.
 pub fn partial_language_map_warnings(data: &Value, lang_codes: &HashSet<String>) -> Vec<String> {
     let mut warnings = Vec::new();
+    // `data` is always a JSON object (the data dir loads into a root map).
     if lang_codes.len() > 1 {
         if let Value::Object(obj) = data {
             for (key, value) in obj {
@@ -68,8 +69,6 @@ pub fn partial_language_map_warnings(data: &Value, lang_codes: &HashSet<String>)
                 }
                 collect_partial(value, &format!("data.{key}"), lang_codes, &mut warnings);
             }
-        } else {
-            collect_partial(data, "data", lang_codes, &mut warnings);
         }
     }
     warnings

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -1,0 +1,327 @@
+//! Per-language resolution of data values ("language maps").
+//!
+//! A *language map* is a JSON object whose keys are EXACTLY the site's
+//! configured language codes, e.g. `{ "en": "Hello", "de": "Hallo" }`. When a
+//! page is rendered for language `L`, such a value resolves to `value[L]`,
+//! falling back to the default language, then the first present entry.
+//!
+//! Any other value — scalars, arrays, or maps that contain a non-language key
+//! (e.g. `{ icon, label }`) — passes through untouched, so plain
+//! single-language data stays byte-identical and fully backward compatible.
+//!
+//! Resolution is exposed as the Tera `i18n` filter (alias `localize`):
+//! `{{ value | i18n(lang=lang) }}`.
+
+use std::collections::{HashMap, HashSet};
+
+use serde_json::{Map, Value};
+
+/// True if `obj` is a non-empty map whose keys are *all* known language codes.
+///
+/// This is the gate from requirement 3: a map is only treated as a language map
+/// when every key is a configured language code. A map that merely contains a
+/// language-like key alongside others (`{ icon, label }`) is left untouched.
+pub fn is_language_map(obj: &Map<String, Value>, lang_codes: &HashSet<String>) -> bool {
+    !obj.is_empty() && obj.keys().all(|k| lang_codes.contains(k))
+}
+
+/// Resolve `value` for `lang`.
+///
+/// If `value` is a language map, return `value[lang]`, falling back to
+/// `value[default_lang]`, then the first present entry. Otherwise return a
+/// clone of `value` unchanged.
+pub fn resolve_value(
+    value: &Value,
+    lang: &str,
+    default_lang: &str,
+    lang_codes: &HashSet<String>,
+) -> Value {
+    if let Value::Object(obj) = value {
+        if is_language_map(obj, lang_codes) {
+            if let Some(v) = obj.get(lang) {
+                return v.clone();
+            }
+            if let Some(v) = obj.get(default_lang) {
+                return v.clone();
+            }
+            if let Some((_, v)) = obj.iter().next() {
+                return v.clone();
+            }
+        }
+    }
+    value.clone()
+}
+
+/// Collect human-readable warnings for *partial* language maps in `data`:
+/// objects whose keys are all language codes but which are missing one or more
+/// configured languages. Only meaningful for multilingual sites.
+pub fn partial_language_map_warnings(data: &Value, lang_codes: &HashSet<String>) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if lang_codes.len() > 1 {
+        if let Value::Object(obj) = data {
+            for (key, value) in obj {
+                // `data.i18n` (data/i18n/{lang}.yaml) is the reserved UI-strings
+                // convention: missing languages intentionally fall back to the
+                // English defaults, so it is not a "partial" translation.
+                if key == "i18n" {
+                    continue;
+                }
+                collect_partial(value, &format!("data.{key}"), lang_codes, &mut warnings);
+            }
+        } else {
+            collect_partial(data, "data", lang_codes, &mut warnings);
+        }
+    }
+    warnings
+}
+
+fn collect_partial(value: &Value, path: &str, lang_codes: &HashSet<String>, out: &mut Vec<String>) {
+    match value {
+        Value::Object(obj) => {
+            if is_language_map(obj, lang_codes) {
+                if obj.len() < lang_codes.len() {
+                    let mut missing: Vec<&str> = lang_codes
+                        .iter()
+                        .filter(|c| !obj.contains_key(*c))
+                        .map(|s| s.as_str())
+                        .collect();
+                    missing.sort_unstable();
+                    out.push(format!(
+                        "{path}: language map missing translation(s) for {}",
+                        missing.join(", ")
+                    ));
+                }
+                // The variants are leaf prose; don't recurse into them.
+            } else {
+                for (k, v) in obj {
+                    collect_partial(v, &format!("{path}.{k}"), lang_codes, out);
+                }
+            }
+        }
+        Value::Array(arr) => {
+            for (i, v) in arr.iter().enumerate() {
+                collect_partial(v, &format!("{path}[{i}]"), lang_codes, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// A Tera filter that resolves a language map to the current language.
+#[derive(Clone)]
+struct LangFilter {
+    default_lang: String,
+    lang_codes: HashSet<String>,
+}
+
+impl tera::Filter for LangFilter {
+    fn filter(&self, value: &Value, args: &HashMap<String, Value>) -> tera::Result<Value> {
+        let lang = args.get("lang").and_then(|v| v.as_str()).unwrap_or("");
+        let default = args
+            .get("default")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&self.default_lang);
+        Ok(resolve_value(value, lang, default, &self.lang_codes))
+    }
+}
+
+/// Register the `i18n` filter (and its `localize` alias) on a Tera instance.
+///
+/// Usage in templates: `{{ value | i18n(lang=lang) }}`. The optional `default`
+/// argument overrides the fallback language. Without a `lang` argument the
+/// filter resolves to the default language.
+pub fn register_filters(tera: &mut tera::Tera, default_lang: &str, lang_codes: &HashSet<String>) {
+    let filter = LangFilter {
+        default_lang: default_lang.to_string(),
+        lang_codes: lang_codes.clone(),
+    };
+    tera.register_filter("i18n", filter.clone());
+    tera.register_filter("localize", filter);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn codes(list: &[&str]) -> HashSet<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ---- is_language_map -------------------------------------------------
+
+    #[test]
+    fn language_map_when_all_keys_are_codes() {
+        let v = json!({ "en": "Hello", "de": "Hallo" });
+        assert!(is_language_map(
+            v.as_object().unwrap(),
+            &codes(&["en", "de"])
+        ));
+    }
+
+    #[test]
+    fn not_language_map_when_a_key_is_not_a_code() {
+        let v = json!({ "icon": "x", "label": "y" });
+        assert!(!is_language_map(
+            v.as_object().unwrap(),
+            &codes(&["en", "de"])
+        ));
+    }
+
+    #[test]
+    fn not_language_map_when_empty() {
+        let v = json!({});
+        assert!(!is_language_map(
+            v.as_object().unwrap(),
+            &codes(&["en", "de"])
+        ));
+    }
+
+    #[test]
+    fn not_language_map_when_one_key_is_foreign() {
+        // `xx` is not configured, so the whole map is left untouched.
+        let v = json!({ "en": "Hello", "xx": "??" });
+        assert!(!is_language_map(
+            v.as_object().unwrap(),
+            &codes(&["en", "de"])
+        ));
+    }
+
+    // ---- resolve_value ---------------------------------------------------
+
+    #[test]
+    fn resolves_to_current_language() {
+        let v = json!({ "en": "Cloud infrastructure", "de": "Cloud-Infrastruktur" });
+        let out = resolve_value(&v, "de", "en", &codes(&["en", "de"]));
+        assert_eq!(out, json!("Cloud-Infrastruktur"));
+    }
+
+    #[test]
+    fn falls_back_to_default_language_when_current_missing() {
+        let v = json!({ "en": "Cloud infrastructure" });
+        let out = resolve_value(&v, "de", "en", &codes(&["en", "de"]));
+        assert_eq!(out, json!("Cloud infrastructure"));
+    }
+
+    #[test]
+    fn falls_back_to_first_entry_when_default_also_missing() {
+        // Only `fr` present; neither requested `de` nor default `en` exist.
+        let v = json!({ "fr": "Bonjour" });
+        let out = resolve_value(&v, "de", "en", &codes(&["en", "de", "fr"]));
+        assert_eq!(out, json!("Bonjour"));
+    }
+
+    #[test]
+    fn passes_scalar_through_unchanged() {
+        let v = json!("plain string");
+        let out = resolve_value(&v, "de", "en", &codes(&["en", "de"]));
+        assert_eq!(out, json!("plain string"));
+    }
+
+    #[test]
+    fn passes_non_language_map_through_unchanged() {
+        let v = json!({ "icon": "shield", "label": "Security" });
+        let out = resolve_value(&v, "de", "en", &codes(&["en", "de"]));
+        assert_eq!(out, v);
+    }
+
+    #[test]
+    fn passes_number_and_bool_through_unchanged() {
+        assert_eq!(
+            resolve_value(&json!(42), "de", "en", &codes(&["en", "de"])),
+            json!(42)
+        );
+        assert_eq!(
+            resolve_value(&json!(true), "de", "en", &codes(&["en", "de"])),
+            json!(true)
+        );
+    }
+
+    // ---- Tera filter -----------------------------------------------------
+
+    fn render(tmpl: &str, ctx: &tera::Context, default_lang: &str, langs: &[&str]) -> String {
+        let mut tera = tera::Tera::default();
+        register_filters(&mut tera, default_lang, &codes(langs));
+        tera.add_raw_template("t", tmpl).unwrap();
+        tera.render("t", ctx).unwrap()
+    }
+
+    #[test]
+    fn filter_resolves_with_explicit_lang() {
+        let mut ctx = tera::Context::new();
+        ctx.insert("v", &json!({ "en": "Hello", "de": "Hallo" }));
+        ctx.insert("lang", "de");
+        let out = render("{{ v | i18n(lang=lang) }}", &ctx, "en", &["en", "de"]);
+        assert_eq!(out, "Hallo");
+    }
+
+    #[test]
+    fn filter_alias_localize_works() {
+        let mut ctx = tera::Context::new();
+        ctx.insert("v", &json!({ "en": "Hello", "de": "Hallo" }));
+        ctx.insert("lang", "de");
+        let out = render("{{ v | localize(lang=lang) }}", &ctx, "en", &["en", "de"]);
+        assert_eq!(out, "Hallo");
+    }
+
+    #[test]
+    fn filter_without_lang_arg_uses_default_language() {
+        let mut ctx = tera::Context::new();
+        ctx.insert("v", &json!({ "en": "Hello", "de": "Hallo" }));
+        let out = render("{{ v | i18n }}", &ctx, "en", &["en", "de"]);
+        assert_eq!(out, "Hello");
+    }
+
+    #[test]
+    fn filter_leaves_plain_string_byte_identical() {
+        let mut ctx = tera::Context::new();
+        ctx.insert("v", &json!("SOC 2 Type II report"));
+        ctx.insert("lang", "de");
+        let out = render("{{ v | i18n(lang=lang) }}", &ctx, "en", &["en", "de"]);
+        assert_eq!(out, "SOC 2 Type II report");
+    }
+
+    // ---- partial language map warnings -----------------------------------
+
+    #[test]
+    fn warns_on_partial_language_map() {
+        let data = json!({ "trust": { "faq": [ { "answer": { "en": "Yes" } } ] } });
+        let warnings = partial_language_map_warnings(&data, &codes(&["en", "de"]));
+        assert_eq!(warnings.len(), 1, "warnings: {warnings:?}");
+        assert!(warnings[0].contains("de"), "warnings: {warnings:?}");
+        assert!(
+            warnings[0].contains("data.trust.faq[0].answer"),
+            "warnings: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn no_warning_when_language_map_is_complete() {
+        let data = json!({ "x": { "en": "Yes", "de": "Ja" } });
+        let warnings = partial_language_map_warnings(&data, &codes(&["en", "de"]));
+        assert!(warnings.is_empty(), "warnings: {warnings:?}");
+    }
+
+    #[test]
+    fn no_warning_for_non_language_map() {
+        let data = json!({ "badge": { "icon": "shield", "label": "Security" } });
+        let warnings = partial_language_map_warnings(&data, &codes(&["en", "de"]));
+        assert!(warnings.is_empty(), "warnings: {warnings:?}");
+    }
+
+    #[test]
+    fn no_warning_for_monolingual_site() {
+        let data = json!({ "x": { "en": "Yes" } });
+        let warnings = partial_language_map_warnings(&data, &codes(&["en"]));
+        assert!(warnings.is_empty(), "warnings: {warnings:?}");
+    }
+
+    #[test]
+    fn no_warning_for_reserved_i18n_ui_strings() {
+        // `data/i18n/{lang}.yaml` deliberately falls back to English defaults for
+        // any language without a file; it must not be flagged as a partial map.
+        let data = json!({ "i18n": { "en": { "newer": "Newer" } } });
+        let warnings = partial_language_map_warnings(&data, &codes(&["en", "de"]));
+        assert!(warnings.is_empty(), "warnings: {warnings:?}");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod data;
 pub mod deploy;
 pub mod docs;
 pub mod error;
+pub mod i18n;
 pub mod mcp;
 pub mod meta;
 pub mod output;

--- a/src/scaffold/i18n.md
+++ b/src/scaffold/i18n.md
@@ -57,3 +57,27 @@ older: "Más antiguos"
 
 Available keys: `search_placeholder`, `skip_to_content`, `no_results`, `newer`, `older`, `page_n_of_total`, `search_label`, `min_read`, `contents`, `tags`, `all_tags`, `tagged`, `changelog`, `roadmap`, `not_found_title`, `not_found_message`, `go_home`, `in_progress`, `planned`, `done`, `other`, `trust_center`, `trust_hero_subtitle`, `certifications_compliance`, `active`, `learn_more`, `auditor`, `scope`, `issued`, `expires`, `subprocessors`, `vendor`, `purpose`, `location`, `dpa`, `yes`, `no`, `faq`.
 
+### Per-Language Data Values
+
+Prose inside data files (e.g. Trust Center certification descriptions, subprocessor purposes, FAQ answers) can be translated with a **language map** — a value keyed by your configured language codes:
+
+```yaml
+# data/trust/faq.yaml
+- question:
+    en: Where is data stored?
+    es: ¿Dónde se almacenan los datos?
+  answer:
+    en: Data is stored in the EU.
+    es: Los datos se almacenan en la UE.
+```
+
+When rendering for a language, a language map resolves to that language (falling back to the default language, then the first entry). A map is only treated this way when **every key is a configured language code** — `{ icon, label }` is left untouched, and plain strings render unchanged.
+
+Resolve language maps in any template with the `i18n` filter (alias `localize`):
+
+```html
+{{ value | i18n(lang=lang) }}
+```
+
+The bundled `trust-index.html` / `trust-item.html` apply it automatically. The build warns when a value is translated into some but not all configured languages.
+

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -40,7 +40,9 @@ fn write_config(path: &Path, cfg: &TelemetryConfig) -> Option<()> {
 }
 
 fn env_nonempty(key: &str) -> bool {
-    std::env::var(key).map(|v| !v.trim().is_empty()).unwrap_or(false)
+    std::env::var(key)
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false)
 }
 
 /// Full opt-out decision using real env + saved config.
@@ -48,7 +50,9 @@ pub fn decision() -> Decision {
     let cfg = config_path().map(|p| load_config(&p)).unwrap_or_default();
     resolve(
         env_nonempty("DO_NOT_TRACK"),
-        std::env::var("SEITE_TELEMETRY").ok().and_then(|v| parse_flag(&v)),
+        std::env::var("SEITE_TELEMETRY")
+            .ok()
+            .and_then(|v| parse_flag(&v)),
         env_nonempty("CI"),
         cfg.enabled,
     )
@@ -69,7 +73,11 @@ pub fn set_enabled(on: bool) -> Option<()> {
 /// One-line human status for `seite telemetry status`.
 pub fn status_line() -> String {
     let d = decision();
-    let state = if d.is_enabled() { "enabled" } else { "disabled" };
+    let state = if d.is_enabled() {
+        "enabled"
+    } else {
+        "disabled"
+    };
     let reason = match d {
         Decision::DisabledByDoNotTrack => "DO_NOT_TRACK is set",
         Decision::EnabledByEnv | Decision::DisabledByEnv => "SEITE_TELEMETRY env override",
@@ -115,13 +123,21 @@ fn resolve(dnt: bool, env_flag: Option<bool>, ci: bool, cfg: Option<bool>) -> De
         return Decision::DisabledByDoNotTrack;
     }
     if let Some(v) = env_flag {
-        return if v { Decision::EnabledByEnv } else { Decision::DisabledByEnv };
+        return if v {
+            Decision::EnabledByEnv
+        } else {
+            Decision::DisabledByEnv
+        };
     }
     if ci {
         return Decision::DisabledByCi;
     }
     if let Some(v) = cfg {
-        return if v { Decision::EnabledByConfig } else { Decision::DisabledByConfig };
+        return if v {
+            Decision::EnabledByConfig
+        } else {
+            Decision::DisabledByConfig
+        };
     }
     Decision::EnabledByDefault
 }
@@ -249,17 +265,38 @@ mod tests {
     #[test]
     fn resolve_precedence() {
         // DO_NOT_TRACK wins over everything.
-        assert_eq!(resolve(true, Some(true), false, Some(true)), Decision::DisabledByDoNotTrack);
+        assert_eq!(
+            resolve(true, Some(true), false, Some(true)),
+            Decision::DisabledByDoNotTrack
+        );
         // env flag beats CI and config.
-        assert_eq!(resolve(false, Some(false), false, Some(true)), Decision::DisabledByEnv);
-        assert_eq!(resolve(false, Some(true), true, Some(false)), Decision::EnabledByEnv);
+        assert_eq!(
+            resolve(false, Some(false), false, Some(true)),
+            Decision::DisabledByEnv
+        );
+        assert_eq!(
+            resolve(false, Some(true), true, Some(false)),
+            Decision::EnabledByEnv
+        );
         // CI beats config.
-        assert_eq!(resolve(false, None, true, Some(true)), Decision::DisabledByCi);
+        assert_eq!(
+            resolve(false, None, true, Some(true)),
+            Decision::DisabledByCi
+        );
         // config beats default.
-        assert_eq!(resolve(false, None, false, Some(false)), Decision::DisabledByConfig);
-        assert_eq!(resolve(false, None, false, Some(true)), Decision::EnabledByConfig);
+        assert_eq!(
+            resolve(false, None, false, Some(false)),
+            Decision::DisabledByConfig
+        );
+        assert_eq!(
+            resolve(false, None, false, Some(true)),
+            Decision::EnabledByConfig
+        );
         // default is enabled (opt-out).
-        assert_eq!(resolve(false, None, false, None), Decision::EnabledByDefault);
+        assert_eq!(
+            resolve(false, None, false, None),
+            Decision::EnabledByDefault
+        );
     }
 
     #[test]
@@ -285,7 +322,10 @@ mod tests {
         assert!(!cfg.notice_shown);
 
         // Write then read back.
-        let written = TelemetryConfig { enabled: Some(false), notice_shown: true };
+        let written = TelemetryConfig {
+            enabled: Some(false),
+            notice_shown: true,
+        };
         write_config(&path, &written).unwrap();
         let read = load_config(&path);
         assert_eq!(read.enabled, Some(false));
@@ -314,8 +354,14 @@ mod tests {
 
     #[test]
     fn endpoint_prefers_runtime_then_compiled_then_default() {
-        assert_eq!(resolve_endpoint(Some("https://rt".into()), Some("https://ct")), "https://rt");
-        assert_eq!(resolve_endpoint(Some("  ".into()), Some("https://ct")), "https://ct");
+        assert_eq!(
+            resolve_endpoint(Some("https://rt".into()), Some("https://ct")),
+            "https://rt"
+        );
+        assert_eq!(
+            resolve_endpoint(Some("  ".into()), Some("https://ct")),
+            "https://ct"
+        );
         assert_eq!(resolve_endpoint(None, Some("https://ct")), "https://ct");
         assert_eq!(resolve_endpoint(None, None), DEFAULT_ENDPOINT);
     }
@@ -323,14 +369,24 @@ mod tests {
     #[test]
     fn command_payload_has_only_allowed_fields() {
         use std::time::Duration;
-        let v = build_command_payload("build", true, Duration::from_secs(2), "0.12.2", "linux", "x86_64");
+        let v = build_command_payload(
+            "build",
+            true,
+            Duration::from_secs(2),
+            "0.12.2",
+            "linux",
+            "x86_64",
+        );
         assert_eq!(v["name"], "command");
         assert_eq!(v["domain"], "cli.seite.sh");
         assert_eq!(v["url"], "https://cli.seite.sh/cmd/build");
         let props = v["props"].as_object().unwrap();
         let mut keys: Vec<&String> = props.keys().collect();
         keys.sort();
-        assert_eq!(keys, vec!["arch", "duration_bucket", "os", "success", "version"]);
+        assert_eq!(
+            keys,
+            vec!["arch", "duration_bucket", "os", "success", "version"]
+        );
         assert_eq!(props["version"], "0.12.2");
         assert_eq!(props["success"], true);
         assert_eq!(props["duration_bucket"], "1-5s");

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -407,8 +407,8 @@ pub const DEFAULT_TRUST_ITEM: &str = r##"{% extends "base.html" %}
         <span class="cert-status cert-status--{{ cert.status }}">
             {% if cert.status == "active" %}{{ t.active }}{% elif cert.status == "in_progress" %}{{ t.in_progress }}{% else %}{{ t.planned }}{% endif %}
         </span>
-        {% if cert.auditor %}<div class="cert-meta"><strong>{{ t.auditor }}:</strong> {{ cert.auditor }}</div>{% endif %}
-        {% if cert.scope %}<div class="cert-meta"><strong>{{ t.scope }}:</strong> {{ cert.scope }}</div>{% endif %}
+        {% if cert.auditor %}<div class="cert-meta"><strong>{{ t.auditor }}:</strong> {{ cert.auditor | i18n(lang=lang) }}</div>{% endif %}
+        {% if cert.scope %}<div class="cert-meta"><strong>{{ t.scope }}:</strong> {{ cert.scope | i18n(lang=lang) }}</div>{% endif %}
         {% if cert.issued %}<div class="cert-meta"><strong>{{ t.issued }}:</strong> {{ cert.issued }}</div>{% endif %}
         {% if cert.expires %}<div class="cert-meta"><strong>{{ t.expires }}:</strong> {{ cert.expires }}</div>{% endif %}
     </div>
@@ -440,8 +440,8 @@ pub const DEFAULT_TRUST_INDEX: &str = r##"{% extends "base.html" %}
                         {% if cert.status == "active" %}{{ t.active }}{% elif cert.status == "in_progress" %}{{ t.in_progress }}{% else %}{{ t.planned }}{% endif %}
                     </span>
                 </div>
-                <h3 class="cert-card__title">{{ cert.name }}</h3>
-                {% if cert.description %}<p class="cert-card__desc">{{ cert.description }}</p>{% endif %}
+                <h3 class="cert-card__title">{{ cert.name | i18n(lang=lang) }}</h3>
+                {% if cert.description %}<p class="cert-card__desc">{{ cert.description | i18n(lang=lang) }}</p>{% endif %}
                 {% if cert.slug %}<a href="{{ lang_prefix }}/trust/certifications/{{ cert.slug }}" class="cert-card__link">{{ t.learn_more }} &rarr;</a>{% endif %}
             </div>
             {% endfor %}
@@ -474,9 +474,9 @@ pub const DEFAULT_TRUST_INDEX: &str = r##"{% extends "base.html" %}
             <tbody>
             {% for sp in data.trust.subprocessors %}
             <tr>
-                <td>{{ sp.name }}</td>
-                <td>{{ sp.purpose | default(value="") }}</td>
-                <td>{{ sp.location | default(value="") }}</td>
+                <td>{{ sp.name | i18n(lang=lang) }}</td>
+                <td>{{ sp.purpose | default(value="") | i18n(lang=lang) }}</td>
+                <td>{{ sp.location | default(value="") | i18n(lang=lang) }}</td>
                 <td>{% if sp.dpa %}{{ t.yes }}{% else %}{{ t.no }}{% endif %}</td>
             </tr>
             {% endfor %}
@@ -491,8 +491,8 @@ pub const DEFAULT_TRUST_INDEX: &str = r##"{% extends "base.html" %}
         <h2>{{ t.faq }}</h2>
         {% for item in data.trust.faq %}
         <details class="faq-item">
-            <summary>{{ item.question }}</summary>
-            <div class="faq-answer">{{ item.answer }}</div>
+            <summary>{{ item.question | i18n(lang=lang) }}</summary>
+            <div class="faq-answer">{{ item.answer | i18n(lang=lang) }}</div>
         </details>
         {% endfor %}
     </section>

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -765,6 +765,196 @@ fn test_i18n_backward_compat_single_language() {
     assert!(!sitemap.contains("xmlns:xhtml"));
 }
 
+/// Helper: write the three bundled Trust Center data files with per-language
+/// "language map" values for prose fields, plus a plain-string field.
+fn write_bilingual_trust_data(site_dir: &std::path::Path) {
+    let trust_dir = site_dir.join("data/trust");
+    fs::create_dir_all(&trust_dir).unwrap();
+
+    fs::write(
+        trust_dir.join("certifications.yaml"),
+        "- name: ISO 27001\n\
+         \x20 framework: iso27001\n\
+         \x20 status: active\n\
+         \x20 slug: iso27001\n\
+         \x20 description:\n\
+         \x20   en: Information security management.\n\
+         \x20   de: Informationssicherheitsmanagement.\n\
+         \x20 scope:\n\
+         \x20   en: All production systems.\n\
+         \x20   de: Alle Produktionssysteme.\n",
+    )
+    .unwrap();
+
+    fs::write(
+        trust_dir.join("subprocessors.yaml"),
+        "- name: AWS\n\
+         \x20 dpa: true\n\
+         \x20 purpose:\n\
+         \x20   en: Cloud infrastructure\n\
+         \x20   de: Cloud-Infrastruktur\n\
+         \x20 location:\n\
+         \x20   en: United States\n\
+         \x20   de: Vereinigte Staaten\n",
+    )
+    .unwrap();
+
+    fs::write(
+        trust_dir.join("faq.yaml"),
+        "- question:\n\
+         \x20   en: Where is data stored?\n\
+         \x20   de: Wo werden Daten gespeichert?\n\
+         \x20 answer:\n\
+         \x20   en: Data is stored in the EU.\n\
+         \x20   de: Daten werden in der EU gespeichert.\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_i18n_data_language_maps_resolve_per_language() {
+    let tmp = TempDir::new().unwrap();
+    init_trust_site(&tmp, "site");
+
+    let site_dir = tmp.path().join("site");
+    add_language(&site_dir, "de", "Vertrauen");
+    write_bilingual_trust_data(&site_dir);
+
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+
+    // Default language (en) at /trust/
+    let en = fs::read_to_string(site_dir.join("dist/trust/index.html")).unwrap();
+    // Language maps must never leak through as raw objects.
+    assert!(
+        !en.contains("[object]"),
+        "en trust index has unresolved map"
+    );
+    // Certification description, subprocessor purpose/location, FAQ Q&A → English
+    assert!(en.contains("Information security management."));
+    assert!(en.contains("Cloud infrastructure"));
+    assert!(en.contains("United States"));
+    assert!(en.contains("Where is data stored?"));
+    assert!(en.contains("Data is stored in the EU."));
+    // Plain-string field renders verbatim
+    assert!(en.contains("ISO 27001"));
+    assert!(en.contains("AWS"));
+    // German variants must NOT appear on the English page
+    assert!(!en.contains("Informationssicherheitsmanagement."));
+    assert!(!en.contains("Cloud-Infrastruktur"));
+    assert!(!en.contains("Daten werden in der EU gespeichert."));
+
+    // Secondary language (de) at /de/trust/
+    let de = fs::read_to_string(site_dir.join("dist/de/trust/index.html")).unwrap();
+    assert!(
+        !de.contains("[object]"),
+        "de trust index has unresolved map"
+    );
+    assert!(de.contains("Informationssicherheitsmanagement."));
+    assert!(de.contains("Cloud-Infrastruktur"));
+    assert!(de.contains("Vereinigte Staaten"));
+    assert!(de.contains("Wo werden Daten gespeichert?"));
+    assert!(de.contains("Daten werden in der EU gespeichert."));
+    // English variants must NOT appear on the German page
+    assert!(!de.contains("Information security management."));
+    assert!(!de.contains("Cloud infrastructure"));
+    assert!(!de.contains("Data is stored in the EU."));
+}
+
+#[test]
+fn test_i18n_data_plain_values_render_verbatim() {
+    // A single-language site with plain-string data must render byte-for-byte
+    // the same prose — the i18n filter is a no-op on scalars (no regression).
+    let tmp = TempDir::new().unwrap();
+    init_trust_site(&tmp, "site");
+
+    let site_dir = tmp.path().join("site");
+    let trust_dir = site_dir.join("data/trust");
+    fs::create_dir_all(&trust_dir).unwrap();
+    fs::write(
+        trust_dir.join("faq.yaml"),
+        "- question: How is data encrypted?\n  answer: AES-256 at rest and TLS in transit.\n",
+    )
+    .unwrap();
+
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+
+    let html = fs::read_to_string(site_dir.join("dist/trust/index.html")).unwrap();
+    assert!(!html.contains("[object]"));
+    assert!(html.contains("How is data encrypted?"));
+    assert!(html.contains("AES-256 at rest and TLS in transit."));
+}
+
+#[test]
+fn test_i18n_data_partial_language_map_warns() {
+    // A value present in some but not all configured languages should emit a
+    // build warning flagging the missing translation.
+    let tmp = TempDir::new().unwrap();
+    init_trust_site(&tmp, "site");
+
+    let site_dir = tmp.path().join("site");
+    add_language(&site_dir, "de", "Vertrauen");
+
+    let trust_dir = site_dir.join("data/trust");
+    fs::create_dir_all(&trust_dir).unwrap();
+    fs::write(
+        trust_dir.join("faq.yaml"),
+        "- question:\n    en: English only?\n    de: Nur Englisch?\n  answer:\n    en: This answer has no German translation.\n",
+    )
+    .unwrap();
+
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success()
+        .stderr(
+            predicate::str::contains("missing translation").and(predicate::str::contains("de")),
+        );
+}
+
+#[test]
+fn test_i18n_data_trust_item_resolves_cert_scope_per_language() {
+    // The cert-detail block in trust-item.html must resolve language-map prose
+    // (scope) for the page's own language, on both the default and /de/ pages.
+    let tmp = TempDir::new().unwrap();
+    init_trust_site(&tmp, "site");
+
+    let site_dir = tmp.path().join("site");
+    add_language(&site_dir, "de", "Vertrauen");
+    write_bilingual_trust_data(&site_dir);
+
+    // A certification detail page (default + German translation) that triggers
+    // the cert-detail block via extra.type/extra.framework.
+    let cert_dir = site_dir.join("content/trust/certifications");
+    fs::create_dir_all(&cert_dir).unwrap();
+    let fm = "---\ntitle: ISO 27001\nextra:\n  type: certification\n  framework: iso27001\n---\n\nDetails.\n";
+    fs::write(cert_dir.join("iso27001.md"), fm).unwrap();
+    fs::write(cert_dir.join("iso27001.de.md"), fm).unwrap();
+
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+
+    let en = fs::read_to_string(site_dir.join("dist/trust/certifications/iso27001.html")).unwrap();
+    assert!(en.contains("All production systems."));
+    assert!(!en.contains("Alle Produktionssysteme."));
+
+    let de =
+        fs::read_to_string(site_dir.join("dist/de/trust/certifications/iso27001.html")).unwrap();
+    assert!(de.contains("Alle Produktionssysteme."));
+    assert!(!de.contains("All production systems."));
+}
+
 #[test]
 fn test_new_with_lang_flag() {
     let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
## What & why

Data-driven templates — notably the bundled **Trust Center** — had no way to supply translated prose. Fields like `{{ cert.description }}`, `{{ sp.purpose }}`, and `{{ item.answer }}` rendered in a single language on both `/trust/` and `/{lang}/trust/`, because data files were treated as language-neutral.

This adds **language maps**: any data value may be an object keyed by the site's configured language codes, resolving to the current page language.

```yaml
# data/trust/faq.yaml
- answer:
    en: Data is stored in the EU.
    de: Daten werden in der EU gespeichert.
```

## How

- **`src/i18n.rs`** (new) — language-map detection (resolve only when *every* key is a configured code), resolution (`value[lang]` → default → first entry), partial-map warnings, and the `i18n` Tera filter (alias `localize`), registered per build with the site's language codes.
- **Filter, not auto-walk** — auto-walking `data` would collapse the `title[lang]` maps that themes index manually (nav/footer) and the reserved `data.i18n` UI-strings map, so it wouldn't be byte-identical. The filter is surgical.
- **Templates** — `trust-index.html` / `trust-item.html` apply `| i18n(lang=lang)` to all prose fields (cert name/description/scope/auditor, subprocessor name/purpose/location, FAQ question/answer).
- **Build warning** for partial language maps (some configured languages missing); the reserved `data.i18n` key is excluded to avoid false positives.

## Backward compatibility

Plain scalars and non-language maps (`{ icon, label }`) pass through unchanged — single-language sites produce byte-identical output.

## Tests (TDD)

19 unit + 4 integration tests: per-language resolution on `/trust/` and `/{lang}/trust/`, trust-item cert scope, plain-value passthrough, and the partial-map warning. Full suite green (lib 1275 + integration 366); `cargo fmt --check` and `cargo clippy -D warnings` clean.

## Release

- Version 0.13.0 → 0.14.0 + changelog entry (release notes).
- Docs updated: i18n, trust-center, and configuration references + the generated-site i18n rule. Verified by building the docs site.

## Notes

- One deviation from the spec's `{{ value | i18n }}` example: the filter takes `lang=lang` because Tera filters can't read render context (the bare form still works, resolving to the default language).
- Optional per-language data files merged by basename (`faq.de.yaml` + `faq.en.yaml`) was **not** implemented — it was marked optional and language maps cover every acceptance case.
- Includes a small `style:` commit applying rustfmt to `telemetry.rs` / `cli/telemetry.rs`, which were committed fmt-dirty and were failing the CI fmt gate on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)