### PR TITLE
Teach project agents about private collections + Cloudflare Access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/seite-sh/content/changelog/2026-06-25-v0-16-0.md
+++ b/seite-sh/content/changelog/2026-06-25-v0-16-0.md
@@ -1,0 +1,23 @@
+---
+title: v0.16.0
+description: "New .claude/rules guidance so your project's AI agent knows about private (gated) collections, subdomain hubs, and that locking access (Cloudflare Access) is a separate manual step. Plus docs for setting it up."
+date: 2026-06-25
+tags:
+- feature
+- docs
+---
+
+## Agent guidance for gated content
+
+Sites now ship a `.claude/rules/private-collections.md` context file so the AI agent working in your project knows what's possible — and what isn't — for gated content:
+
+- **`private = true`** collections build their hub + pages but stay out of every discovery surface (sitemap, llms.txt, search, feeds, homepage, tags) and carry `noindex, nofollow`.
+- **`private` does not lock access.** It only hides content from discovery — the HTML is still publicly fetchable. seite has no Cloudflare Access integration; gating who can load the pages is a separate step you configure (Cloudflare Access / Zero Trust, HTTP auth, etc.).
+- **Subdomain hubs** render the collection's own index template, and the **custom-domain attach** on a subdomain's Pages project is a manual one-time step (seite only auto-attaches the main site's domain).
+
+New sites get the rule from `seite init`; existing sites get it on `seite upgrade`.
+
+## Docs
+
+- [Deployment](/docs/deployment) gains "Custom domain for a subdomain" and "Gating a subdomain behind Cloudflare Access" sections.
+- [Configuration](/docs/configuration) already warns that `private` is not access control — now cross-referenced from the deploy guide.

--- a/seite-sh/content/docs/deployment.md
+++ b/seite-sh/content/docs/deployment.md
@@ -197,6 +197,20 @@ deploy_project = "my-docs"   # Cloudflare/Netlify project for this subdomain
 GitHub Pages does not support per-collection subdomains. Use Cloudflare Pages or Netlify for subdomain deploys.
 {{% end %}}
 
+### Custom domain for a subdomain
+
+`seite deploy --setup` auto-creates the Cloudflare Pages **project** for each subdomain collection, and `seite deploy` pushes to it (the project gets a `*.pages.dev` URL automatically). Attaching the **custom domain** (e.g. `docs.example.com`) to that project is a **one-time manual step** — seite only auto-attaches the *main* site's domain, not a subdomain's. In the Cloudflare dashboard, open the subdomain's Pages project → **Custom domains** → add the host. If the zone is on the same Cloudflare account, Cloudflare creates the DNS record for you.
+
+### Gating a subdomain behind Cloudflare Access
+
+[`private = true`](/docs/configuration#private-collections) keeps a collection out of discovery and stamps `noindex`, but it does **not** authenticate requests — the pages are still publicly fetchable. To actually restrict access, put **Cloudflare Access** in front of the subdomain (seite does not configure this for you):
+
+1. Cloudflare dashboard → **Zero Trust → Access → Applications → Add an application → Self-hosted**.
+2. Set the application domain to the subdomain (e.g. `trust.example.com`).
+3. Add an **access policy** (allow by email domain, Google/Okta SSO, one-time PIN, etc.).
+
+The full gated pattern: `private = true` + `subdomain` + a Cloudflare Access application on the subdomain.
+
 ## Override Target
 
 Override the configured target on the command line:

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -907,6 +907,13 @@ fn generate_rules_files(
             include_str!("../scaffold/design-prompts.md"),
         ),
     )?;
+    fs::write(
+        rules_dir.join("private-collections.md"),
+        rules_file(
+            &["seite.toml", "content/**"],
+            include_str!("../scaffold/private-collections.md"),
+        ),
+    )?;
 
     // Conditional rules
     if has_contact {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -174,7 +174,32 @@ const fn upgrade_steps() -> &'static [UpgradeStep] {
             label: "Subdomain collection deploy steps in CI workflow",
             check: check_subdomain_workflow,
         },
+        UpgradeStep {
+            introduced_in: (0, 16, 0),
+            label: "Private collections + Cloudflare Access guidance (.claude/rules)",
+            check: check_private_collections_rule,
+        },
     ]
