### PR TITLE
Fix: seite serve --site bakes the dev address into base_url in a workspace (#86 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/seite-sh/content/changelog/2026-07-20-v0-16-2.md
+++ b/seite-sh/content/changelog/2026-07-20-v0-16-2.md
@@ -1,0 +1,15 @@
+---
+title: v0.16.2
+description: "Bugfix: `seite serve --site <name>` in a workspace now bakes the live dev address into that site's absolute URLs, extending the standalone serve fix from v0.16.1."
+date: 2026-07-20
+tags:
+- fix
+---
+
+## `seite serve --site` respects the dev address in a workspace
+
+[v0.16.1](/changelog/v0-16-1) fixed absolute URLs for standalone `seite serve`, but single-site serve inside a workspace (`seite serve --site <name>`) still baked the configured `base_url` — defaulting to `http://localhost:3000` — into `og:image`, `<link rel="canonical">`, the sitemap, and feeds.
+
+Now `serve --site` resolves the port up front and rewrites that site's `base_url` to the live dev address, for both the initial build and watcher rebuilds, exactly like standalone serve.
+
+The multi-site workspace dev server (`seite serve` with no `--site`) is unchanged: it still serves every site under its own path prefix with each site's configured `base_url`. Rewriting those per-site is tracked as a separate change.

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -43,6 +43,7 @@ pub fn run(args: &BuildArgs, site_filter: Option<&str>) -> anyhow::Result<()> {
             include_drafts: args.drafts,
             strict: args.strict,
             site_filter: site_filter.map(String::from),
+            base_url_override: None,
         };
 
         workspace::build::build_workspace(&ws_config, &ws_root, &opts)?;

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -42,6 +42,26 @@ pub fn run(args: &ServeArgs, site_filter: Option<&str>) -> anyhow::Result<()> {
     if let Some(ws_root) = workspace::find_workspace_root(&cwd) {
         let ws_config = workspace::WorkspaceConfig::load(&ws_root.join("seite-workspace.toml"))?;
 
+        // For single-site serve, bake the live dev address into that site's
+        // base_url (mirrors standalone). Resolve its port up front so even the
+        // first build is correct, then hand that exact port to the server with
+        // auto-increment off. The multi-site server below keeps each site's own
+        // configured base_url — a per-site rewrite there is a separate design. (#86)
+        let single_site_port = match site_filter {
+            Some(_) => Some(match args.port {
+                Some(p) => p,
+                None => server::find_available_port(host, DEFAULT_PORT).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "no available port found in {}-{}",
+                        DEFAULT_PORT,
+                        DEFAULT_PORT.saturating_add(99)
+                    )
+                })?,
+            }),
+            None => None,
+        };
+        let dev_base_url = single_site_port.map(|p| server::dev_base_url(host, p));
+
         // Build all sites first
         if args.build {
             human::info("Building workspace...");
@@ -49,20 +69,22 @@ pub fn run(args: &ServeArgs, site_filter: Option<&str>) -> anyhow::Result<()> {
                 include_drafts: true,
                 strict: false,
                 site_filter: site_filter.map(String::from),
+                base_url_override: dev_base_url.clone(),
             };
             workspace::build::build_workspace(&ws_config, &ws_root, &build_opts)?;
         }
