### PR TITLE
feat: EXIF metadata propagation to image variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +288,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +528,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -1316,6 +1367,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "little_exif"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21eeb58b22d31be8dc5c625004fcd4b9b385cd3c05df575f523bcca382c51122"
+dependencies = [
+ "brotli",
+ "crc",
+ "log",
+ "miniz_oxide",
+ "paste",
+ "quick-xml 0.37.5",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,6 +1951,15 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
@@ -2181,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2194,6 +2268,7 @@ dependencies = [
  "image",
  "indicatif",
  "katex-rs",
+ "little_exif",
  "notify",
  "open",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"
@@ -79,6 +79,7 @@ slug = "0.1"
 # Image processing
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp", "avif"] }
 webp = "0.3"
+little_exif = "0.6"
 
 # HTTP client (for Cloudflare API and self-update)
 ureq = { version = "3", features = ["json"] }
@@ -99,6 +100,8 @@ math = ["dep:katex-rs"]
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+little_exif = "0.6"
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp", "avif"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/seite-sh/content/changelog/2026-07-01-v0-17-0.md
+++ b/seite-sh/content/changelog/2026-07-01-v0-17-0.md
@@ -1,0 +1,52 @@
+---
+title: v0.17.0
+description: "EXIF metadata from source images is now preserved and propagated to all generated image variants — resized JPEG, WebP, AVIF, and full-size copies — filtered by a configurable allow-list."
+date: 2026-07-01
+tags:
+- feature
+---
+
+## EXIF metadata propagation
+
+Source images in `static/` often carry EXIF metadata — camera make/model, capture date, orientation, GPS coordinates, and more. Previously, the build pipeline's image variants (resized copies, WebP, AVIF) lost all EXIF because the pixel data was re-encoded by the `image`/`webp`/`avif` encoders.
+
+Now, EXIF is read from the source image once, filtered by your allow-list, and written to every generated variant using [little_exif](https://crates.io/crates/little_exif) — a lossless, byte-level EXIF splicer that touches only the metadata segment, never the pixel data.
+
+### Configuration
+
+New `exif_data_allow` field under `[images]`:
+
+```toml
+[images]
+# Preserve everything, propagate to all variants (default)
+exif_data_allow = "ALL"
+
+# Strip all EXIF from originals and variants
+exif_data_allow = "NONE"
+
+# Preserve only specific fields, strip the rest
+exif_data_allow = ["DateTimeOriginal", "Orientation", "Make", "Model"]
+
+# Custom tags via hex ID
+exif_data_allow = ["DateTimeOriginal", "0xC62F"]
+```
+
+| Value | Originals in `dist/static/` | Variants (resized/WebP/AVIF) |
+|-------|-----------------------------|-------------------------------|
+| `"ALL"` (default) | Full EXIF preserved | Full EXIF minus dimension fields |
+| `"NONE"` | All EXIF stripped | No EXIF |
+| `["field", ...]` | Only listed fields | Only listed fields (minus dimensions) |
+
+Dimension fields (`ImageWidth`, `ImageHeight`, `ExifImageWidth`, `ExifImageHeight`) are always stripped from variants because they reflect the original dimensions, not the resized copy's.
+
+### Behavioral change for existing sites
+
+Sites with `[images]` configured will now have EXIF propagated to variants by default (`exif_data_allow = "ALL"`). Previously, variants had no EXIF at all. If you relied on the absence of EXIF in variants, set `exif_data_allow = "NONE"` to restore the old behavior.
+
+Sites without an `[images]` block are unaffected — originals are copied byte-for-byte as before.
+
+### Implementation notes
+
+- Uses `little_exif` v0.6 for lossless EXIF reads and writes across JPEG, WebP, PNG, and AVIF.
+- All EXIF operations are non-fatal: malformed or unreadable images log a warning and the build continues.
+- `catch_unwind` guards against documented panic risk in `little_exif`'s read path.

--- a/seite-sh/content/docs/configuration.md
+++ b/seite-sh/content/docs/configuration.md
@@ -246,8 +246,29 @@ Optional. When this section is present, `seite` automatically processes images i
 | `avif` | bool | `false` | Generate AVIF variants alongside originals (better compression than WebP) |
 | `avif_quality` | int | `70` | AVIF quality (1-100). Lower than WebP is fine — AVIF compresses better |
 | `lazy_loading` | bool | `true` | Add `loading="lazy"` to `<img>` tags |
+| `exif_data_allow` | string or array | `"ALL"` | Controls which EXIF metadata fields are preserved and propagated to image variants. `"ALL"` preserves everything (default). `"NONE"` strips all EXIF from originals and adds none to variants. A list of field names preserves only those fields. Dimension fields are always stripped from variants. Field names match ExifTag variant names (e.g. `"DateTimeOriginal"`, `"Orientation"`, `"Make"`, `"Model"`). Custom tags use hex IDs (e.g. `"0xC62F"`) |
 
 When configured, images in `static/` are resized to each width, optionally converted to WebP and/or AVIF, and `<img>` tags in HTML are rewritten with `srcset` and `<picture>` elements. AVIF sources appear first in the `<picture>` element so browsers that support AVIF use it (best compression), falling back to WebP, then the original format. To disable image processing, remove the `[images]` section entirely.
+
+EXIF metadata from source images is preserved and propagated to all generated variants (resized JPEG, WebP, AVIF, and full-size WebP/AVIF copies). Dimension fields (`ImageWidth`, `ImageHeight`, `ExifImageWidth`, `ExifImageHeight`) are always stripped from variants since they would be stale after resizing. Originals in `dist/static/` keep their full EXIF when `exif_data_allow = "ALL"` (the default).
+
+```toml
+# Preserve only camera info and capture date, propagate to all variants
+[images]
+exif_data_allow = ["DateTimeOriginal", "Orientation", "Make", "Model"]
+
+# Preserve a custom tag added by your workflow (hex ID)
+[images]
+exif_data_allow = ["DateTimeOriginal", "0xC62F"]
+
+# Strip all EXIF from originals and variants
+[images]
+exif_data_allow = "NONE"
+
+# Preserve everything, propagate to all variants (default)
+[images]
+exif_data_allow = "ALL"
+```
 
 ## [analytics]
 

--- a/src/build/images.rs
+++ b/src/build/images.rs
@@ -7,14 +7,22 @@ use image::codecs::jpeg::JpegEncoder;
 use image::codecs::png::{CompressionType, FilterType as PngFilterType, PngEncoder};
 use image::imageops::FilterType;
 use image::{ImageEncoder, ImageFormat};
+use little_exif::exif_tag::ExifTag;
+use little_exif::metadata::Metadata;
 use rayon::prelude::*;
 use walkdir::WalkDir;
 
-use crate::config::{ImageSection, ResolvedPaths};
+use crate::config::{ExifDataAllow, ImageSection, ResolvedPaths};
 use crate::error::{PageError, Result};
 
-/// Supported input image extensions.
+/// Supported input image extensions for variant generation.
 const IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp"];
+
+/// Broader list of extensions for original EXIF filtering — covers all formats
+/// `little_exif` can read/write, including formats we don't generate variants for.
+const EXIF_FILTER_EXTENSIONS: &[&str] = &[
+    "jpg", "jpeg", "png", "webp", "avif", "heic", "heif", "tiff", "tif",
+];
 
 /// An entry in the image manifest mapping original paths to processed outputs.
 #[derive(Debug, Clone)]
@@ -86,6 +94,202 @@ pub fn process_images(
     Ok(manifest)
 }
 
+/// Read EXIF metadata from a file, catching both errors and panics.
+/// little_exif 0.6.23 docs state `new_from_path` "currently panics" on read failure.
+/// Use `catch_unwind` to ensure a malformed image never crashes the build.
+fn read_metadata_safely(path: &Path) -> Option<Metadata> {
+    let path_owned = path.to_path_buf();
+    std::panic::catch_unwind(|| Metadata::new_from_path(&path_owned))
+        .ok()
+        .and_then(|r| r.ok())
+}
+
+/// Parse the allow-list into a set of variant names and a set of hex tag IDs.
+/// Entries that look like hex IDs (e.g. "0x0112", "0xC62F") are parsed into u16.
+/// Everything else is treated as a variant name (e.g. "DateTimeOriginal").
+fn parse_allow_list(
+    allow: &ExifDataAllow,
+) -> (
+    std::collections::HashSet<String>,
+    std::collections::HashSet<u16>,
+) {
+    let mut names = std::collections::HashSet::new();
+    let mut hex_ids = std::collections::HashSet::new();
+    if let ExifDataAllow::Allow(fields) = allow {
+        for field in fields {
+            let trimmed = field.trim();
+            if let Some(hex_part) = trimmed
+                .strip_prefix("0x")
+                .or_else(|| trimmed.strip_prefix("0X"))
+            {
+                if let Ok(id) = u16::from_str_radix(hex_part, 16) {
+                    hex_ids.insert(id);
+                    continue;
+                }
+            }
+            names.insert(trimmed.to_lowercase());
+        }
+    }
+    (names, hex_ids)
+}
+
+/// Check whether a tag is in the allow-list, matching by variant name or hex tag ID.
+fn is_allowed(
+    tag: &ExifTag,
+    allow_names: &std::collections::HashSet<String>,
+    allow_hex_ids: &std::collections::HashSet<u16>,
+) -> bool {
+    // 1. Check by variant name: Debug-format yields e.g. `Make("TestCamera")`.
+    //    Extract the variant name before any `(` character.
+    let debug_str = format!("{:?}", tag);
+    let variant_name = debug_str.split('(').next().unwrap_or(&debug_str);
+    if allow_names.contains(variant_name.to_lowercase().as_str()) {
+        return true;
+    }
+    // 2. Check by hex tag ID (for custom/unknown tags, and as a fallback for named tags)
+    let hex_id = tag.as_u16();
+    allow_hex_ids.contains(&hex_id)
+}
+
+/// Read EXIF from a source file, apply the allow-list, and return filtered `Metadata`.
+/// Used for both originals and variant propagation.
+/// Returns `None` if there's no EXIF to propagate (e.g. `None` policy or source has no EXIF).
+fn filter_exif(source: &Path, config: &ImageSection) -> Option<Metadata> {
+    match &config.exif_data_allow {
+        ExifDataAllow::All => {
+            // "ALL" — read EXIF as-is, no filtering
+            read_metadata_safely(source)
+        }
+        ExifDataAllow::None => {
+            // "NONE" — don't propagate any EXIF to variants
+            None
+        }
+        ExifDataAllow::Allow(_) => {
+            let mut metadata = read_metadata_safely(source)?;
+
+            let (allow_names, allow_hex_ids) = parse_allow_list(&config.exif_data_allow);
+
+            // Remove non-allowed tags. Collect first (cloning from references),
+            // then remove, because `remove_tag` takes ownership and we can't
+            // mutate while borrowing.
+            let to_remove: Vec<ExifTag> = (&metadata)
+                .into_iter()
+                .filter(|tag| !is_allowed(tag, &allow_names, &allow_hex_ids))
+                .cloned()
+                .collect();
+            for tag in to_remove {
+                metadata.remove_tag(tag);
+            }
+            Some(metadata)
+        }
+    }
+}
+
+/// Remove dimension fields from a `Metadata` struct.
+/// These reflect the original dimensions and would be stale on resized variants.
+/// `remove_tag` matches by hex value + group, not by data, so dummy vec values are fine.
+fn strip_dimensions(metadata: &mut Metadata) {
+    for tag in [
+        ExifTag::ImageWidth(vec![0u32]),
+        ExifTag::ImageHeight(vec![0u32]),
+        ExifTag::ExifImageWidth(vec![0u32]),
+        ExifTag::ExifImageHeight(vec![0u32]),
+    ] {
+        metadata.remove_tag(tag);
+    }
+}
+
+/// Write filtered EXIF to a variant file. Non-fatal on error.
+fn write_exif_to_file(metadata: &Metadata, path: &Path) {
+    if let Err(e) = metadata.write_to_file(path) {
+        tracing::warn!("Failed to write EXIF to {}: {e}", path.display());
+    }
+}
+
+/// Filter EXIF metadata on original images in `dist/static/` per policy.
+/// Only runs when `exif_data_allow` is not `All` (All = preserve everything as-is).
+/// `None` strips all EXIF. A field list preserves only those fields.
+/// Modifies files in-place — only the EXIF segment is touched.
+pub fn apply_exif_policy_to_originals(
+    paths: &ResolvedPaths,
+    config: &ImageSection,
+) -> Result<usize> {
+    // Early return — "ALL" means preserve everything as-is
+    if config.exif_data_allow == ExifDataAllow::All {
+        return Ok(0);
+    }
+
+    let static_output = paths.output.join("static");
+    if !static_output.exists() {
+        return Ok(0);
+    }
+
+    let mut count = 0;
+    for entry in WalkDir::new(&static_output)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+    {
+        let ext = entry
+            .path()
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_lowercase())
+            .unwrap_or_default();
+
+        if !EXIF_FILTER_EXTENSIONS.contains(&ext.as_str()) {
+            continue;
+        }
+
+        let path = entry.path();
+
+        match &config.exif_data_allow {
+            ExifDataAllow::None => {
+                // Strip all EXIF — use little_exif's file_clear_metadata
+                let path_owned = path.to_path_buf();
+                let result =
+                    std::panic::catch_unwind(|| Metadata::file_clear_metadata(&path_owned));
+                match result {
+                    Ok(Ok(())) => count += 1,
+                    Ok(Err(e)) => {
+                        tracing::warn!("Failed to strip EXIF from {}: {e}", path.display());
+                    }
+                    Err(_) => {
+                        tracing::warn!("Failed to strip EXIF from {} (panic)", path.display());
+                    }
+                }
+            }
+            ExifDataAllow::Allow(_) => {
+                // Filter to allow-list
+                if let Some(filtered) = filter_exif(path, config) {
+                    // Write the filtered metadata back (replaces existing EXIF)
+                    write_exif_to_file(&filtered, path);
+                    count += 1;
+                } else {
+                    // No EXIF in source, or read failed — try to clear any existing EXIF
+                    let path_owned = path.to_path_buf();
+                    let result =
+                        std::panic::catch_unwind(|| Metadata::file_clear_metadata(&path_owned));
+                    match result {
+                        Ok(Ok(())) => count += 1,
+                        Ok(Err(e)) => {
+                            tracing::warn!("Failed to clear EXIF from {}: {e}", path.display());
+                        }
+                        Err(_) => {
+                            tracing::warn!("Failed to clear EXIF from {} (panic)", path.display());
+                        }
+                    }
+                }
+            }
+            ExifDataAllow::All => {
+                // Already handled by early return above
+            }
+        }
+    }
+
+    Ok(count)
+}
+
 fn process_single_image(
     source: &Path,
     rel: &Path,
@@ -99,6 +303,13 @@ fn process_single_image(
 
     let original_width = img.width();
     let original_height = img.height();
+
+    // Read and filter EXIF from the source image for propagation to variants.
+    // Dimension fields are stripped — they'd be stale after resizing.
+    let variant_exif: Option<Metadata> = filter_exif(source, config).map(|mut m| {
+        strip_dimensions(&mut m);
+        m
+    });
 
     let stem = source
         .file_stem()
@@ -143,6 +354,9 @@ fn process_single_image(
         let resized_name = format!("{stem}-{width}w.{ext}");
         let resized_path = output_base.join(&resized_name);
         save_image(&resized, &resized_path, save_format, config.quality)?;
+        if let Some(ref exif) = variant_exif {
+            write_exif_to_file(exif, &resized_path);
+        }
 
         let url = if rel_dir_str.is_empty() {
             format!("/static/{resized_name}")
@@ -156,6 +370,9 @@ fn process_single_image(
             let webp_name = format!("{stem}-{width}w.webp");
             let webp_path = output_base.join(&webp_name);
             save_image(&resized, &webp_path, ImageFormat::WebP, config.quality)?;
+            if let Some(ref exif) = variant_exif {
+                write_exif_to_file(exif, &webp_path);
+            }
 
             let webp_url = if rel_dir_str.is_empty() {
                 format!("/static/{webp_name}")
@@ -170,6 +387,9 @@ fn process_single_image(
             let avif_name = format!("{stem}-{width}w.avif");
             let avif_path = output_base.join(&avif_name);
             save_image(&resized, &avif_path, ImageFormat::Avif, avif_quality)?;
+            if let Some(ref exif) = variant_exif {
+                write_exif_to_file(exif, &avif_path);
+            }
 
             let avif_url = if rel_dir_str.is_empty() {
                 format!("/static/{avif_name}")
@@ -189,6 +409,9 @@ fn process_single_image(
         let webp_name = format!("{stem}.webp");
         let webp_path = output_base.join(&webp_name);
         save_image(&img, &webp_path, ImageFormat::WebP, config.quality)?;
+        if let Some(ref exif) = variant_exif {
+            write_exif_to_file(exif, &webp_path);
+        }
 
         let webp_url = if rel_dir_str.is_empty() {
             format!("/static/{webp_name}")
@@ -203,6 +426,9 @@ fn process_single_image(
         let avif_name = format!("{stem}.avif");
         let avif_path = output_base.join(&avif_name);
         save_image(&img, &avif_path, ImageFormat::Avif, avif_quality)?;
+        if let Some(ref exif) = variant_exif {
+            write_exif_to_file(exif, &avif_path);
+        }
 
         let avif_url = if rel_dir_str.is_empty() {
             format!("/static/{avif_name}")
@@ -240,13 +466,13 @@ fn save_image(
             })?;
             let writer = BufWriter::new(file);
             let encoder = JpegEncoder::new_with_quality(writer, quality);
-            let rgba = img.to_rgba8();
+            let rgb = img.to_rgb8();
             encoder
                 .write_image(
-                    rgba.as_raw(),
+                    rgb.as_raw(),
                     img.width(),
                     img.height(),
-                    image::ExtendedColorType::Rgba8,
+                    image::ExtendedColorType::Rgb8,
                 )
                 .map_err(|e| {
                     PageError::Build(format!("failed to encode JPEG '{}': {e}", path.display()))
@@ -530,6 +756,7 @@ fn add_lazy_loading(html: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn test_extract_attr() {
@@ -1936,5 +2163,537 @@ mod tests {
         let result = rewrite_html_images(html, &manifest, false);
         assert!(result.ends_with("trailing text here"));
         assert!(result.contains("srcset="));
+    }
+
+    // ── EXIF tests ───────────────────────────────────────────────────────
+
+    /// Helper: create a small JPEG with known EXIF tags in a tempdir.
+    /// Tags injected: Make, Model, DateTimeOriginal, Orientation, ImageWidth, ImageHeight.
+    fn create_test_jpeg_with_exif(dir: &Path, name: &str) -> PathBuf {
+        let img = image::ImageBuffer::from_pixel(40, 40, image::Rgb([255, 0, 0]));
+        let path = dir.join(name);
+        image::save_buffer(&path, &img, 40, 40, image::ExtendedColorType::Rgb8).unwrap();
+
+        let mut metadata = Metadata::new();
+        metadata.set_tag(ExifTag::Make("TestCamera".to_string()));
+        metadata.set_tag(ExifTag::Model("TestModel".to_string()));
+        metadata.set_tag(ExifTag::DateTimeOriginal("2026:01:15 12:00:00".to_string()));
+        metadata.set_tag(ExifTag::Orientation(vec![1u16]));
+        metadata.set_tag(ExifTag::ImageWidth(vec![40u32]));
+        metadata.set_tag(ExifTag::ImageHeight(vec![40u32]));
+        metadata.write_to_file(&path).unwrap();
+
+        path
+    }
+
+    /// Helper: create a small JPEG with no EXIF.
+    fn create_test_jpeg_no_exif(dir: &Path, name: &str) -> PathBuf {
+        let img = image::ImageBuffer::from_pixel(40, 40, image::Rgb([0, 255, 0]));
+        let path = dir.join(name);
+        image::save_buffer(&path, &img, 40, 40, image::ExtendedColorType::Rgb8).unwrap();
+        path
+    }
+
+    /// Helper: build ResolvedPaths for a tempdir.
+    fn make_paths(tmp: &Path) -> ResolvedPaths {
+        ResolvedPaths {
+            root: tmp.to_path_buf(),
+            output: tmp.join("dist"),
+            content: tmp.join("content"),
+            templates: tmp.join("templates"),
+            static_dir: tmp.join("static"),
+            data_dir: tmp.join("data"),
+            public_dir: tmp.join("public"),
+        }
+    }
+
+    #[test]
+    fn test_filter_exif_all_preserves_metadata() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = create_test_jpeg_with_exif(tmp.path(), "photo.jpg");
+
+        let config = ImageSection {
+            exif_data_allow: ExifDataAllow::All,
+            ..Default::default()
+        };
+        let filtered = filter_exif(&source, &config).expect("should have metadata");
+        let tags: Vec<_> = (&filtered).into_iter().collect();
+        assert_eq!(tags.len(), 6, "ALL should preserve all 6 tags");
+    }
+
+    #[test]
+    fn test_filter_exif_allow_list_strips_others() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = create_test_jpeg_with_exif(tmp.path(), "photo.jpg");
+
+        let config = ImageSection {
+            exif_data_allow: ExifDataAllow::Allow(vec!["DateTimeOriginal".to_string()]),
+            ..Default::default()
+        };
+        let filtered = filter_exif(&source, &config).expect("should have metadata");
+
+        let tag_names: Vec<String> = (&filtered)
+            .into_iter()
+            .map(|t| {
+                let s = format!("{:?}", t);
+                s.split('(').next().unwrap_or(&s).to_string()
+            })
+            .collect();
+        assert_eq!(tag_names, vec!["DateTimeOriginal"]);
+    }
+
+    #[test]
+    fn test_filter_exif_empty_list_strips_all() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = create_test_jpeg_with_exif(tmp.path(), "photo.jpg");
+
+        let config = ImageSection {
+            exif_data_allow: ExifDataAllow::Allow(vec![]),
+            ..Default::default()
+        };
+        let filtered = filter_exif(&source, &config).expect("should have metadata (empty)");
+        let tags: Vec<_> = (&filtered).into_iter().collect();
+        assert!(tags.is_empty(), "empty allow-list should strip all tags");
+    }
+
+    #[test]
+    fn test_filter_exif_none_returns_no_metadata() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = create_test_jpeg_with_exif(tmp.path(), "photo.jpg");
+
+        let config = ImageSection {
+            exif_data_allow: ExifDataAllow::None,
+            ..Default::default()
+        };
+        assert!(filter_exif(&source, &config).is_none());
+    }
+
+    #[test]
+    fn test_filter_exif_custom_hex_tag() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = create_test_jpeg_with_exif(tmp.path(), "photo.jpg");
+
+        // 0x010F is the hex for Make
+        let config = ImageSection {
+            exif_data_allow: ExifDataAllow::Allow(vec!["0x010F".to_string()]),
+            ..Default::default()
+        };
+        let filtered = filter_exif(&source, &config).expect("should have metadata");
+
+        let tag_names: Vec<String> = (&filtered)
+            .into_iter()
+            .map(|t| {
+                let s = format!("{:?}", t);
+                s.split('(').next().unwrap_or(&s).to_string()
+            })
+            .collect();
+        assert_eq!(tag_names, vec!["Make"]);
+    }
+
+    #[test]
+    fn test_strip_dimensions_removes_four_fields() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = create_test_jpeg_with_exif(tmp.path(), "photo.jpg");
+        let mut metadata = Metadata::new_from_path(&source).expect("should read metadata");
+
+        strip_dimensions(&mut metadata);
+
+        let tag_names: Vec<String> = (&metadata)
+            .into_iter()
+            .map(|t| {
+                let s = format!("{:?}", t);
+                s.split('(').next().unwrap_or(&s).to_string()
+            })
+            .collect();
+        assert!(!tag_names.contains(&"ImageWidth".to_string()));
+        assert!(!tag_names.contains(&"ImageHeight".to_string()));
+        assert!(!tag_names.contains(&"ExifImageWidth".to_string()));
+        assert!(!tag_names.contains(&"ExifImageHeight".to_string()));
+        // Make, Model, DateTimeOriginal, Orientation should remain
+        assert!(tag_names.contains(&"Make".to_string()));
+        assert_eq!(tag_names.len(), 4);
+    }
+
+    #[test]
+    fn test_apply_exif_policy_to_originals_no_exif_image_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = make_paths(tmp.path());
+        let static_out = paths.output.join("static");
+        fs::create_dir_all(&static_out).unwrap();
+
+        // Image with no EXIF
+        create_test_jpeg_no_exif(&static_out, "clean.jpg");
+
+        let config = ImageSection {
+            exif_data_allow: ExifDataAllow::Allow(vec!["Make".to_string()]),
+            ..Default::default()
+        };
+        let count = apply_exif_policy_to_originals(&paths, &config).unwrap();
+        // No EXIF to filter — should succeed, may or may not count
+        // The key assertion is that it doesn't error
+        let _ = count;
+    }
+
+    #[test]
+    fn test_apply_exif_policy_to_originals_corrupt_image_warns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = make_paths(tmp.path());
+        let static_out = paths.output.join("static");
+        fs::create_dir_all(&static_out).unwrap();
+
+        // Write a corrupt "jpeg" — just random bytes with .jpg extension
+        fs::write(static_out.join("corrupt.jpg"), b"not a real jpeg").unwrap();
+
+        let config = ImageSection {
+            exif_data_allow: ExifDataAllow::None,
+            ..Default::default()
+        };
+        // Should not panic or error — build continues
+        let result = apply_exif_policy_to_originals(&paths, &config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_apply_exif_policy_to_originals_preserves_pixel_data() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = make_paths(tmp.path());
+        let static_out = paths.output.join("static");
+        fs::create_dir_all(&static_out).unwrap();
+
+        // Create image with EXIF in the output dir
+        let path = create_test_jpeg_with_exif(&static_out, "photo.jpg");
+
+        // Read pixel data before filtering
+        let before = image::open(&path).unwrap();
+        let before_rgba = before.to_rgba8();
+
+        let config = ImageSection {
+            exif_data_allow: ExifDataAllow::Allow(vec!["Make".to_string()]),
+            ..Default::default()
+        };
+        apply_exif_policy_to_originals(&paths, &config).unwrap();
+
+        // Read pixel data after filtering — should be identical
+        let after = image::open(&path).unwrap();
+        let after_rgba = after.to_rgba8();
+        assert_eq!(before_rgba.as_raw(), after_rgba.as_raw());
+
+        // Verify EXIF was filtered — only Make should remain
+        let read_meta = Metadata::new_from_path(&path).unwrap();
+        let tag_names: Vec<String> = (&read_meta)
+            .into_iter()
+            .map(|t| {
+                let s = format!("{:?}", t);
+                s.split('(').next().unwrap_or(&s).to_string()
+            })
+            .collect();
+        assert_eq!(tag_names, vec!["Make"]);
+    }
+
+    #[test]
+    fn test_apply_exif_policy_to_originals_none_strips_all() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = make_paths(tmp.path());
+        let static_out = paths.output.join("static");
+        fs::create_dir_all(&static_out).unwrap();
+
+        create_test_jpeg_with_exif(&static_out, "photo.jpg");
+        let path = static_out.join("photo.jpg");
+
+        let config = ImageSection {
+            exif_data_allow: ExifDataAllow::None,
+            ..Default::default()
+        };
+        apply_exif_policy_to_originals(&paths, &config).unwrap();
+
+        // Verify EXIF was stripped — reading back should fail or return empty
+        let read_meta = Metadata::new_from_path(&path);
+        match read_meta {
+            Ok(m) => {
+                let count = (&m).into_iter().count();
+                assert_eq!(count, 0, "all EXIF should be stripped");
+            }
+            Err(_) => {
+                // Acceptable: file_clear_metadata may make it unreadable as EXIF
+            }
+        }
+    }
+
+    #[test]
+    fn test_process_single_image_propagates_exif_to_jpeg_variants() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = make_paths(tmp.path());
+        fs::create_dir_all(&paths.static_dir).unwrap();
+        fs::create_dir_all(&paths.output).unwrap();
+
+        let source = create_test_jpeg_with_exif(&paths.static_dir, "photo.jpg");
+        let rel = Path::new("photo.jpg");
+
+        let config = ImageSection {
+            widths: vec![20],
+            quality: 80,
+            webp: false,
+            avif: false,
+            exif_data_allow: ExifDataAllow::All,
+            ..Default::default()
+        };
+        process_single_image(&source, rel, &paths.output, &config, "jpg").unwrap();
+
+        // Check the resized JPEG variant
+        let variant = paths.output.join("static").join("photo-20w.jpg");
+        assert!(variant.exists());
+        let read_meta = Metadata::new_from_path(&variant).expect("should have EXIF");
+        let tag_names: Vec<String> = (&read_meta)
+            .into_iter()
+            .map(|t| {
+                let s = format!("{:?}", t);
+                s.split('(').next().unwrap_or(&s).to_string()
+            })
+            .collect();
+
+        // Make, Model, DateTimeOriginal, Orientation should be present
+        assert!(tag_names.contains(&"Make".to_string()));
+        assert!(tag_names.contains(&"Orientation".to_string()));
+        // Dimensions should be stripped
+        assert!(!tag_names.contains(&"ImageWidth".to_string()));
+        assert!(!tag_names.contains(&"ImageHeight".to_string()));
+    }
+
+    #[test]
+    fn test_process_single_image_propagates_exif_to_webp_variants() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = make_paths(tmp.path());
+        fs::create_dir_all(&paths.static_dir).unwrap();
+        fs::create_dir_all(&paths.output).unwrap();
+
+        let source = create_test_jpeg_with_exif(&paths.static_dir, "photo.jpg");
+        let rel = Path::new("photo.jpg");
+
+        let config = ImageSection {
+            widths: vec![20],
+            quality: 80,
+            webp: true,
+            avif: false,
+            exif_data_allow: ExifDataAllow::All,
+            ..Default::default()
+        };
+        process_single_image(&source, rel, &paths.output, &config, "jpg").unwrap();
+
+        // Check the resized WebP variant
+        let variant = paths.output.join("static").join("photo-20w.webp");
+        assert!(variant.exists());
+        let read_meta = Metadata::new_from_path(&variant).expect("WebP should have EXIF");
+        let tag_names: Vec<String> = (&read_meta)
+            .into_iter()
+            .map(|t| {
+                let s = format!("{:?}", t);
+                s.split('(').next().unwrap_or(&s).to_string()
+            })
+            .collect();
+        assert!(tag_names.contains(&"Make".to_string()));
+        assert!(!tag_names.contains(&"ImageWidth".to_string()));
+    }
+
+    #[test]
+    fn test_process_single_image_propagates_exif_to_avif_variants() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = make_paths(tmp.path());
+        fs::create_dir_all(&paths.static_dir).unwrap();
+        fs::create_dir_all(&paths.output).unwrap();
+
+        let source = create_test_jpeg_with_exif(&paths.static_dir, "photo.jpg");
+        let rel = Path::new("photo.jpg");
+
+        let config = ImageSection {
+            widths: vec![20],
+            quality: 80,
+            webp: false,
+            avif: true,
+            exif_data_allow: ExifDataAllow::All,
+            ..Default::default()
+        };
+        process_single_image(&source, rel, &paths.output, &config, "jpg").unwrap();
+
+        // Check the resized AVIF variant
+        let variant = paths.output.join("static").join("photo-20w.avif");
+        assert!(variant.exists());
+        let read_meta = Metadata::new_from_path(&variant).expect("AVIF should have EXIF");
+        let tag_names: Vec<String> = (&read_meta)
+            .into_iter()
+            .map(|t| {
+                let s = format!("{:?}", t);
+                s.split('(').next().unwrap_or(&s).to_string()
+            })
+            .collect();
+        assert!(tag_names.contains(&"Make".to_string()));
+        assert!(!tag_names.contains(&"ImageWidth".to_string()));
+    }
+
+    #[test]
+    fn test_process_single_image_no_exif_source_no_variant_exif() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = make_paths(tmp.path());
+        fs::create_dir_all(&paths.static_dir).unwrap();
+        fs::create_dir_all(&paths.output).unwrap();
+
+        let source = create_test_jpeg_no_exif(&paths.static_dir, "photo.jpg");
+        let rel = Path::new("photo.jpg");
+
+        let config = ImageSection {
+            widths: vec![20],
+            quality: 80,
+            webp: false,
+            avif: false,
+            exif_data_allow: ExifDataAllow::All,
+            ..Default::default()
+        };
+        process_single_image(&source, rel, &paths.output, &config, "jpg").unwrap();
+
+        let variant = paths.output.join("static").join("photo-20w.jpg");
+        assert!(variant.exists());
+        // Should either fail to read EXIF (no EXIF) or return empty
+        match Metadata::new_from_path(&variant) {
+            Ok(m) => {
+                let count = (&m).into_iter().count();
+                assert_eq!(count, 0, "no EXIF should be present on variant");
+            }
+            Err(_) => { /* acceptable — no EXIF means nothing to read */ }
+        }
+    }
+
+    #[test]
+    fn test_process_single_image_none_no_variant_exif() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = make_paths(tmp.path());
+        fs::create_dir_all(&paths.static_dir).unwrap();
+        fs::create_dir_all(&paths.output).unwrap();
+
+        let source = create_test_jpeg_with_exif(&paths.static_dir, "photo.jpg");
+        let rel = Path::new("photo.jpg");
+
+        let config = ImageSection {
+            widths: vec![20],
+            quality: 80,
+            webp: false,
+            avif: false,
+            exif_data_allow: ExifDataAllow::None,
+            ..Default::default()
+        };
+        process_single_image(&source, rel, &paths.output, &config, "jpg").unwrap();
+
+        let variant = paths.output.join("static").join("photo-20w.jpg");
+        assert!(variant.exists());
+        match Metadata::new_from_path(&variant) {
+            Ok(m) => {
+                let count = (&m).into_iter().count();
+                assert_eq!(count, 0, "NONE should produce no EXIF on variants");
+            }
+            Err(_) => { /* acceptable */ }
+        }
+    }
+
+    #[test]
+    fn test_process_single_image_dimensions_stripped_from_variants() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = make_paths(tmp.path());
+        fs::create_dir_all(&paths.static_dir).unwrap();
+        fs::create_dir_all(&paths.output).unwrap();
+
+        let source = create_test_jpeg_with_exif(&paths.static_dir, "photo.jpg");
+        let rel = Path::new("photo.jpg");
+
+        let config = ImageSection {
+            widths: vec![20],
+            quality: 80,
+            webp: true,
+            avif: true,
+            exif_data_allow: ExifDataAllow::All,
+            ..Default::default()
+        };
+        process_single_image(&source, rel, &paths.output, &config, "jpg").unwrap();
+
+        // Check all variant types for absence of dimension fields
+        for variant_name in &[
+            "photo-20w.jpg",
+            "photo-20w.webp",
+            "photo-20w.avif",
+            "photo.webp",
+            "photo.avif",
+        ] {
+            let variant = paths.output.join("static").join(variant_name);
+            if !variant.exists() {
+                continue;
+            }
+            if let Ok(meta) = Metadata::new_from_path(&variant) {
+                let tag_names: Vec<String> = (&meta)
+                    .into_iter()
+                    .map(|t| {
+                        let s = format!("{:?}", t);
+                        s.split('(').next().unwrap_or(&s).to_string()
+                    })
+                    .collect();
+                assert!(
+                    !tag_names.contains(&"ImageWidth".to_string()),
+                    "{variant_name} should not have ImageWidth"
+                );
+                assert!(
+                    !tag_names.contains(&"ImageHeight".to_string()),
+                    "{variant_name} should not have ImageHeight"
+                );
+                assert!(
+                    !tag_names.contains(&"ExifImageWidth".to_string()),
+                    "{variant_name} should not have ExifImageWidth"
+                );
+                assert!(
+                    !tag_names.contains(&"ExifImageHeight".to_string()),
+                    "{variant_name} should not have ExifImageHeight"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_is_allowed_variant_name_matching() {
+        let mut names = std::collections::HashSet::new();
+        names.insert("make".to_string());
+        let hex_ids = std::collections::HashSet::new();
+
+        // A Make tag should match by name
+        let tag = ExifTag::Make("Canon".to_string());
+        assert!(is_allowed(&tag, &names, &hex_ids));
+
+        // A Model tag should not match
+        let tag = ExifTag::Model("EOS".to_string());
+        assert!(!is_allowed(&tag, &names, &hex_ids));
+    }
+
+    #[test]
+    fn test_is_allowed_case_insensitive_name_matching() {
+        // parse_allow_list normalizes names to lowercase; is_allowed compares case-insensitively.
+        // So a user writing "datetimEoriginal" should still match DateTimeOriginal.
+        let (names, _hex) =
+            parse_allow_list(&ExifDataAllow::Allow(vec!["datetimEoriginal".to_string()]));
+        let hex_ids = std::collections::HashSet::new();
+
+        let tag = ExifTag::DateTimeOriginal("2026:01:01 00:00:00".to_string());
+        assert!(is_allowed(&tag, &names, &hex_ids));
+
+        // Non-matching tag should still be rejected
+        let tag = ExifTag::Make("Canon".to_string());
+        assert!(!is_allowed(&tag, &names, &hex_ids));
+    }
+
+    #[test]
+    fn test_is_allowed_hex_id_matching() {
+        let names = std::collections::HashSet::new();
+        let mut hex_ids = std::collections::HashSet::new();
+        // 0x010F = hex for Make
+        hex_ids.insert(0x010Fu16);
+
+        let tag = ExifTag::Make("Canon".to_string());
+        assert!(is_allowed(&tag, &names, &hex_ids));
+
+        let tag = ExifTag::Model("EOS".to_string());
+        assert!(!is_allowed(&tag, &names, &hex_ids));
     }
 }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -63,6 +63,8 @@ pub struct BuildStats {
     pub incremental: bool,
     /// Number of content items skipped (unchanged).
     pub items_skipped: usize,
+    /// Number of original images that had EXIF filtered in-place.
+    pub exif_files_modified: usize,
 }
 
 impl CommandOutput for BuildStats {
@@ -92,6 +94,12 @@ impl CommandOutput for BuildStats {
         }
         if self.data_files_loaded > 0 {
             out.push_str(&format!(", {} data files loaded", self.data_files_loaded));
+        }
+        if self.exif_files_modified > 0 {
+            out.push_str(&format!(
+                ", {} images EXIF filtered",
+                self.exif_files_modified
+            ));
         }
         if self.incremental && self.items_skipped > 0 {
             out.push_str(&format!(", {} items unchanged", self.items_skipped));
@@ -279,6 +287,7 @@ pub fn build_site(
                     step_timings: Vec::new(),
                     incremental: true,
                     items_skipped: cs.total_content,
+                    exif_files_modified: 0,
                 },
                 link_check: links::LinkCheckResult {
                     total_links_checked: 0,
@@ -2222,6 +2231,19 @@ fn build_site_inner(
         step_start.elapsed().as_secs_f64() * 1000.0,
     ));
 
+    // Step 10b: Apply EXIF data policy to original images
+    let exif_step_start = Instant::now();
+    let mut exif_files_modified = 0;
+    if let Some(ref images_config) = config.images {
+        exif_files_modified = images::apply_exif_policy_to_originals(paths, images_config)?;
+        if exif_files_modified > 0 {
+            step_timings.push((
+                "Filter EXIF on originals".to_string(),
+                exif_step_start.elapsed().as_secs_f64() * 1000.0,
+            ));
+        }
+    }
+
     // Step 11: Process images (resize, WebP, srcset)
     progress.step("Processing images");
     let step_start = Instant::now();
@@ -2328,6 +2350,7 @@ fn build_site_inner(
         step_timings,
         incremental: is_incremental,
         items_skipped,
+        exif_files_modified,
     };
 
     Ok(BuildResult {
@@ -3635,6 +3658,7 @@ mod tests {
             step_timings: vec![],
             incremental: false,
             items_skipped: 0,
+            exif_files_modified: 0,
         };
         let display = stats.human_display();
         assert!(display.contains("5 posts"));
@@ -3655,6 +3679,7 @@ mod tests {
             step_timings: vec![],
             incremental: false,
             items_skipped: 0,
+            exif_files_modified: 0,
         };
         let display = stats.human_display();
         assert!(display.contains("2 public files copied"));
@@ -3672,6 +3697,7 @@ mod tests {
             step_timings: vec![("Fast step".into(), 0.5), ("Slow step".into(), 15.3)],
             incremental: false,
             items_skipped: 0,
+            exif_files_modified: 0,
         };
         let display = stats.human_display();
         assert!(display.contains("Timings:"));
@@ -3694,6 +3720,7 @@ mod tests {
             step_timings: vec![],
             incremental: true,
             items_skipped: 18,
+            exif_files_modified: 0,
         };
         let display = stats.human_display();
         assert!(display.contains("Incremental build"));

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -42,6 +42,10 @@ pub fn avif_quality() -> u8 {
     70
 }
 
+pub fn exif_data_allow() -> crate::config::ExifDataAllow {
+    crate::config::ExifDataAllow::All
+}
+
 pub fn bool_true() -> bool {
     true
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -312,7 +312,64 @@ pub enum DeployTarget {
     Netlify,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Controls which EXIF metadata fields are preserved and propagated to image variants.
+///
+/// Field names match `little_exif::exif_tag::ExifTag` variant names (e.g.
+/// `"DateTimeOriginal"`, `"Orientation"`, `"Make"`, `"Model"`, `"GPSLatitude"`).
+/// Custom/unknown tags use hex IDs as strings (e.g. `"0xC62F"`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExifDataAllow {
+    /// Preserve all EXIF fields and propagate to variants. Default behavior.
+    All,
+    /// Strip all EXIF from originals, don't add EXIF to variants.
+    None,
+    /// Preserve only the listed fields, strip everything else.
+    Allow(Vec<String>),
+}
+
+impl<'de> Deserialize<'de> for ExifDataAllow {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+        let v: toml::Value = Deserialize::deserialize(deserializer)?;
+        match &v {
+            toml::Value::String(s) if s.eq_ignore_ascii_case("ALL") => Ok(ExifDataAllow::All),
+            toml::Value::String(s) if s.eq_ignore_ascii_case("NONE") => Ok(ExifDataAllow::None),
+            toml::Value::Array(arr) => {
+                let fields: Vec<String> = arr
+                    .iter()
+                    .map(|item| match item {
+                        toml::Value::String(s) => Ok(s.clone()),
+                        _ => Err(D::Error::custom(
+                            "exif_data_allow array must contain only strings",
+                        )),
+                    })
+                    .collect::<std::result::Result<_, _>>()?;
+                Ok(ExifDataAllow::Allow(fields))
+            }
+            _ => Err(D::Error::custom(
+                "exif_data_allow must be \"ALL\", \"NONE\", or an array of field names",
+            )),
+        }
+    }
+}
+
+impl Serialize for ExifDataAllow {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            ExifDataAllow::All => serializer.serialize_str("ALL"),
+            ExifDataAllow::None => serializer.serialize_str("NONE"),
+            ExifDataAllow::Allow(fields) => fields.serialize(serializer),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ImageSection {
     /// Generate resized copies at these widths (pixels). Default: [480, 800, 1200].
     #[serde(default = "defaults::image_widths")]
@@ -332,6 +389,12 @@ pub struct ImageSection {
     /// AVIF quality (1-100). Default: 70 (AVIF compresses better than WebP, so lower is OK).
     #[serde(default = "defaults::avif_quality")]
     pub avif_quality: u8,
+    /// Which EXIF fields to preserve and propagate to image variants. "ALL" preserves
+    /// everything (default). "NONE" strips all EXIF from originals and adds none to variants.
+    /// A list of field names preserves only those fields. Dimension fields are always
+    /// stripped from variants since they'd be stale after resizing.
+    #[serde(default = "defaults::exif_data_allow")]
+    pub exif_data_allow: ExifDataAllow,
 }
 
 impl Default for ImageSection {
@@ -343,6 +406,7 @@ impl Default for ImageSection {
             webp: true,
             avif: false,
             avif_quality: defaults::avif_quality(),
+            exif_data_allow: defaults::exif_data_allow(),
         }
     }
 }
@@ -924,5 +988,219 @@ deploy_project = "my-docs"
             paths.subdomain_output("docs"),
             PathBuf::from("/project/dist-subdomains/docs")
         );
+    }
+
+    // ── ExifDataAllow tests ──────────────────────────────────────────────
+
+    #[test]
+    fn test_exif_data_allow_all_deserialize() {
+        let toml_str = r#"
+[site]
+title = "Test"
+base_url = "https://example.com"
+
+[[collections]]
+name = "posts"
+label = "Posts"
+directory = "posts"
+default_template = "post.html"
+
+[images]
+exif_data_allow = "ALL"
+"#;
+        let config: SiteConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.images.unwrap().exif_data_allow, ExifDataAllow::All);
+    }
+
+    #[test]
+    fn test_exif_data_allow_none_deserialize() {
+        let toml_str = r#"
+[site]
+title = "Test"
+base_url = "https://example.com"
+
+[[collections]]
+name = "posts"
+label = "Posts"
+directory = "posts"
+default_template = "post.html"
+
+[images]
+exif_data_allow = "NONE"
+"#;
+        let config: SiteConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.images.unwrap().exif_data_allow, ExifDataAllow::None);
+    }
+
+    #[test]
+    fn test_exif_data_allow_case_insensitive() {
+        // Lowercase "all" and "none" should also be accepted
+        let toml_all = r#"
+[site]
+title = "Test"
+base_url = "https://example.com"
+
+[[collections]]
+name = "posts"
+label = "Posts"
+directory = "posts"
+default_template = "post.html"
+
+[images]
+exif_data_allow = "all"
+"#;
+        let config: SiteConfig = toml::from_str(toml_all).unwrap();
+        assert_eq!(config.images.unwrap().exif_data_allow, ExifDataAllow::All);
+
+        let toml_none = r#"
+[site]
+title = "Test"
+base_url = "https://example.com"
+
+[[collections]]
+name = "posts"
+label = "Posts"
+directory = "posts"
+default_template = "post.html"
+
+[images]
+exif_data_allow = "none"
+"#;
+        let config: SiteConfig = toml::from_str(toml_none).unwrap();
+        assert_eq!(config.images.unwrap().exif_data_allow, ExifDataAllow::None);
+    }
+
+    #[test]
+    fn test_exif_data_allow_list_deserialize() {
+        let toml_str = r#"
+[site]
+title = "Test"
+base_url = "https://example.com"
+
+[[collections]]
+name = "posts"
+label = "Posts"
+directory = "posts"
+default_template = "post.html"
+
+[images]
+exif_data_allow = ["DateTimeOriginal", "Orientation"]
+"#;
+        let config: SiteConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.images.unwrap().exif_data_allow,
+            ExifDataAllow::Allow(vec!["DateTimeOriginal".into(), "Orientation".into()])
+        );
+    }
+
+    #[test]
+    fn test_exif_data_allow_empty_list_deserialize() {
+        let toml_str = r#"
+[site]
+title = "Test"
+base_url = "https://example.com"
+
+[[collections]]
+name = "posts"
+label = "Posts"
+directory = "posts"
+default_template = "post.html"
+
+[images]
+exif_data_allow = []
+"#;
+        let config: SiteConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.images.unwrap().exif_data_allow,
+            ExifDataAllow::Allow(vec![])
+        );
+    }
+
+    #[test]
+    fn test_exif_data_allow_default_is_all() {
+        assert_eq!(ImageSection::default().exif_data_allow, ExifDataAllow::All);
+    }
+
+    #[test]
+    fn test_exif_data_allow_full_toml_roundtrip() {
+        // Test with list including hex tag
+        let toml_str = r#"
+[site]
+title = "Test"
+base_url = "https://example.com"
+
+[[collections]]
+name = "posts"
+label = "Posts"
+directory = "posts"
+default_template = "post.html"
+
+[images]
+exif_data_allow = ["DateTimeOriginal", "0xC62F"]
+"#;
+        let config: SiteConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.images.unwrap().exif_data_allow,
+            ExifDataAllow::Allow(vec!["DateTimeOriginal".into(), "0xC62F".into()])
+        );
+
+        // Test ALL
+        let toml_all = r#"
+[site]
+title = "Test"
+base_url = "https://example.com"
+
+[[collections]]
+name = "posts"
+label = "Posts"
+directory = "posts"
+default_template = "post.html"
+
+[images]
+exif_data_allow = "ALL"
+"#;
+        let config_all: SiteConfig = toml::from_str(toml_all).unwrap();
+        assert_eq!(
+            config_all.images.unwrap().exif_data_allow,
+            ExifDataAllow::All
+        );
+
+        // Test NONE
+        let toml_none = r#"
+[site]
+title = "Test"
+base_url = "https://example.com"
+
+[[collections]]
+name = "posts"
+label = "Posts"
+directory = "posts"
+default_template = "post.html"
+
+[images]
+exif_data_allow = "NONE"
+"#;
+        let config_none: SiteConfig = toml::from_str(toml_none).unwrap();
+        assert_eq!(
+            config_none.images.unwrap().exif_data_allow,
+            ExifDataAllow::None
+        );
+    }
+
+    #[test]
+    fn test_exif_data_allow_no_images_section_unchanged() {
+        let toml_str = r#"
+[site]
+title = "Test"
+base_url = "https://example.com"
+
+[[collections]]
+name = "posts"
+label = "Posts"
+directory = "posts"
+default_template = "post.html"
+"#;
+        let config: SiteConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.images.is_none());
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10604,3 +10604,260 @@ fn test_completions_stdout_is_clean() {
         "update notification must not appear on stdout"
     );
 }
+
+// ── EXIF integration tests ─────────────────────────────────────────────
+
+/// Helper: create a small JPEG with known EXIF tags in a site's static dir.
+fn create_exif_jpeg(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+    use little_exif::exif_tag::ExifTag;
+    use little_exif::metadata::Metadata;
+
+    let img = image::ImageBuffer::from_pixel(40, 40, image::Rgb([255, 0, 0]));
+    let path = dir.join(name);
+    image::save_buffer(&path, &img, 40, 40, image::ExtendedColorType::Rgb8).unwrap();
+
+    let mut metadata = Metadata::new();
+    metadata.set_tag(ExifTag::Make("TestCamera".to_string()));
+    metadata.set_tag(ExifTag::Model("TestModel".to_string()));
+    metadata.set_tag(ExifTag::DateTimeOriginal("2026:01:15 12:00:00".to_string()));
+    metadata.set_tag(ExifTag::Orientation(vec![1u16]));
+    metadata.set_tag(ExifTag::ImageWidth(vec![40u32]));
+    metadata.set_tag(ExifTag::ImageHeight(vec![40u32]));
+    metadata.write_to_file(&path).unwrap();
+
+    path
+}
+
+/// Helper: read EXIF tag names from a file (returns sorted vector of variant names).
+fn read_exif_tag_names(path: &std::path::Path) -> Vec<String> {
+    use little_exif::metadata::Metadata;
+
+    match Metadata::new_from_path(path) {
+        Ok(meta) => {
+            let mut names: Vec<String> = (&meta)
+                .into_iter()
+                .map(|t| {
+                    let s = format!("{:?}", t);
+                    s.split('(').next().unwrap_or(&s).to_string()
+                })
+                .collect();
+            names.sort();
+            names
+        }
+        Err(_) => vec![],
+    }
+}
+
+/// Helper: replace the [images] section in seite.toml (or append if not present).
+fn add_images_config(site_dir: &std::path::Path, config: &str) {
+    let toml_path = site_dir.join("seite.toml");
+    let content = std::fs::read_to_string(&toml_path).unwrap();
+
+    // Find and replace the existing [images] section, or append if not present.
+    // The [images] section runs from "[images]" to the next section header
+    // (a line starting with "[") or end of file.
+    let new_section = format!("[images]\n{}\n", config);
+
+    let updated = if let Some(start) = content.find("[images]") {
+        // Find the end of the images section — next section header or EOF
+        let after_images = &content[start..];
+        let end_offset = after_images[1..]
+            .find("\n[")
+            .map(|pos| start + 1 + pos + 1) // +1 to skip the \n before [
+            .unwrap_or(content.len());
+
+        let before = &content[..start];
+        let after = if end_offset < content.len() {
+            &content[end_offset..]
+        } else {
+            ""
+        };
+        format!("{before}{new_section}\n{after}")
+    } else {
+        format!("{content}\n{new_section}")
+    };
+
+    std::fs::write(&toml_path, updated).unwrap();
+}
+
+#[test]
+fn test_build_with_exif_propagation() {
+    let tmp = TempDir::new().unwrap();
+    init_site(&tmp, "site", "EXIF Test", "posts,pages");
+
+    let site_dir = tmp.path().join("site");
+    let static_dir = site_dir.join("static");
+    std::fs::create_dir_all(&static_dir).unwrap();
+    create_exif_jpeg(&static_dir, "photo.jpg");
+
+    // Configure with allow-list: only Orientation
+    add_images_config(
+        &site_dir,
+        "widths = [20]\nquality = 80\nexif_data_allow = [\"Orientation\"]\n",
+    );
+
+    // Build
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+
+    let dist = site_dir.join("dist/static");
+
+    // Original should have only Orientation
+    let orig_tags = read_exif_tag_names(&dist.join("photo.jpg"));
+    assert_eq!(
+        orig_tags,
+        vec!["Orientation"],
+        "original should have only Orientation, got: {orig_tags:?}"
+    );
+
+    // JPEG variant should have Orientation (no dimensions)
+    let variant_tags = read_exif_tag_names(&dist.join("photo-20w.jpg"));
+    assert!(
+        variant_tags.contains(&"Orientation".to_string()),
+        "JPEG variant should have Orientation, got: {variant_tags:?}"
+    );
+    assert!(
+        !variant_tags.contains(&"ImageWidth".to_string()),
+        "JPEG variant should not have ImageWidth"
+    );
+
+    // WebP variant should have Orientation
+    let webp_tags = read_exif_tag_names(&dist.join("photo-20w.webp"));
+    assert!(
+        webp_tags.contains(&"Orientation".to_string()),
+        "WebP variant should have Orientation, got: {webp_tags:?}"
+    );
+}
+
+#[test]
+fn test_build_without_exif_config_unchanged() {
+    let tmp = TempDir::new().unwrap();
+    init_site(&tmp, "site", "EXIF Default", "posts,pages");
+
+    let site_dir = tmp.path().join("site");
+    let static_dir = site_dir.join("static");
+    std::fs::create_dir_all(&static_dir).unwrap();
+    create_exif_jpeg(&static_dir, "photo.jpg");
+
+    // No exif_data_allow — default is "ALL"
+    add_images_config(&site_dir, "widths = [20]\nquality = 80\n");
+
+    // Build
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+
+    let dist = site_dir.join("dist/static");
+
+    // Original should keep ALL EXIF tags
+    let orig_tags = read_exif_tag_names(&dist.join("photo.jpg"));
+    assert!(
+        orig_tags.contains(&"Make".to_string()),
+        "original should have Make (ALL default), got: {orig_tags:?}"
+    );
+    assert!(
+        orig_tags.contains(&"DateTimeOriginal".to_string()),
+        "original should have DateTimeOriginal"
+    );
+    assert!(
+        orig_tags.contains(&"ImageWidth".to_string()),
+        "original should have ImageWidth (originals keep dimensions)"
+    );
+
+    // JPEG variant should have EXIF but no dimensions
+    let variant_tags = read_exif_tag_names(&dist.join("photo-20w.jpg"));
+    assert!(
+        variant_tags.contains(&"Make".to_string()),
+        "JPEG variant should have Make (ALL default), got: {variant_tags:?}"
+    );
+    assert!(
+        !variant_tags.contains(&"ImageWidth".to_string()),
+        "JPEG variant should not have ImageWidth"
+    );
+    assert!(
+        !variant_tags.contains(&"ImageHeight".to_string()),
+        "JPEG variant should not have ImageHeight"
+    );
+}
+
+#[test]
+fn test_build_no_images_section_unchanged() {
+    let tmp = TempDir::new().unwrap();
+    init_site(&tmp, "site", "No Images", "posts,pages");
+
+    let site_dir = tmp.path().join("site");
+    let static_dir = site_dir.join("static");
+    std::fs::create_dir_all(&static_dir).unwrap();
+    create_exif_jpeg(&static_dir, "photo.jpg");
+
+    // No [images] section at all
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+
+    let dist = site_dir.join("dist/static");
+
+    // Original should keep ALL EXIF (byte-for-byte copy)
+    let orig_tags = read_exif_tag_names(&dist.join("photo.jpg"));
+    assert!(
+        orig_tags.contains(&"Make".to_string()),
+        "original should have Make (no images section), got: {orig_tags:?}"
+    );
+    assert!(
+        orig_tags.contains(&"ImageWidth".to_string()),
+        "original should have ImageWidth"
+    );
+
+    // No variants should exist
+    assert!(
+        !dist.join("photo-20w.jpg").exists(),
+        "no variants should be generated without [images] section"
+    );
+}
+
+#[test]
+fn test_build_with_exif_none_strips_all() {
+    let tmp = TempDir::new().unwrap();
+    init_site(&tmp, "site", "EXIF None", "posts,pages");
+
+    let site_dir = tmp.path().join("site");
+    let static_dir = site_dir.join("static");
+    std::fs::create_dir_all(&static_dir).unwrap();
+    create_exif_jpeg(&static_dir, "photo.jpg");
+
+    // Strip all EXIF
+    add_images_config(
+        &site_dir,
+        "widths = [20]\nquality = 80\nexif_data_allow = \"NONE\"\n",
+    );
+
+    // Build
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+
+    let dist = site_dir.join("dist/static");
+
+    // Original should have no EXIF
+    let orig_tags = read_exif_tag_names(&dist.join("photo.jpg"));
+    assert!(
+        orig_tags.is_empty(),
+        "original should have no EXIF (NONE), got: {orig_tags:?}"
+    );
+
+    // JPEG variant should have no EXIF
+    let variant_tags = read_exif_tag_names(&dist.join("photo-20w.jpg"));
+    assert!(
+        variant_tags.is_empty(),
+        "JPEG variant should have no EXIF (NONE), got: {variant_tags:?}"
+    );
+}


### PR DESCRIPTION
Add  config field under [images] to control which
EXIF fields are preserved from source images and propagated to all generated variants (resized JPEG, WebP, AVIF, full-size copies).

- ALL (default): preserve everything, propagate to variants
- NONE: strip all EXIF from originals and variants
- [DateTimeOriginal, Orientation, ...]: allow-list specific fields
- Custom tags supported via hex ID (e.g. 0xC62F)
- Dimension fields always stripped from variants (stale after resize)
- Lossless writes via little_exif (byte-level, no re-encoding)
- Non-fatal: malformed images warn and continue

Behavioral change: sites with [images] now propagate EXIF to variants by default. Previously variants had no EXIF. Set exif_data_allow = NONE to restore old behavior.

Bumps version to 0.17.0.

Generated-with: Polytoken.