### PR TITLE
Add `private` collection flag to gate content from public discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ language = "en"
 [[collections]]
 name = "posts"
 # subdomain = "blog"     # optional: deploy separately
+# private = true         # optional: build hub+pages but exclude from all discovery (Cloudflare Access)
 
 [build]
 output_dir = "dist"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/seite-sh/content/changelog/2026-06-24-v0-15-0.md
+++ b/seite-sh/content/changelog/2026-06-24-v0-15-0.md
@@ -1,0 +1,32 @@
+---
+title: v0.15.0
+description: "New `private = true` collection flag builds a collection's hub and pages but keeps them out of every public discovery surface (sitemap, llms.txt, search index, feeds, homepage) — for content placed behind Cloudflare Access or HTTP auth."
+date: 2026-06-24
+tags:
+- feature
+---
+
+## Private collections (gated content)
+
+Collections can now be marked `private = true` to build fully while staying out of every public discovery surface. This is the missing piece for putting a section — like the bundled Trust Center — behind Cloudflare Access or HTTP auth without leaking it.
+
+```toml
+[[collections]]
+name = "trust"
+private = true
+url_prefix = "/trust"
+default_template = "trust-item.html"
+```
+
+### What `private` does
+
+- **Builds everything.** Every item page *and* the auto-generated hub/index page render normally — with the collection's index template and full context (`collections`, `data.*`) — for the default language and every `/{lang}/` variant. Unlike `listed = false`, the hub is **not** suppressed.
+- **Hidden from discovery.** The collection's pages are excluded from the homepage listing, `sitemap.xml`, `llms.txt`, `llms-full.txt`, `search-index.json`, RSS/Atom feeds, and tag pages.
+- **`noindex, nofollow`.** Every private page is stamped with `<meta name="robots" content="noindex, nofollow">` unless the page sets its own `robots` frontmatter.
+- **Still navigable.** Internal links resolve normally, and the `.md` alternates keep generating (they live under the gated path).
+
+`private` is independent of `listed`: the hub renders even when the collection is hidden from the homepage. The build logs how many pages were excluded, e.g. `12 private pages excluded from discovery`.
+
+### Backward compatible
+
+Absent `private` (or `private = false`) is the existing behavior, byte-for-byte. The flag composes with `subdomain`, `paginate`, and the rest.

--- a/seite-sh/content/docs/collections.md
+++ b/seite-sh/content/docs/collections.md
@@ -55,6 +55,7 @@ paginate = 10
 | `has_date` | bool | preset-based | Items have dates |
 | `has_rss` | bool | preset-based | Include in RSS feed |
 | `listed` | bool | preset-based | Show on index page |