-
-        let port = args.port.unwrap_or(DEFAULT_PORT);
-        let auto_increment = args.port.is_none();
 
         // If --site is specified, serve only that site in standalone mode
         if let Some(site_name) = site_filter {
             let ws_site = ws_config
                 .find_site(site_name)
                 .ok_or_else(|| anyhow::anyhow!("unknown site '{site_name}' in workspace"))?;
-            let (config, paths) = workspace::load_site_in_workspace(&ws_root, ws_site)?;
-            let handle = server::start(&config, &paths, host, port, true, auto_increment)?;
+            let (mut config, paths) = workspace::load_site_in_workspace(&ws_root, ws_site)?;
+            if let Some(ref url) = dev_base_url {
+                config.site.base_url = url.clone();
+            }
+            let port = single_site_port.expect("resolved above when site_filter is set");
+            let handle = server::start(&config, &paths, host, port, true, false)?;
 
             human::info(&format!(
                 "Serving site '{site_name}'. Type \"help\" for commands, \"stop\" to quit (port {})",
@@ -73,7 +95,9 @@ pub fn run(args: &ServeArgs, site_filter: Option<&str>) -> anyhow::Result<()> {
             return Ok(());
         }
 
-        // Workspace dev server (all sites)
+        // Workspace dev server (all sites) — each site keeps its configured base_url.
+        let port = args.port.unwrap_or(DEFAULT_PORT);
+        let auto_increment = args.port.is_none();
         let handle = workspace::server::start(&ws_config, &ws_root, host, port, auto_increment)?;
 
         human::info(&format!(

--- a/src/workspace/build.rs
+++ b/src/workspace/build.rs
@@ -9,6 +9,9 @@ pub struct WorkspaceBuildOptions {
     pub include_drafts: bool,
     pub strict: bool,
     pub site_filter: Option<String>,
+    /// Override each built site's `base_url` (used by single-site `serve` to
+    /// bake the live dev address). `None` keeps the configured `base_url`.
+    pub base_url_override: Option<String>,
 }
 
 pub struct WorkspaceBuildResult {
@@ -52,7 +55,10 @@ pub fn build_workspace(
             ws_site.name
         ));
 
-        let (config, paths) = load_site_in_workspace(ws_root, ws_site)?;
+        let (mut config, paths) = load_site_in_workspace(ws_root, ws_site)?;
+        if let Some(ref base_url) = opts.base_url_override {
+            config.site.base_url = base_url.clone();
+        }
 
         let build_opts = BuildOptions {
             include_drafts: opts.include_drafts,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8030,9 +8030,12 @@ fn test_workspace_serve_site_bakes_actual_port() {
             .unwrap();
 
         if !output.status.success() {
+            // Retry on a fresh port for a likely race, but surface the real
+            // stderr on exhaustion so a genuine failure isn't hidden.
             assert!(
                 attempt < 4,
-                "serve --site failed to start on 5 ephemeral ports"
+                "serve --site failed to start on 5 ephemeral ports; last stderr:\n{}",
+                String::from_utf8_lossy(&output.stderr)
             );
             continue;
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7980,6 +7980,76 @@ fn test_workspace_build_with_site_filter() {
         .success();
 }
 
+/// Regression follow-up to #86: `serve --site` in a workspace must bake the
+/// live dev address into that site's absolute URLs, not localhost:3000.
+#[test]
+fn test_workspace_serve_site_bakes_actual_port() {
+    let tmp = TempDir::new().unwrap();
+
+    page_cmd()
+        .args(["workspace", "init", "ws-serve"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    page_cmd()
+        .args([
+            "workspace",
+            "add",
+            "foo",
+            "--title",
+            "Foo",
+            "--collections",
+            "posts,pages",
+        ])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Retry across ephemeral ports (TOCTOU between selection and the child bind).
+    for attempt in 0..5 {
+        let port = std::net::TcpListener::bind(("127.0.0.1", 0))
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+
+        let output = page_cmd()
+            .args([
+                "serve",
+                "--site",
+                "foo",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                &port.to_string(),
+            ])
+            .current_dir(tmp.path())
+            .write_stdin("stop\n")
+            .output()
+            .unwrap();
+
+        if !output.status.success() {
+            assert!(
+                attempt < 4,
+                "serve --site failed to start on 5 ephemeral ports"
+            );
+            continue;
+        }
+
+        let sitemap = fs::read_to_string(tmp.path().join("sites/foo/dist/sitemap.xml")).unwrap();
+        assert!(
+            sitemap.contains(&format!("http://127.0.0.1:{port}")),
+            "workspace --site sitemap should use the actual serve address, got:\n{sitemap}"
+        );
+        assert!(
+            !sitemap.contains("localhost:3000"),
+            "workspace --site sitemap must not fall back to localhost:3000"
+        );
+        return;
+    }
+}
+
 // --- self-update ---
 
 #[test]


### PR DESCRIPTION
Follow-up to #88 (which fixed standalone `seite serve`). **Stacked on `fix/serve-base-url`** — it reuses the `dev_base_url` / `find_available_port` helpers from #88, so review/merge that first; this PR will auto-retarget to `main` once #88 lands.

## Problem

`seite serve --site <name>` inside a workspace still built with the site's configured `base_url` (defaulting to `http://localhost:3000`), so `og:image`, canonical, sitemap, and feeds ignored the actual `--host`/`--port` — the same bug #88 fixed for standalone serve, just on the workspace path.

## Fix

For the single-site serve path, resolve the port up front and rewrite that site's `base_url` to the live dev address, applied to **both** the initial workspace build and the server (auto-increment off, so the bound port matches the baked URL). Mechanically:
- `WorkspaceBuildOptions` gains `base_url_override`, applied per-site in `build_workspace`.
- `serve --site` overrides the loaded site config's `base_url` before `server::start` (covers watcher rebuilds too).

**Out of scope:** the multi-site workspace dev server (`seite serve` with no `--site`) is unchanged — it serves each site under its own path prefix with that site's configured `base_url`. Per-site rewriting there needs its own design and is left as a follow-up.

## Verified
- New integration test `test_workspace_serve_site_bakes_actual_port`: `serve --site foo --port <free>` → `sites/foo/dist/sitemap.xml` uses the actual address, not `localhost:3000` (confirmed failing before the fix).
- Full suite green; standalone regression test still passes.
- v0.16.2 + changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)