### PR TITLE
Add Mermaid diagram support (mermaid = true) (#87)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ src/
   lib.rs, error.rs     Module declarations, PageError enum (thiserror)
   themes.rs            10 bundled themes + src/themes/*.tera
   shortcodes/          ShortcodeRegistry, parser, builtins (youtube, vimeo, gist, callout, figure, contact_form)
-  build/               15-step build pipeline (mod.rs), analytics, base_path, code_copy, links, markdown, feed, sitemap, discovery, images, math
+  build/               15-step build pipeline (mod.rs), analytics, base_path, code_copy, links, markdown, feed, sitemap, discovery, images, math, mermaid
   docs.rs              Embedded docs (15 pages from seite-sh/content/docs/)
   i18n.rs              Language-map resolution + `i18n`/`localize` Tera filter (per-language data values)
   meta.rs              Project metadata (.seite/config.json)
@@ -75,6 +75,7 @@ output_dir = "dist"
 minify = true
 fingerprint = true
 math = true              # KaTeX
+mermaid = true           # Mermaid diagrams (```mermaid fences, client-side)
 
 [deploy]
 target = "github-pages"  # or "cloudflare" or "netlify"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "seite"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seite"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2021"
 description = "AI-native static site generator — every page ships as HTML, markdown, and structured data"
 license = "MIT"

--- a/seite-sh/content/changelog/2026-07-20-v0-17-0.md
+++ b/seite-sh/content/changelog/2026-07-20-v0-17-0.md
@@ -1,0 +1,26 @@
+---
+title: v0.17.0
+description: "Mermaid diagram support: set `mermaid = true` and fenced ```mermaid blocks render as diagrams client-side — no shortcode required."
+date: 2026-07-20
+tags:
+- feature
+---
+
+## Mermaid diagrams
+
+Set `mermaid = true` under `[build]` and fenced ` ```mermaid ` code blocks render as [Mermaid](https://mermaid.js.org/) diagrams — the same syntax Hugo, Zola, and GitHub accept, no shortcode required:
+
+````markdown
+```mermaid
+graph TD
+  A[Start] --> B{Works?}
+  B -->|Yes| C[Ship it]
+  B -->|No| A
+```
+````
+
+Each block is emitted as `<div class="mermaid">…</div>`, and a small client-side Mermaid loader is injected **only on pages that actually contain a diagram** — diagram-free pages have zero overhead. Diagrams render in the browser, so they work with every bundled and custom theme.
+
+With `mermaid = false` (the default), a ` ```mermaid ` block is treated like any other unrecognized language and rendered as a plain code block, so existing sites are unaffected.
+
+Requested in [#87](https://github.com/seite-sh/seite/issues/87).

--- a/seite-sh/content/docs/configuration.md
+++ b/seite-sh/content/docs/configuration.md
@@ -126,12 +126,30 @@ When `private = true`:
 | `minify` | bool | `false` | Strip CSS/JS comments and collapse whitespace |
 | `fingerprint` | bool | `false` | Add content hash to asset filenames for cache busting |
 | `math` | bool | `false` | Enable math/LaTeX rendering (`$inline$` and `$$display$$` blocks via KaTeX) |
+| `mermaid` | bool | `false` | Render fenced ` ```mermaid ` blocks as [Mermaid](https://mermaid.js.org/) diagrams (client-side) |
 
 {{% callout(type="tip") %}}
 Enable `minify` for production builds. It strips CSS/JS comments and collapses whitespace for smaller files. Enable `fingerprint` when your CDN caches aggressively: content hashes in filenames ensure browsers always fetch the latest version.
 {{% end %}}
 
 When `fingerprint = true`, static files get hashed names (e.g., `style.a1b2c3d4.css`) and an `asset-manifest.json` is written to the output directory.
+
+### Mermaid diagrams
+
+Set `mermaid = true` under `[build]` to render [Mermaid](https://mermaid.js.org/) diagrams from ordinary fenced code blocks — no shortcode required:
+
+````markdown
+```mermaid
+graph TD
+  A[Start] --> B{Works?}
+  B -->|Yes| C[Ship it]
+  B -->|No| A
+```
+````
+
+Each ` ```mermaid ` block is emitted as `<div class="mermaid">…</div>`, and a small Mermaid loader (from a CDN) is injected **only on pages that contain a diagram** — pages without one pay nothing. Diagrams render in the browser, so they work with any theme.
+
+When `mermaid = false` (the default), a ` ```mermaid ` block is treated like any other unrecognized language and rendered as a plain code block.
 
 ### CSS processing
 

--- a/src/build/markdown.rs
+++ b/src/build/markdown.rs
@@ -59,6 +59,13 @@ fn slugify_heading(text: &str) -> String {
 }
 
 pub fn markdown_to_html(markdown: &str) -> (String, Vec<TocEntry>) {
+    markdown_to_html_with(markdown, false)
+}
+
+/// Like [`markdown_to_html`], but when `mermaid` is true, fenced ` ```mermaid `
+/// blocks are emitted as `<div class="mermaid">` containers for client-side
+/// rendering instead of being syntax-highlighted or dumped as plain code.
+pub fn markdown_to_html_with(markdown: &str, mermaid: bool) -> (String, Vec<TocEntry>) {
     let ss = syntax_set();
     let ts = theme_set();
     let theme = &ts.themes["base16-ocean.dark"];
@@ -148,23 +155,41 @@ pub fn markdown_to_html(markdown: &str) -> (String, Vec<TocEntry>) {
             }
             Event::End(TagEnd::CodeBlock) => {
                 in_code_block = false;
-                let mut highlighted = false;
 
-                if let Some(ref lang) = code_lang {
-                    let resolved = resolve_lang_alias(lang);
-                    if let Some(syntax) = ss.find_syntax_by_token(resolved) {
-                        if let Ok(html) = highlighted_html_for_string(&code_buf, ss, syntax, theme)
-                        {
-                            html_output.push_str(&html);
-                            highlighted = true;
+                // Mermaid diagrams: emit a passthrough container for client-side
+                // rendering rather than syntax-highlighting the source as code.
+                // A <div> (not <pre>) keeps the code-copy button + syntax
+                // highlighter from touching it. The source is HTML-escaped; the
+                // browser un-escapes it via textContent for Mermaid.
+                let is_mermaid = mermaid
+                    && code_lang
+                        .as_deref()
+                        .is_some_and(|l| l.eq_ignore_ascii_case("mermaid"));
+
+                if is_mermaid {
+                    html_output.push_str("<div class=\"mermaid\">");
+                    html_output.push_str(&html_escape(&code_buf));
+                    html_output.push_str("</div>\n");
+                } else {
+                    let mut highlighted = false;
+
+                    if let Some(ref lang) = code_lang {
+                        let resolved = resolve_lang_alias(lang);
+                        if let Some(syntax) = ss.find_syntax_by_token(resolved) {
+                            if let Ok(html) =
+                                highlighted_html_for_string(&code_buf, ss, syntax, theme)
+                            {
+                                html_output.push_str(&html);
+                                highlighted = true;
+                            }
                         }
                     }
-                }
 
-                if !highlighted {
-                    html_output.push_str("<pre><code>");
-                    html_output.push_str(&html_escape(&code_buf));
-                    html_output.push_str("</code></pre>\n");
+                    if !highlighted {
+                        html_output.push_str("<pre><code>");
+                        html_output.push_str(&html_escape(&code_buf));
+                        html_output.push_str("</code></pre>\n");
+                    }
                 }
             }
             _ if in_code_block => { /* skip non-text events inside code blocks */ }