+}
+
+/// Install the `.claude/rules/private-collections.md` context file so the project's
+/// agent knows about `private` collections, subdomain hubs, and that gating access
+/// (Cloudflare Access) is a separate, manual step. Created only if missing.
+fn check_private_collections_rule(root: &Path) -> Vec<UpgradeAction> {
+    use crate::cli::init::rules_file;
+
+    let path = root.join(".claude/rules/private-collections.md");
+    if path.exists() {
+        return Vec::new();
+    }
+    vec![UpgradeAction::Create {
+        content: rules_file(
+            &["seite.toml", "content/**"],
+            include_str!("../scaffold/private-collections.md"),
+        ),
+        path,
+        description: ".claude/rules/private-collections.md".to_string(),
+    }]
 }
 
 pub fn run(args: &UpgradeArgs) -> anyhow::Result<()> {

--- a/src/scaffold/private-collections.md
+++ b/src/scaffold/private-collections.md
@@ -1,0 +1,59 @@
+## Private (gated) collections & access control
+
+A collection can set `private = true` in `seite.toml` to keep its content out of every public
+discovery surface while still building its hub and pages:
+
+```toml
+[[collections]]
+name = "trust"
+private = true
+url_prefix = "/trust"
+default_template = "trust-item.html"
+```
+
+When `private = true`, the collection's pages (hub + items, all languages) are excluded from the
+homepage listing, `sitemap.xml`, `llms.txt`, `llms-full.txt`, `search-index.json`, RSS/Atom feeds,
+and tag pages, and every page is stamped `<meta name="robots" content="noindex, nofollow">`
+(unless the page sets its own `robots`). It is independent of `listed`, and the build logs how many
+pages were excluded. Absent or `false` is the normal, fully-discoverable behavior.
+
+### `private` does NOT lock access
+
+**Important: `private` only hides content from discovery — it does not authenticate or restrict
+who can load the pages.** The HTML is still publicly fetchable by anyone who has the URL. seite has
+no Cloudflare Access / auth integration; it does not create any access policy for you. To actually
+gate the content you must put an access layer in front of the path or subdomain yourself:
+
+- **Cloudflare Access (Zero Trust)** — the usual choice. In the Cloudflare dashboard: Zero Trust →
+  Access → Applications → add a **self-hosted** application covering the gated host or path (e.g.
+  `trust.example.com` or `example.com/trust*`), then attach an access policy (email domain, Google/
+  Okta SSO, one-time PIN, etc.).
+- Or HTTP basic auth / a Worker in front, depending on the host.
+
+So the gated pattern is: **`private = true` (no discovery + `noindex`) + an access layer you
+configure on the host/path.**
+
+### Serving gated content on a subdomain
+
+For a clean boundary, deploy the collection to its own subdomain and lock the whole subdomain:
+
+```toml
+[[collections]]
+name = "trust"
+private = true
+subdomain = "trust"
+subdomain_base_url = "https://trust.example.com"
+default_template = "trust-item.html"
+```
+
+- `seite deploy --setup` auto-creates the Cloudflare Pages **project** (`{site}-trust`).
+- `seite deploy` pushes `dist-subdomains/trust/` to it; the subdomain **root** renders the
+  collection's own index template (e.g. `trust-index.html`), not the generic site index.
+- **Manual one-time step:** attach the custom domain (`trust.example.com`) to that Pages project
+  (Cloudflare dashboard → the Pages project → Custom domains). seite does **not** auto-attach a
+  subdomain's custom domain — it only attaches the *main* site's domain. Once attached, Cloudflare
+  creates the DNS record automatically if the zone is on the same Cloudflare account.
+- Then add a Cloudflare Access application over `trust.example.com` to require auth.
+
+Note: `domain = "..."` on a `[[collections]]` block is **not** a recognized field and is ignored —
+a subdomain's URL comes from `subdomain_base_url` (or auto-derives to `{subdomain}.{base_domain}`).

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4218,6 +4218,53 @@ fn test_upgrade_adds_mcp_to_existing_project() {
 }
 
 #[test]
+fn test_init_includes_private_collections_rule() {
+    // New sites get the .claude/rules guidance so the agent knows private +
+    // Cloudflare Access are possible (and that private != access control).
+    let tmp = TempDir::new().unwrap();
+    init_site(&tmp, "site", "Gated", "posts,pages");
+    let site_dir = tmp.path().join("site");
+    let rule = fs::read_to_string(site_dir.join(".claude/rules/private-collections.md")).unwrap();
+    assert!(
+        rule.contains("private = true"),
+        "rule should cover the flag"
+    );
+    assert!(
+        rule.contains("Cloudflare Access"),
+        "rule should point at Cloudflare Access for the actual lock"
+    );
+    assert!(
+        rule.contains("does not authenticate"),
+        "rule must be explicit that private does not enforce access control"
+    );
+}
+
+#[test]
+fn test_upgrade_installs_private_collections_rule() {
+    // Existing sites get the rule when they run `seite upgrade`.
+    let tmp = TempDir::new().unwrap();
+    init_site(&tmp, "site", "Gated Upgrade", "posts,pages");
+    let site_dir = tmp.path().join("site");
+
+    // Simulate a project from before the rule existed.
+    fs::remove_file(site_dir.join(".claude/rules/private-collections.md")).unwrap();
+    fs::remove_file(site_dir.join(".seite/config.json")).unwrap();
+
+    page_cmd()
+        .args(["upgrade", "--force"])
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+
+    assert!(
+        site_dir
+            .join(".claude/rules/private-collections.md")
+            .exists(),
+        "upgrade should install the private-collections rule"
+    );
+}
+
+#[test]
 fn test_upgrade_appends_mcp_section_to_claude_md() {
     let tmp = TempDir::new().unwrap();
     init_site(&tmp, "site", "CLAUDE.md Upgrade", "posts,pages");


### PR DESCRIPTION
## Why

seite has **no** Cloudflare Access integration — `private = true` only hides content from discovery and stamps `noindex`; it does **not** authenticate requests. But nothing in a generated project's `.claude/rules` told the AI agent that, so an upgraded session had no idea private collections, subdomain hubs, or the manual access step even existed.

## What

- **New scaffold rule** `.claude/rules/private-collections.md` — documents `private` (discovery-hiding + `noindex`), that it does **not** lock access (pair with Cloudflare Access / Zero Trust, configured manually), and the subdomain-hub + manual custom-domain-attach story.
- **init** installs it for new sites; **upgrade** installs it for existing sites via a version-gated (0.16.0) step.
- **docs**: `deployment.md` gains "Custom domain for a subdomain" and "Gating a subdomain behind Cloudflare Access" sections.
- **tests**: init includes the rule; upgrade installs it for existing sites.

Full suite green; fmt + clippy clean. Coverage: `upgrade.rs` 100% functions; new init/upgrade lines covered. Release **v0.16.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)