+| `private` | bool | `false` | Build the hub + pages but hide them from all discovery (sitemap, llms.txt, search, feeds) — for content behind Cloudflare Access / HTTP auth. See [Configuration](/docs/configuration#private-collections) |
 | `nested` | bool | preset-based | Support subdirectories as groups |
 | `paginate` | int | none | Items per page (enables pagination) |
 | `subdomain` | string | none | Deploy to `{subdomain}.{base_domain}` |

--- a/seite-sh/content/docs/configuration.md
+++ b/seite-sh/content/docs/configuration.md
@@ -81,6 +81,7 @@ default_template = "post.html"
 has_date = true
 has_rss = true
 listed = true
+private = false             # optional: gate behind Cloudflare Access / HTTP auth
 nested = false
 paginate = 10
 subdomain = "blog"          # optional: deploy to blog.example.com
@@ -89,6 +90,31 @@ deploy_project = "my-blog"  # optional: Cloudflare/Netlify project for subdomain
 ```
 
 When `subdomain` is set on a collection, it gets its own output directory (`dist-subdomains/{name}/`), its own base URL (`https://{subdomain}.{base_domain}`), and its own sitemap, RSS, robots.txt, llms.txt, and search index. The collection is excluded from the main site build. Use `subdomain_base_url` to override the auto-derived URL (useful when `base_url` contains `www`). See [Collections](/docs/collections) for details.
+
+### Private collections
+
+Set `private = true` to keep a collection **out of every public discovery surface** while still building its hub and pages — the flag for content placed behind **Cloudflare Access** or HTTP auth (for example, a Trust Center served at a gated `/trust*` path).
+
+```toml
+[[collections]]
+name = "trust"
+private = true
+url_prefix = "/trust"
+default_template = "trust-item.html"
+```
+
+When `private = true`:
+
+- **The collection builds fully** — every item page *and* its auto-generated hub/index page render (with the collection's index template and `data.*` context), for the default language and every `/{lang}/` variant. Unlike `listed = false`, the hub is **not** suppressed.
+- **Its pages are excluded** from the homepage listing, `sitemap.xml`, `llms.txt`, `llms-full.txt`, `search-index.json`, RSS/Atom feeds, and tag pages.
+- **Every page is stamped** `<meta name="robots" content="noindex, nofollow">` unless it sets its own `robots` frontmatter.
+- **Internal links still resolve** and the `.md` alternates keep generating (they live under the gated path).
+
+`private` is independent of `listed` (the hub renders even when the collection is hidden from the homepage) and composes with `subdomain`, `paginate`, and the rest. The build logs how many pages were excluded, e.g. `12 private pages excluded from discovery`. Absent or `false`, behavior is unchanged.
+
+{{% callout(type="warning") %}}
+`private` keeps content out of seite's own discovery files — it does **not** enforce access control. Pair it with Cloudflare Access, HTTP basic auth, or similar on the gated path to actually restrict who can load the pages.
+{{% end %}}
 
 ## [build]
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -948,7 +948,8 @@ fn build_site_inner(
                                     .expect("default language missing from site context cache")
                             });
 
-                        let mut ctx = build_page_context(site_ctx_for_item, item, &data);
+                        let mut ctx =
+                            build_page_context(site_ctx_for_item, item, &data, collection.private);
 
                         // Inject adjacent post links (prev_post / next_post).
                         // Always insert both keys so Tera templates can check them without errors.
@@ -1100,7 +1101,7 @@ fn build_site_inner(
         let collections_ctx: Vec<CollectionContext> = config
             .collections
             .iter()
-            .filter(|c| c.listed)
+            .filter(|c| c.listed && !c.private)
             .map(|c| {
                 let items = all_collections
                     .get(&c.name)
@@ -1294,7 +1295,7 @@ fn build_site_inner(
     // Page N → dist/{url_prefix}/page/N/index.html  (URL: /{url_prefix}/page/N/)
     for lang in &config.all_languages() {
         let lang_site_ctx = SiteContext::for_lang(config, lang);
-        for c in config.collections.iter().filter(|c| c.listed) {
+        for c in config.collections.iter().filter(|c| c.listed || c.private) {
             let page_size = match c.paginate {
                 Some(n) if n > 0 => n,
                 _ => continue,
@@ -1416,7 +1417,7 @@ fn build_site_inner(
                             tags: ci.frontmatter.tags.clone(),
                             url: page_url(page_num),
                             collection: c.name.clone(),
-                            robots: ci.frontmatter.robots.clone(),
+                            robots: effective_robots(ci.frontmatter.robots.clone(), c.private),
                             word_count: ci.word_count,
                             reading_time: ci.reading_time,
                             excerpt: ci.excerpt_html.clone(),
@@ -1435,7 +1436,7 @@ fn build_site_inner(
                             tags: Vec::new(),
                             url: page_url(page_num),
                             collection: String::new(),
-                            robots: None,
+                            robots: effective_robots(None, c.private),
                             word_count: 0,
                             reading_time: 0,
                             excerpt: String::new(),
@@ -1498,7 +1499,7 @@ fn build_site_inner(
         for c in config
             .collections
             .iter()
-            .filter(|c| c.listed && c.paginate.is_none() && !c.url_prefix.is_empty())
+            .filter(|c| (c.listed || c.private) && c.paginate.is_none() && !c.url_prefix.is_empty())
         {
             let url_prefix_trimmed = c.url_prefix.trim_start_matches('/');
             let collection_url = if *lang == *default_lang {
@@ -1596,7 +1597,7 @@ fn build_site_inner(
                         tags: ci.frontmatter.tags.clone(),
                         url: collection_url.clone(),
                         collection: c.name.clone(),
-                        robots: ci.frontmatter.robots.clone(),
+                        robots: effective_robots(ci.frontmatter.robots.clone(), c.private),
                         word_count: ci.word_count,
                         reading_time: ci.reading_time,
                         excerpt: ci.excerpt_html.clone(),
@@ -1615,7 +1616,7 @@ fn build_site_inner(
                         tags: Vec::new(),
                         url: collection_url.clone(),
                         collection: c.name.clone(),
-                        robots: None,
+                        robots: effective_robots(None, c.private),
                         word_count: 0,
                         reading_time: 0,
                         excerpt: String::new(),
@@ -1734,6 +1735,10 @@ fn build_site_inner(
             // Gather all tags and their items for this language
             let mut tag_map: HashMap<String, Vec<ItemSummary>> = HashMap::new();
             for c in &config.collections {
+                // Private collections never contribute to public tag pages.
+                if c.private {
+                    continue;
+                }
                 if let Some(items) = all_collections.get(&c.name) {
                     for item in items.iter().filter(|i| i.lang == *lang) {
                         let summary = ItemSummary {
@@ -1885,7 +1890,7 @@ fn build_site_inner(
     let default_feed_items: Vec<&ContentItem> = config
         .collections
         .iter()
-        .filter(|c| c.has_rss)
+        .filter(|c| c.has_rss && !c.private)
         .flat_map(|c| all_collections.get(&c.name).into_iter().flatten())
         .filter(|item| item.lang == *default_lang)
         .collect();
@@ -1900,7 +1905,7 @@ fn build_site_inner(
             let lang_feed_items: Vec<&ContentItem> = config
                 .collections
                 .iter()
-                .filter(|c| c.has_rss)
+                .filter(|c| c.has_rss && !c.private)
                 .flat_map(|c| all_collections.get(&c.name).into_iter().flatten())
                 .filter(|item| item.lang == *lang)
                 .collect();
@@ -1924,10 +1929,35 @@ fn build_site_inner(
         step_start.elapsed().as_secs_f64() * 1000.0,
     ));
 
-    // Step 6: Generate sitemap (all items, all languages)
+    // Private collections (e.g. behind Cloudflare Access) are kept out of every
+    // public discovery surface below, even though their pages were fully built.
+    let private_collections: std::collections::HashSet<&str> = config
+        .collections
+        .iter()
+        .filter(|c| c.private)
+        .map(|c| c.name.as_str())
+        .collect();
+    if !private_collections.is_empty() {
+        let excluded: usize = all_collections
+            .iter()
+            .filter(|(name, _)| private_collections.contains(name.as_str()))
+            .map(|(_, items)| items.len())
+            .sum();
+        if excluded > 0 {
+            crate::output::human::info(&format!(
+                "{excluded} private pages excluded from discovery"
+            ));
+        }
+    }
+
+    // Step 6: Generate sitemap (all non-private items, all languages)
     progress.step("Generating sitemap");
     let step_start = Instant::now();
-    let all_items: Vec<&ContentItem> = all_collections.values().flatten().collect();
+    let all_items: Vec<&ContentItem> = all_collections
+        .iter()
+        .filter(|(name, _)| !private_collections.contains(name.as_str()))
+        .flat_map(|(_, items)| items)
+        .collect();
     let sitemap_xml =
         sitemap::generate_sitemap(config, &all_items, &translation_map, &tag_page_urls)?;
     fs::write(paths.output.join("sitemap.xml"), sitemap_xml)?;
@@ -1946,6 +1976,7 @@ fn build_site_inner(
     let default_discovery_collections: Vec<(String, Vec<&ContentItem>)> = config
         .collections
         .iter()
+        .filter(|c| !c.private)
         .map(|c| {
             let items: Vec<&ContentItem> = all_collections
                 .get(&c.name)
@@ -1967,6 +1998,7 @@ fn build_site_inner(
             let lang_collections: Vec<(String, Vec<&ContentItem>)> = config
                 .collections
                 .iter()
+                .filter(|c| !c.private)
                 .map(|c| {
                     let items: Vec<&ContentItem> = all_collections
                         .get(&c.name)
@@ -2629,10 +2661,17 @@ fn generate_redirect_html(target_url: &str) -> String {
     )
 }
 
+/// Robots directive for a page: the page's own `robots` frontmatter if set,
+/// otherwise `noindex, nofollow` when its collection is `private`, else `None`.
+fn effective_robots(own: Option<String>, collection_private: bool) -> Option<String> {
+    own.or_else(|| collection_private.then(|| "noindex, nofollow".to_string()))
+}
+
 fn build_page_context(
     site: &SiteContext,
     item: &ContentItem,
     data: &serde_json::Value,
+    collection_private: bool,
 ) -> tera::Context {
     let mut ctx = tera::Context::new();
     ctx.insert("site", site);
@@ -2650,7 +2689,7 @@ fn build_page_context(
             tags: item.frontmatter.tags.clone(),
             url: item.url.clone(),
             collection: item.collection.clone(),
-            robots: item.frontmatter.robots.clone(),
+            robots: effective_robots(item.frontmatter.robots.clone(), collection_private),
             word_count: item.word_count,
             reading_time: item.reading_time,
             excerpt: item.excerpt_html.clone(),
@@ -2809,10 +2848,11 @@ fn insert_build_flags(ctx: &mut tera::Context, config: &SiteConfig) {
 /// Build a JSON search index from a slice of content items.
 /// Only items from `listed: true` collections are included.
 fn generate_search_index(items: &[&ContentItem], config: &SiteConfig) -> String {
+    // Listed, non-private collections only: private content stays out of search.
     let listed: std::collections::HashSet<&str> = config
         .collections
         .iter()
-        .filter(|c| c.listed)
+        .filter(|c| c.listed && !c.private)
         .map(|c| c.name.as_str())
         .collect();
 
@@ -2856,6 +2896,26 @@ mod tests {
     use crate::content::Frontmatter;
     use std::collections::{BTreeMap, HashMap, HashSet};
     use std::path::{Path, PathBuf};
+
+    #[test]
+    fn test_effective_robots() {
+        // A page's own robots frontmatter always wins, private or not.
+        assert_eq!(
+            effective_robots(Some("noindex".into()), false),
+            Some("noindex".into())
+        );
+        assert_eq!(
+            effective_robots(Some("all".into()), true),
+            Some("all".into())
+        );
+        // Private pages without their own robots get noindex, nofollow.
+        assert_eq!(
+            effective_robots(None, true),
+            Some("noindex, nofollow".into())
+        );
+        // Public pages without their own robots get nothing.
+        assert_eq!(effective_robots(None, false), None);
+    }
 
     // ── Helper: minimal SiteConfig ──────────────────────────────────────
     fn minimal_config() -> SiteConfig {
@@ -3757,7 +3817,7 @@ mod tests {
             excerpt_html: "<p>Some body</p>".into(),
         };
 
-        let ctx = build_page_context(&site, &item, &data);
+        let ctx = build_page_context(&site, &item, &data, false);
         let json = ctx.into_json();
         let page = json.get("page").unwrap();
         assert_eq!(page["title"], "My Post");
@@ -3799,7 +3859,7 @@ mod tests {
             excerpt_html: String::new(),
         };
 
-        let ctx = build_page_context(&site, &item, &data);
+        let ctx = build_page_context(&site, &item, &data, false);
         let json = ctx.into_json();
         let page = json.get("page").unwrap();
         assert!(page["image"].is_null());

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -47,6 +47,14 @@ pub struct CollectionConfig {
     pub has_rss: bool,
     #[serde(default)]
     pub listed: bool,
+    /// Keep this collection out of every public discovery surface (sitemap,
+    /// llms.txt, llms-full.txt, search index, feeds, and the homepage listing)
+    /// while still building its hub and item pages — for content placed behind
+    /// Cloudflare Access / HTTP auth. Stamps `noindex, nofollow` on every page.
+    /// Independent of `listed`: the hub renders even when the collection is
+    /// hidden from the homepage.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub private: bool,
     #[serde(default)]
     pub url_prefix: String,
     #[serde(default)]
@@ -88,6 +96,7 @@ impl CollectionConfig {
             subdomain: None,
             subdomain_base_url: None,
             deploy_project: None,
+            private: false,
         }
     }
 
@@ -106,6 +115,7 @@ impl CollectionConfig {
             subdomain: None,
             subdomain_base_url: None,
             deploy_project: None,
+            private: false,
         }
     }
 
@@ -124,6 +134,7 @@ impl CollectionConfig {
             subdomain: None,
             subdomain_base_url: None,
             deploy_project: None,
+            private: false,
         }
     }
 
@@ -142,6 +153,7 @@ impl CollectionConfig {
             subdomain: None,
             subdomain_base_url: None,
             deploy_project: None,
+            private: false,
         }
     }
 
@@ -160,6 +172,7 @@ impl CollectionConfig {
             subdomain: None,
             subdomain_base_url: None,
             deploy_project: None,
+            private: false,
         }
     }
 
@@ -178,6 +191,7 @@ impl CollectionConfig {
             subdomain: None,
             subdomain_base_url: None,
             deploy_project: None,
+            private: false,
         }
     }
 
@@ -708,6 +722,29 @@ mod tests {
         let mut c = CollectionConfig::preset_docs();
         c.subdomain = Some("docs".into());
         c
+    }
+
+    #[test]
+    fn test_collection_private_defaults_false() {
+        assert!(!CollectionConfig::preset_trust().private);
+        let toml =
+            "name = \"x\"\nlabel = \"X\"\ndirectory = \"x\"\ndefault_template = \"t.html\"\n";
+        let c: CollectionConfig = toml::from_str(toml).unwrap();
+        assert!(!c.private);
+    }
+
+    #[test]
+    fn test_collection_private_parses_from_toml() {
+        let toml = "name = \"trust\"\nlabel = \"Trust\"\ndirectory = \"trust\"\ndefault_template = \"trust-item.html\"\nprivate = true\n";
+        let c: CollectionConfig = toml::from_str(toml).unwrap();
+        assert!(c.private);
+    }
+
+    #[test]
+    fn test_collection_private_false_is_not_serialized() {
+        // Byte-identical seite.toml: `private = false` must be omitted.
+        let toml = toml::to_string(&CollectionConfig::preset_posts()).unwrap();
+        assert!(!toml.contains("private"), "serialized: {toml}");
     }
 
     #[test]

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -5665,6 +5665,7 @@ target = "github-pages"
                     subdomain_base_url: None,
                     deploy_project: None,
                     paginate: None,
+                    private: false,
                 },
                 crate::config::CollectionConfig {
                     name: "docs".into(),
@@ -5680,6 +5681,7 @@ target = "github-pages"
                     subdomain_base_url: Some("https://docs.example.com".into()),
                     deploy_project: Some("my-docs".into()),
                     paginate: None,
+                    private: false,
                 },
             ],
             build: Default::default(),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7299,6 +7299,193 @@ fn init_trust_site(tmp: &TempDir, name: &str) {
         .success();
 }
 
+/// Helper: insert a TOML line into the [[collections]] block whose `name` matches.
+fn add_collection_line(site_dir: &std::path::Path, collection: &str, line: &str) {
+    let toml_path = site_dir.join("seite.toml");
+    let config = fs::read_to_string(&toml_path).unwrap();
+    let needle = format!("name = \"{collection}\"");
+    let replaced = config.replacen(&needle, &format!("{needle}\n{line}"), 1);
+    assert_ne!(
+        config, replaced,
+        "collection '{collection}' not found in seite.toml"
+    );
+    fs::write(&toml_path, replaced).unwrap();
+}
+
+/// Helper: add plain-string subprocessor + FAQ data so the trust hub renders all
+/// of its data-driven sections.
+fn write_plain_trust_sections(site_dir: &std::path::Path) {
+    let trust_dir = site_dir.join("data/trust");
+    fs::create_dir_all(&trust_dir).unwrap();
+    fs::write(
+        trust_dir.join("subprocessors.yaml"),
+        "- name: AWS\n  purpose: Cloud infrastructure\n  location: United States\n  dpa: true\n",
+    )
+    .unwrap();
+    fs::write(
+        trust_dir.join("faq.yaml"),
+        "- question: Where is data stored?\n  answer: Data is stored in the EU.\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_private_collection_hub_renders_but_excluded_from_discovery() {
+    let tmp = TempDir::new().unwrap();
+    init_trust_site(&tmp, "site");
+    let site_dir = tmp.path().join("site");
+    add_language(&site_dir, "de", "Vertrauen");
+    add_collection_line(&site_dir, "trust", "private = true");
+    write_plain_trust_sections(&site_dir);
+
+    // German translation of the scaffolded trust item so /de/trust/ has content too.
+    let overview = fs::read_to_string(site_dir.join("content/trust/security-overview.md")).unwrap();
+    fs::write(
+        site_dir.join("content/trust/security-overview.de.md"),
+        overview,
+    )
+    .unwrap();
+
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+    let dist = site_dir.join("dist");
+
+    // 1. Hub renders its data-driven sections AND carries noindex — both languages.
+    for hub in ["trust/index.html", "de/trust/index.html"] {
+        let html = fs::read_to_string(dist.join(hub)).unwrap();
+        assert!(
+            html.contains("AWS"),
+            "{hub}: hub missing subprocessor section"
+        );
+        assert!(
+            html.contains("Where is data stored?"),
+            "{hub}: hub missing FAQ section"
+        );
+        assert!(
+            html.contains(r#"<meta name="robots" content="noindex, nofollow">"#),
+            "{hub}: missing noindex robots meta"
+        );
+    }
+
+    // 2. Item pages + .md alternates still build, with noindex.
+    for p in [
+        "trust/security-overview.html",
+        "de/trust/security-overview.html",
+    ] {
+        let html = fs::read_to_string(dist.join(p)).unwrap();
+        assert!(
+            html.contains(r#"<meta name="robots" content="noindex, nofollow">"#),
+            "{p}: missing noindex robots meta"
+        );
+    }
+    assert!(dist.join("trust/security-overview.md").exists());
+    assert!(dist.join("de/trust/security-overview.md").exists());
+
+    // 3. ZERO trust URLs/content in any public discovery surface (default + /de/).
+    for f in [
+        "llms.txt",
+        "llms-full.txt",
+        "sitemap.xml",
+        "search-index.json",
+        "index.html",
+        "de/llms.txt",
+        "de/llms-full.txt",
+        "de/search-index.json",
+        "de/index.html",
+    ] {
+        let content = fs::read_to_string(dist.join(f)).unwrap();
+        assert!(!content.contains("/trust"), "{f} leaks a /trust URL");
+        assert!(
+            !content.contains("Security Overview"),
+            "{f} leaks the private page title"
+        );
+    }
+}
+
+#[test]
+fn test_private_collection_hub_renders_even_when_unlisted() {
+    // private is independent of listed: hub builds even when hidden from the
+    // homepage. (listed = false alone would suppress the hub entirely.)
+    let tmp = TempDir::new().unwrap();
+    init_trust_site(&tmp, "site");
+    let site_dir = tmp.path().join("site");
+
+    let toml_path = site_dir.join("seite.toml");
+    let cfg = fs::read_to_string(&toml_path).unwrap();
+    let cfg = cfg.replace(
+        "listed = true\nurl_prefix = \"/trust\"",
+        "listed = false\nurl_prefix = \"/trust\"",
+    );
+    fs::write(&toml_path, cfg).unwrap();
+    add_collection_line(&site_dir, "trust", "private = true");
+    write_plain_trust_sections(&site_dir);
+
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+    let dist = site_dir.join("dist");
+
+    // Hub still renders despite listed = false.
+    let hub = fs::read_to_string(dist.join("trust/index.html")).unwrap();
+    assert!(
+        hub.contains("AWS"),
+        "hub did not render with listed=false + private=true"
+    );
+    // Still excluded from discovery.
+    assert!(!fs::read_to_string(dist.join("sitemap.xml"))
+        .unwrap()
+        .contains("/trust"));
+    assert!(!fs::read_to_string(dist.join("index.html"))
+        .unwrap()
+        .contains("/trust"));
+}
+
+#[test]
+fn test_collection_without_private_appears_in_discovery() {
+    // Backward compatibility: absent `private` keeps the collection discoverable.
+    let tmp = TempDir::new().unwrap();
+    init_trust_site(&tmp, "site");
+    let site_dir = tmp.path().join("site");
+    write_plain_trust_sections(&site_dir);
+
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+    let dist = site_dir.join("dist");
+
+    assert!(
+        fs::read_to_string(dist.join("sitemap.xml"))
+            .unwrap()
+            .contains("/trust"),
+        "non-private collection should appear in the sitemap"
+    );
+    assert!(fs::read_to_string(dist.join("llms.txt"))
+        .unwrap()
+        .contains("/trust"));
+}
+
+#[test]
+fn test_private_collection_logs_excluded_count() {
+    let tmp = TempDir::new().unwrap();
+    init_trust_site(&tmp, "site");
+    let site_dir = tmp.path().join("site");
+    add_collection_line(&site_dir, "trust", "private = true");
+
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("private").and(predicate::str::contains("excluded")));
+}
+
 #[test]
 fn test_mcp_resources_list_with_trust() {
     let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
## What

Adds a `private = true` flag to `[[collections]]` that builds a collection's **hub and pages** while keeping them out of **every public discovery surface** — the missing combination for content behind Cloudflare Access / HTTP auth (e.g. the bundled Trust Center served at a gated `/trust*`).

Neither existing flag does this today: `listed = true` leaks the collection into `llms.txt`/`sitemap.xml`/`search-index.json` (served at the site root, so Access on `/trust*` can't protect them), and `listed = false` *also disables hub generation* while still leaking into the discovery files.

## When `private = true`

- **Builds everything** — every item page *and* the auto-generated hub render (collection index template + `collections`/`data.*` context), for the default language and every `/{lang}/` variant. Unlike `listed = false`, the hub is **not** suppressed (generation now keys on `listed || private`).
- **Excluded from discovery** — homepage listing, `sitemap.xml`, `llms.txt`, `llms-full.txt`, `search-index.json`, RSS/Atom feeds, and tag pages.
- **`noindex, nofollow`** stamped on every page unless it sets its own `robots` frontmatter.
- **Still navigable** — internal links resolve; `.md` alternates keep generating.
- Build logs the count: `N private pages excluded from discovery`.

Independent of `listed`; composes with `subdomain`, `paginate`, etc. Absent / `false` → byte-identical output (field is skip-serialized when false).

## Tests (TDD)

- 4 integration tests: hub renders its data-driven sections + **zero** trust URLs/content across `llms.txt`, `llms-full.txt`, `sitemap.xml`, `search-index.json`, `index.html` (and `/de/` equivalents); independent-of-`listed`; backward-compat (discoverable without the flag); excluded-count log.
- Unit tests for the config field (parse / default / skip-serialize) and `effective_robots()`.
- Full suite green; `fmt` + `clippy -D warnings` clean. Coverage: `build/mod.rs` 95.3%, `config/mod.rs` 97.4%.

Docs updated in the configuration + collections references. Releases **v0.15.0**.

> Note: the second commit re-applies `rustfmt` to the telemetry files (committed fmt-dirty on `main`, failing the CI `fmt` gate). Same fix as #74; merging either first makes it a no-op for the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)