### PR TITLE
docs: document subdomain collection hubs (Trust Center + configuration)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/seite-sh/content/changelog/2026-06-25-v0-15-2.md
+++ b/seite-sh/content/changelog/2026-06-25-v0-15-2.md
@@ -1,0 +1,16 @@
+---
+title: v0.15.2
+description: "Documentation: how to deploy the Trust Center (or any collection) to a subdomain, where the root renders the collection's own index template."
+date: 2026-06-25
+tags:
+- docs
+---
+
+## Docs: subdomain collection hubs
+
+Follow-up to the [v0.15.1](/changelog/2026-06-25-v0-15-1) fix. The docs now explain that a collection deployed to a subdomain renders its root page with the collection's **own index template** (and context), just like its index on the main domain:
+
+- The [Trust Center](/docs/trust-center) reference gains a "Deploying to a subdomain" section — serve the trust hub from `trust.example.com`, optionally paired with `private = true` for content behind Cloudflare Access.
+- The [Configuration](/docs/configuration) reference notes that the subdomain root uses the collection's index template (e.g. `trust-index.html`).
+
+No code changes.

--- a/seite-sh/content/docs/configuration.md
+++ b/seite-sh/content/docs/configuration.md
@@ -89,7 +89,7 @@ subdomain_base_url = "https://blog.example.com"  # optional: explicit URL overri
 deploy_project = "my-blog"  # optional: Cloudflare/Netlify project for subdomain
 ```
 
-When `subdomain` is set on a collection, it gets its own output directory (`dist-subdomains/{name}/`), its own base URL (`https://{subdomain}.{base_domain}`), and its own sitemap, RSS, robots.txt, llms.txt, and search index. The collection is excluded from the main site build. Use `subdomain_base_url` to override the auto-derived URL (useful when `base_url` contains `www`). See [Collections](/docs/collections) for details.
+When `subdomain` is set on a collection, it gets its own output directory (`dist-subdomains/{name}/`), its own base URL (`https://{subdomain}.{base_domain}`), and its own sitemap, RSS, robots.txt, llms.txt, and search index. The collection is excluded from the main site build. The subdomain **root page** renders with the collection's own index template (e.g. `trust-index.html`) and context — exactly like that collection's index page on the main domain. Use `subdomain_base_url` to override the auto-derived URL (useful when `base_url` contains `www`). See [Collections](/docs/collections) for details.
 
 ### Private collections
 

--- a/seite-sh/content/docs/trust-center.md
+++ b/seite-sh/content/docs/trust-center.md
@@ -138,6 +138,21 @@ The hub page at `/trust/` is rendered using `trust-index.html` and displays:
 
 All sections are conditional: if a data file is empty or missing, the section doesn't render.
 
+### Deploying to a subdomain
+
+The trust center can be served from its own subdomain (e.g. `trust.example.com`) by setting `subdomain` on the collection. The subdomain root renders the **full hub** — the same `trust-index.html` template and context (cert grid, subprocessor table, FAQ) as `/trust/` on the main domain — for the default language and every `/{lang}/` variant:
+
+```toml
+[[collections]]
+name = "trust"
+url_prefix = "/trust"
+default_template = "trust-item.html"
+subdomain = "trust"
+subdomain_base_url = "https://trust.example.com"
+```
+
+Pair it with [`private = true`](/docs/configuration#private-collections) to keep the trust content out of your main site's discovery files (sitemap, llms.txt, search index) and stamp `noindex, nofollow` on every page — the right combination for content gated behind **Cloudflare Access** or HTTP auth.
+
 ## Configuration
 
 The `[trust]` section in `seite.toml` stores trust center metadata:


### PR DESCRIPTION
Follow-up docs for the [v0.15.1](https://github.com/seite-sh/seite/pull/77) subdomain hub fix.

- **trust-center.md** — new "Deploying to a subdomain" section: serve the trust hub from `trust.example.com` (the root renders the full `trust-index.html` hub per language), optionally paired with `private = true` for content behind Cloudflare Access. The Trust Center reference previously didn't mention subdomain deployment at all.
- **configuration.md** — note that a subdomain root renders the collection's own index template.

Docs-only — no code changes. Full suite green; embedded docs + changelog compile. Coverage unaffected (no code paths changed). Release **v0.15.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)