@@ -234,6 +259,41 @@ mod tests {
         assert!(html.contains("fn"));
         assert!(html.contains("main"));
         assert!(html.contains("style=\""));
+    }
+
+    #[test]
+    fn test_mermaid_fence_emits_div_when_enabled() {
+        let md = "```mermaid\ngraph TD\n  A-->B\n```";
+        let (html, _) = markdown_to_html_with(md, true);
+        assert!(
+            html.contains(r#"<div class="mermaid">"#),
+            "mermaid fence should become a mermaid div, got: {html}"
+        );
+        assert!(html.contains("graph TD"));
+        // It must NOT be wrapped in a <pre> (so the code-copy button + syntax
+        // highlighter both leave it alone).
+        assert!(
+            !html.contains("<pre"),
+            "mermaid block should not be a <pre>: {html}"
+        );
+    }
+
+    #[test]
+    fn test_mermaid_fence_escapes_source() {
+        let md = "```mermaid\nflowchart LR\n  A[\"<b>x</b>\"]\n```";
+        let (html, _) = markdown_to_html_with(md, true);
+        // Angle brackets in the source are HTML-escaped inside the div;
+        // the browser un-escapes them via textContent for Mermaid.
+        assert!(html.contains("&lt;b&gt;"), "got: {html}");
+    }
+
+    #[test]
+    fn test_mermaid_fence_plain_when_disabled() {
+        let md = "```mermaid\ngraph TD\n  A-->B\n```";
+        let (html, _) = markdown_to_html_with(md, false);
+        // With mermaid off, an unknown language falls back to plain <pre><code>.
+        assert!(!html.contains(r#"class="mermaid""#));
+        assert!(html.contains("<pre><code>"));
     }
 
     #[test]

--- a/src/build/mermaid.rs
+++ b/src/build/mermaid.rs
@@ -1,0 +1,96 @@
+//! Mermaid diagram support.
+//!
+//! When `[build] mermaid = true`, fenced ```mermaid code blocks are emitted as
+//! `<div class="mermaid">…source…</div>` by the markdown renderer (rather than
+//! syntax-highlighted or dumped as plain `<pre><code>`), and this module injects
+//! a small client-side loader that renders them in the browser.
+//!
+//! Rendering is client-side because there is no practical pure-Rust Mermaid
+//! renderer — Mermaid needs a JS/DOM runtime. The loader is injected only on
+//! pages that actually contain a diagram, so diagram-free pages pay nothing.
+
+/// Marker class placed on emitted diagram containers. The loader targets it, and
+/// the post-processor uses it to decide whether a page needs the loader at all.
+pub const MERMAID_CLASS: &str = "mermaid";
+
+/// Client-side loader: import Mermaid from a CDN and render every `.mermaid`
+/// block. `startOnLoad: false` + an explicit `run()` keeps control predictable.
+const MERMAID_SCRIPT: &str = r#"<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+mermaid.initialize({ startOnLoad: false });
+await mermaid.run({ querySelector: '.mermaid' });
+</script>"#;
+
+/// Inject the Mermaid loader before `</body>`, but only on pages that actually
+/// contain a `<div class="mermaid">` block. Pages without diagrams are returned
+/// unchanged, so there is zero overhead where Mermaid isn't used.
+pub fn inject_mermaid(html: &str) -> String {
+    if !html.contains(&format!("class=\"{MERMAID_CLASS}\"")) {
+        return html.to_string();
+    }
+
+    if let Some(pos) = html.rfind("</body>") {
+        let mut out = String::with_capacity(html.len() + MERMAID_SCRIPT.len() + 2);
+        out.push_str(&html[..pos]);
+        out.push('\n');
+        out.push_str(MERMAID_SCRIPT);
+        out.push('\n');
+        out.push_str(&html[pos..]);
+        out
+    } else {
+        html.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HTML_WITH_DIAGRAM: &str = r#"<!DOCTYPE html>
+<html lang="en">
+<head><title>Test</title></head>
+<body>
+<div class="mermaid">graph TD
+A--&gt;B</div>
+</body>
+</html>"#;
+
+    const HTML_WITHOUT_DIAGRAM: &str = r#"<!DOCTYPE html>
+<html lang="en">
+<head><title>Test</title></head>
+<body><p>Hello world</p></body>
+</html>"#;
+
+    #[test]
+    fn test_injects_loader_when_diagram_present() {
+        let result = inject_mermaid(HTML_WITH_DIAGRAM);
+        assert!(result.contains("mermaid.esm.min.mjs"));
+        assert!(result.contains("mermaid.run"));
+        // Injected before </body>
+        let script_pos = result.find("mermaid.esm.min.mjs").unwrap();
+        let body_end = result.rfind("</body>").unwrap();
+        assert!(script_pos < body_end);
+        // Original diagram markup preserved
+        assert!(result.contains(r#"<div class="mermaid">graph TD"#));
+    }
+
+    #[test]
+    fn test_skips_pages_without_diagram() {
+        let result = inject_mermaid(HTML_WITHOUT_DIAGRAM);
+        assert_eq!(result, HTML_WITHOUT_DIAGRAM);
+        assert!(!result.contains("mermaid"));
+    }
+
+    #[test]
+    fn test_no_body_tag_unchanged() {
+        let no_body = r#"<html><head></head><div class="mermaid">graph TD</div></html>"#;
+        let result = inject_mermaid(no_body);
+        assert_eq!(result, no_body);
+    }
+
+    #[test]
+    fn test_uses_module_script() {
+        let result = inject_mermaid(HTML_WITH_DIAGRAM);
+        assert!(result.contains(r#"<script type="module">"#));
+    }
+}

--- a/src/build/mermaid.rs
+++ b/src/build/mermaid.rs
@@ -14,10 +14,14 @@
 pub const MERMAID_CLASS: &str = "mermaid";
 
 /// Client-side loader: import Mermaid from a CDN and render every `.mermaid`
-/// block. `startOnLoad: false` + an explicit `run()` keeps control predictable.
+/// block. `startOnLoad: false` + an explicit `run()` keeps control predictable,
+/// and `securityLevel: 'strict'` is set explicitly rather than relying on the
+/// library default (which could change across versions). The CDN URL is pinned
+/// to an exact version for deterministic, reproducible builds — matching how
+/// `math.rs` pins KaTeX. Bump the version here to upgrade Mermaid.
 const MERMAID_SCRIPT: &str = r#"<script type="module">
-import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-mermaid.initialize({ startOnLoad: false });
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.16.0/dist/mermaid.esm.min.mjs';
+mermaid.initialize({ startOnLoad: false, securityLevel: 'strict' });
 await mermaid.run({ querySelector: '.mermaid' });
 </script>"#;
 
@@ -92,5 +96,24 @@ A--&gt;B</div>
     fn test_uses_module_script() {
         let result = inject_mermaid(HTML_WITH_DIAGRAM);
         assert!(result.contains(r#"<script type="module">"#));
+    }
+
+    #[test]
+    fn test_loader_is_version_pinned_and_strict() {
+        // Deterministic builds: the CDN URL must pin an exact version, not a
+        // floating major range. Security: strict mode is set explicitly rather
+        // than relying on the library default.
+        assert!(
+            MERMAID_SCRIPT.contains("mermaid@11.16.0"),
+            "Mermaid CDN URL should pin an exact version"
+        );
+        assert!(
+            !MERMAID_SCRIPT.contains("mermaid@11/"),
+            "Mermaid CDN URL should not use a floating major range"
+        );
+        assert!(
+            MERMAID_SCRIPT.contains("securityLevel: 'strict'"),
+            "Mermaid should be initialized with explicit strict security"
+        );
     }
 }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -8,6 +8,7 @@ pub mod images;
 pub mod links;
 pub mod markdown;
 pub mod math;
+pub mod mermaid;
 pub mod redirects;
 pub mod sitemap;
 
@@ -654,7 +655,8 @@ fn build_site_inner(
                     } else {
                         expanded_body
                     };
-                    let (html_body, toc) = markdown::markdown_to_html(&html_input);
+                    let (html_body, toc) =
+                        markdown::markdown_to_html_with(&html_input, config.build.mermaid);
 
                     let base_url = build_url(&collection.url_prefix, &slug);
                     let url = if lang != *default_lang {
@@ -2270,6 +2272,7 @@ fn build_site_inner(
         subdomain_rewrites,
         base_path: &site_base_path,
         analytics: config.analytics.as_ref(),
+        mermaid: config.build.mermaid,
     };
     let link_check = post_process_html_files(&paths.output, &post_ctx)?;
     step_timings.push((
@@ -2346,6 +2349,7 @@ struct HtmlPostProcessContext<'a> {
     subdomain_rewrites: &'a HashMap<String, String>,
     base_path: &'a str,
     analytics: Option<&'a AnalyticsSection>,
+    mermaid: bool,
 }
 
 /// Walk all `.html` files once, apply all post-processing transforms in memory, write once.
@@ -2403,6 +2407,11 @@ fn post_process_html_files(
                 // 5. Analytics injection
                 if let Some(analytics_config) = ctx.analytics {
                     html = analytics::inject_analytics(&html, analytics_config);
+                }
+
+                // 6. Mermaid loader injection (no-op unless the page has a diagram)
+                if ctx.mermaid {
+                    html = mermaid::inject_mermaid(&html);
                 }
 
                 // Only write if something changed

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -2419,7 +2419,7 @@ fn post_process_html_files(
                     fs::write(entry.path(), &html).map_err(PageError::from)?;
                 }
 
-                // 6. Extract internal links from final HTML for validation
+                // 7. Extract internal links from final HTML for validation
                 let internal_links = links::extract_internal_links(&html);
                 let link_count = internal_links.len();
                 let rel_path = entry

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -258,6 +258,9 @@ pub struct BuildSection {
     /// Enable math/LaTeX rendering ($inline$ and $$display$$ blocks). Default: false.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub math: bool,
+    /// Render fenced ```mermaid blocks as client-side Mermaid diagrams. Default: false.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub mermaid: bool,
 }
 
 impl Default for BuildSection {
@@ -272,6 +275,7 @@ impl Default for BuildSection {
             minify: false,
             fingerprint: false,
             math: false,
+            mermaid: false,
         }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2406,6 +2406,66 @@ fn test_build_math_enabled_renders_katex() {
     );
 }
 
+#[test]
+fn test_build_mermaid_enabled_renders_diagram() {
+    let tmp = TempDir::new().unwrap();
+    init_site(&tmp, "site", "Mermaid On", "posts,pages");
+    let site_dir = tmp.path().join("site");
+
+    let page_content = "---\ntitle: Diagram Page\n---\n\n```mermaid\ngraph TD\n  A-->B\n```\n";
+    fs::write(site_dir.join("content/pages/diagram.md"), page_content).unwrap();
+
+    set_build_option(&site_dir, "mermaid", "true");
+
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+
+    let html = fs::read_to_string(site_dir.join("dist/diagram.html")).unwrap();
+    assert!(
+        html.contains(r#"<div class="mermaid">"#),
+        "mermaid fence should render as a mermaid div: {html}"
+    );
+    assert!(html.contains("graph TD"));
+    assert!(
+        html.contains("mermaid.esm.min.mjs"),
+        "should inject the mermaid loader: {html}"
+    );
+}
+
+#[test]
+fn test_build_mermaid_disabled_plain_code() {
+    let tmp = TempDir::new().unwrap();
+    init_site(&tmp, "site", "Mermaid Off", "posts,pages");
+    let site_dir = tmp.path().join("site");
+
+    let page_content = "---\ntitle: Diagram Page\n---\n\n```mermaid\ngraph TD\n  A-->B\n```\n";
+    fs::write(site_dir.join("content/pages/diagram.md"), page_content).unwrap();
+
+    // mermaid defaults to off — no config change
+    page_cmd()
+        .arg("build")
+        .current_dir(&site_dir)
+        .assert()
+        .success();
+
+    let html = fs::read_to_string(site_dir.join("dist/diagram.html")).unwrap();
+    assert!(
+        !html.contains(r#"class="mermaid""#),
+        "no mermaid div when disabled: {html}"
+    );
+    assert!(
+        !html.contains("mermaid.esm.min.mjs"),
+        "no loader when disabled"
+    );
+    assert!(
+        html.contains("<pre><code>"),
+        "unknown language should fall back to plain code: {html}"
+    );
+}
+
 // ── Reading time + word count ──
 
 #[test]


### PR DESCRIPTION
Implements Mermaid support for #87 — the canonical, batteries-included path from that thread. **Not merging yet: I'd like the reporter to test it against their setup first.**

## How it works

Set `mermaid = true` under `[build]`, then write diagrams as ordinary fenced blocks — the syntax you (and Hugo/Zola/GitHub) already expect, no shortcode:

```mermaid
gitGraph
   commit id: "A"
   branch feature
   checkout feature
   commit id: "B"
   checkout main
   merge feature
```

- **Markdown renderer:** a ` ```mermaid ` fence is emitted as `<div class="mermaid">…source…</div>` (HTML-escaped; the browser un-escapes it via `textContent`) instead of being syntax-highlighted or dumped as plain `<pre><code>`. It's a `<div>`, not a `<pre>`, so **neither the syntax highlighter nor the code-copy button touches it**. Crucially, the language is no longer thrown away at parse time — there's now a real `.mermaid` hook, so no more content-sniffing.
- **Loader injection:** a small client-side Mermaid loader (ESM from jsDelivr) is injected **only on pages that actually contain a diagram** — the same "zero overhead on diagram-free pages" property as your workaround, but decided at build time from the real markup rather than a hand-maintained keyword regex.
- **Client-side by necessity:** unlike KaTeX (rendered server-side via a Rust crate), there's no practical pure-Rust Mermaid renderer — Mermaid needs a JS/DOM runtime — so rendering happens in the browser.

Why `mermaid = true` rather than a shortcode: it keeps the portable fenced-block syntax authors expect, and it mirrors how `math = true` already works — the least-surprising thing in seite.

## Scope / notes
- `mermaid = false` (default) is unchanged: a ` ```mermaid ` block renders as a plain code block, so existing sites are unaffected.
- The full fence body is passed through verbatim, so Mermaid's own front-matter `config:` blocks (like your `gitGraph` example) work.
- Default Mermaid theme + `securityLevel: strict`. We can expose theme/config later if there's demand.
- v0.17.0 (new `[build]` option), documented in `configuration.md`.

## Please test 🙏

Could you drop `mermaid = true` in your `[build]` section, keep your existing ` ```mermaid ` fences (including the gitGraph + front-matter-config cases), and confirm they render? If it covers your use I'll merge and cut the release; if anything's off — a diagram type, theme, the front-matter block — tell me and I'll adjust **before** merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
